### PR TITLE
Display genre on AlbumCard when mouse over it

### DIFF
--- a/src/lib/adapters/qobuzAdapters.ts
+++ b/src/lib/adapters/qobuzAdapters.ts
@@ -260,7 +260,8 @@ function toArtistAlbumSummary(album: QobuzAlbum): ArtistAlbumSummary {
     title: album.title,
     artwork,
     year: album.release_date_original?.split('-')[0],
-    quality
+    quality,
+    genre: album.genre?.name || "Unknown genre"
   };
 }
 

--- a/src/lib/components/AlbumCard.svelte
+++ b/src/lib/components/AlbumCard.svelte
@@ -14,6 +14,7 @@
     artwork: string;
     title: string;
     artist: string;
+    genre: string;
     quality?: string;
     size?: 'standard' | 'large';
     searchId?: string;
@@ -38,6 +39,7 @@
     artwork,
     title,
     artist,
+    genre,
     quality,
     size = 'standard',
     searchId,
@@ -182,6 +184,7 @@
     <!-- Action Overlay -->
     {#if hasOverlay}
       <div class="action-overlay" class:menu-open={menuOpen}>
+        <div class="overlay-genre">{genre}</div>
         <div class="action-buttons">
           {#if showFavoriteButton}
             <button
@@ -322,7 +325,7 @@
     justify-content: center;
     opacity: 0;
     transition: opacity 150ms ease;
-    background: rgba(10, 10, 10, 0.25);
+    background: rgba(10, 10, 10, 0.5);
     backdrop-filter: blur(4px);
     -webkit-backdrop-filter: blur(4px);
     pointer-events: auto;
@@ -388,6 +391,23 @@
   .overlay-btn--minor {
     width: 30px;
     height: 30px;
+  }
+
+  .overlay-genre {
+    align-self: flex-start;
+    width: 100%;
+    text-align: left;
+    padding-left: 1em;
+    color: white;
+    text-shadow:
+    0.06em 0 black,
+            0 0.06em black,
+            -0.06em 0 black,
+            0 -0.06em black,
+            -0.06em -0.06em black,
+            -0.06em 0.06em black,
+            0.06em -0.06em black,
+            0.06em 0.06em black;
   }
 
   :global(.album-card .album-menu) {

--- a/src/lib/components/VirtualizedAlbumList.svelte
+++ b/src/lib/components/VirtualizedAlbumList.svelte
@@ -311,6 +311,7 @@
                 artwork={getArtworkUrl(album.artwork_path)}
                 title={album.title}
                 artist={album.artist}
+                genre={"Unknown genre"}
                 quality={getQualityBadge(album)}
                 showFavorite={true}
                 favoriteEnabled={false}

--- a/src/lib/components/views/ArtistDetailView.svelte
+++ b/src/lib/components/views/ArtistDetailView.svelte
@@ -1273,6 +1273,7 @@
               artwork={album.artwork}
               title={album.title}
               artist={album.year || ''}
+              genre={album.genre}
               quality={album.quality}
               searchId={`album-${album.id}`}
               onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
@@ -1333,6 +1334,7 @@
             artwork={album.artwork}
             title={album.title}
             artist={album.year || ''}
+            genre={album.genre}
             quality={album.quality}
             searchId={`album-${album.id}`}
             onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
@@ -1392,6 +1394,7 @@
             artwork={album.artwork}
             title={album.title}
             artist={album.year || ''}
+            genre={album.genre}
             quality={album.quality}
             searchId={`album-${album.id}`}
             onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
@@ -1451,6 +1454,7 @@
             artwork={album.artwork}
             title={album.title}
             artist={album.year || ''}
+            genre={album.genre}
             quality={album.quality}
             searchId={`album-${album.id}`}
             onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
@@ -1510,6 +1514,7 @@
             artwork={album.artwork}
             title={album.title}
             artist={album.year || ''}
+            genre={album.genre}
             quality={album.quality}
             searchId={`album-${album.id}`}
             onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
@@ -1632,6 +1637,7 @@
               artwork={album.artwork}
               title={album.title}
               artist={album.year || ''}
+              genre={album.genre}
               quality={album.quality}
               searchId={`album-${album.id}`}
               onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}

--- a/src/lib/components/views/FavoritesView.svelte
+++ b/src/lib/components/views/FavoritesView.svelte
@@ -16,6 +16,7 @@
     id: string;
     title: string;
     artist: { id: number; name: string };
+    genre?: { name: string };
     image: { small?: string; thumbnail?: string; large?: string };
     release_date_original?: string;
     hires: boolean;
@@ -554,6 +555,10 @@
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
     return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  function getGenreLabel(album: FavoriteAlbum): string {
+    return album.genre?.name || 'Unknown genre'
   }
 
   function getQualityLabel(item: { hires?: boolean; maximum_bit_depth?: number; maximum_sampling_rate?: number }): string {
@@ -1292,6 +1297,7 @@
                         artwork={album.image?.large || album.image?.thumbnail || ''}
                         title={album.title}
                         artist={album.artist.name}
+                        genre={getGenreLabel(album)}
                         quality={getQualityLabel(album)}
                         onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                         onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -1363,6 +1369,7 @@
                 artwork={album.image?.large || album.image?.thumbnail || ''}
                 title={album.title}
                 artist={album.artist.name}
+                genre={getGenreLabel(album)}
                 quality={getQualityLabel(album)}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}

--- a/src/lib/components/views/HomeView.svelte
+++ b/src/lib/components/views/HomeView.svelte
@@ -36,6 +36,7 @@
     artwork: string;
     title: string;
     artist: string;
+    genre: string;
     quality?: string;
   }
 
@@ -330,6 +331,7 @@
       artwork: getQobuzImage(album.image),
       title: album.title,
       artist: album.artist?.name || 'Unknown Artist',
+      genre: album.genre?.name || 'Unknown genre',
       quality: formatQuality(album.hires_streamable, album.maximum_bit_depth, album.maximum_sampling_rate)
     };
   }
@@ -642,6 +644,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -671,6 +674,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -700,6 +704,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -729,6 +734,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -758,6 +764,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -787,6 +794,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -886,6 +894,7 @@
                 artwork={album.artwork}
                 title={album.title}
                 artist={album.artist}
+                genre={album.genre}
                 quality={album.quality}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}

--- a/src/lib/components/views/SearchView.svelte
+++ b/src/lib/components/views/SearchView.svelte
@@ -132,6 +132,7 @@
     id: string;
     title: string;
     artist: { name: string };
+    genre?: { name: string; };
     image: { small?: string; thumbnail?: string; large?: string };
     release_date_original?: string;
     hires_streamable?: boolean;
@@ -374,6 +375,10 @@
     const mins = Math.floor(seconds / 60);
     const secs = Math.floor(seconds % 60);
     return `${mins}:${secs.toString().padStart(2, '0')}`;
+  }
+
+  function getGenreLabel(album: Album): string {
+    return album.genre?.name || 'Unknown genre'
   }
 
   function getQualityLabel(track: Track | Album): string {
@@ -632,6 +637,7 @@
                 artwork={getAlbumArtwork(allResults.albums.items[0])}
                 title={allResults.albums.items[0].title}
                 artist={allResults.albums.items[0].artist?.name || 'Unknown Artist'}
+                genre={getGenreLabel(allResults.albums.items[0])}
                 quality={getQualityLabel(allResults.albums.items[0])}
                 onPlay={onAlbumPlay ? () => onAlbumPlay(allResults.albums.items[0].id) : undefined}
                 onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(allResults.albums.items[0].id) : undefined}
@@ -767,6 +773,7 @@
                           artwork={getAlbumArtwork(album)}
                           title={album.title}
                           artist={album.artist?.name || 'Unknown Artist'}
+                          genre={getGenreLabel(album)}
                           quality={getQualityLabel(album)}
                           onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
                           onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}
@@ -904,6 +911,7 @@
               artwork={getAlbumArtwork(album)}
               title={album.title}
               artist={album.artist?.name || 'Unknown Artist'}
+              genre={getGenreLabel(album)}
               quality={getQualityLabel(album)}
               onPlay={onAlbumPlay ? () => onAlbumPlay(album.id) : undefined}
               onPlayNext={onAlbumPlayNext ? () => onAlbumPlayNext(album.id) : undefined}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -133,6 +133,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   epsSingles: {
     id: string;
@@ -140,6 +141,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   liveAlbums: {
     id: string;
@@ -147,6 +149,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   compilations: {
     id: string;
@@ -154,6 +157,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   tributes: {
     id: string;
@@ -161,6 +165,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   others: {
     id: string;
@@ -168,6 +173,7 @@ export interface ArtistDetail {
     artwork: string;
     year?: string;
     quality: string;
+    genre: string;
   }[];
   playlists: {
     id: number;


### PR DESCRIPTION
Hey again @vicrodh, I have another small feature I miss from the official client. I saw the new contribution guidelines, hope I'm doing it right :)

Problem:

Unable to see genre of a release at a glance.

Solution:

Display genre when hovering over a release's cover. Similar behavior as the official Quboz mac client.

<img width="341" height="311" alt="Screenshot from 2026-01-25 16-09-34" src="https://github.com/user-attachments/assets/998f79a9-5181-49c1-8c09-6be7ff67c47c" />
