### PR TITLE
Add confirmation imodal when adding duplicate tracks to a playlist

### DIFF
--- a/src-tauri/src/api/models.rs
+++ b/src-tauri/src/api/models.rs
@@ -254,6 +254,14 @@ pub struct PlaylistGenre {
     pub slug: Option<String>,
 }
 
+/// Result of checking for duplicate tracks in a playlist
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PlaylistDuplicateResult {
+    pub total_tracks: usize,
+    pub duplicate_count: usize,
+    pub duplicate_track_ids: std::collections::HashSet<u64>,
+}
+
 /// Image set with multiple resolutions
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct ImageSet {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -490,6 +490,7 @@ pub fn run() {
             // Playlist commands
             commands::get_user_playlists,
             commands::get_playlist,
+            commands::check_playlist_duplicates,
             commands::search_playlists,
             commands::create_playlist,
             commands::delete_playlist,

--- a/src/lib/components/PlaylistDuplicateConfirmModal.svelte
+++ b/src/lib/components/PlaylistDuplicateConfirmModal.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import Modal from './Modal.svelte';
+  import type { PlaylistDuplicateResult } from '$lib/types/index';
+
+  export let isOpen = false;
+  export let duplicateResult: PlaylistDuplicateResult | null = null;
+  export let loading = false;
+
+  const dispatch = createEventDispatcher();
+
+  function handleAddAll() {
+    dispatch('addAll');
+  }
+
+  function handleSkipDuplicates() {
+    dispatch('skipDuplicates');
+  }
+
+  function handleCancel() {
+    dispatch('cancel');
+  }
+
+  function handleClose() {
+    if (!loading) {
+      dispatch('cancel');
+    }
+  }
+</script>
+
+<Modal {isOpen} onClose={handleClose} title={'You\'ve added some of these tracks before'}>
+  {#if duplicateResult}
+    <div class="duplicate-info">
+      <p>
+        This playlist already contains <strong>{duplicateResult.duplicate_count}</strong> of the
+        track{duplicateResult.duplicate_count !== 1 ? 's' : ''} you're adding.
+        Add only the new ones, or add everything including duplicates ({duplicateResult.total_tracks} track{duplicateResult.total_tracks !== 1 ? 's' : ''}).
+      </p>
+    </div>
+  {/if}
+
+  {#snippet footer()}
+    <div class="footer-right">
+      <button 
+        class="btn btn-secondary" 
+        on:click={handleAddAll}
+        disabled={loading}
+      >
+        {#if loading}
+          Adding...
+        {:else}
+          Add all tracks
+        {/if}
+      </button>
+      
+      <button 
+        class="btn btn-primary" 
+        on:click={handleSkipDuplicates}
+        disabled={loading || duplicateResult?.duplicate_count === 0}
+      >
+        {#if loading}
+          Adding...
+        {:else}
+          Add only new tracks
+        {/if}
+      </button>
+    </div>
+  {/snippet}
+</Modal>
+
+<style>
+  .duplicate-info {
+    margin-bottom: 24px;
+  }
+
+  .duplicate-info p {
+    margin: 0;
+    color: var(--text-secondary);
+    line-height: 1.4;
+  }
+
+  .footer-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-left: auto;
+  }
+</style>

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -113,6 +113,12 @@ export interface QobuzPlaylist {
   duration?: number;
 }
 
+export interface PlaylistDuplicateResult {
+  total_tracks: number;
+  duplicate_count: number;
+  duplicate_track_ids: Set<number>;
+}
+
 export interface QobuzArtist {
   id: number;
   name: string;


### PR DESCRIPTION
Hello @vicrodh - really digging the work in 1.1.8 and 1.1.9! Here's another one from me, again around playlists. This one's a little bigger so I appreciate any pointers/feedback.

Problem:

Adding already existing tracks to a playlist doesn't warn about duplicates

Solution:

Add similar dialogue as the official iOS client when adding tracks that already exist in playlist - we then will prompt the user for what action they would like to take:

<img width="593" height="479" alt="Screenshot from 2026-02-09 21-13-39" src="https://github.com/user-attachments/assets/85ffd082-6319-49cb-aca4-89f2bc4d802c" />