### PR TITLE
Improve moving tracks in play queue 

### DIFF
--- a/src-tauri/src/queue/mod.rs
+++ b/src-tauri/src/queue/mod.rs
@@ -59,7 +59,7 @@ impl Default for RepeatMode {
 #[derive(Debug, PartialEq, Eq)]
 enum QueueMoveDirection {
     Up,
-    Down
+    Down,
 }
 
 /// Queue state snapshot for frontend
@@ -265,11 +265,11 @@ impl QueueManager {
         let mut to_idx = to_index;
 
         if let Some(curr_idx) = state.current_index {
-          // map to the internal state, which differs from the frontend's
-          // representation because the here we also have the current playing
-          // track part of the tracks.
-          from_idx = from_idx + curr_idx + 1;
-          to_idx = to_idx + curr_idx + 1;
+            // map to the internal state, which differs from the frontend's
+            // representation because the here we also have the current playing
+            // track part of the tracks.
+            from_idx = from_idx + curr_idx + 1;
+            to_idx = to_idx + curr_idx + 1;
         }
 
         if direction == QueueMoveDirection::Down {
@@ -620,5 +620,151 @@ impl QueueManager {
         } else {
             state.shuffle_position = 0;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_track(id: u64) -> QueueTrack {
+        QueueTrack {
+            id,
+            title: format!("Track {}", id),
+            artist: "Artist".to_string(),
+            album: "Album".to_string(),
+            duration_secs: 180,
+            artwork_url: None,
+            hires: false,
+            bit_depth: None,
+            sample_rate: None,
+            is_local: false,
+            album_id: None,
+            artist_id: None,
+            streamable: true,
+            source: Some("test".to_string()),
+        }
+    }
+
+    #[test]
+    fn test_clear_without_current_track() {
+        let queue = QueueManager::new();
+
+        queue.add_track(create_test_track(123));
+        queue.add_track(create_test_track(124));
+        queue.add_track(create_test_track(125));
+
+        queue.clear();
+
+        let state = queue.get_state();
+        assert!(state.current_track.is_none());
+        assert!(state.upcoming.is_empty());
+        assert_eq!(state.total_tracks, 0);
+    }
+
+    #[test]
+    fn test_clear_keeps_current_track() {
+        let queue = QueueManager::new();
+
+        queue.add_track(create_test_track(123));
+        queue.add_track(create_test_track(124));
+        queue.add_track(create_test_track(125));
+        queue.play_index(0);
+
+        queue.clear();
+
+        let state = queue.get_state();
+        assert!(state.current_track.is_some());
+        assert_eq!(state.current_track.unwrap().id, 123);
+        assert!(state.upcoming.is_empty());
+        assert_eq!(state.total_tracks, 1);
+    }
+
+    #[test]
+    fn test_move_track_down_without_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+
+        let result = queue.move_track(0, 3);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![2, 3, 1, 4, 5]);
+    }
+
+    #[test]
+    fn test_move_track_down_with_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+        queue.play_index(0);
+
+        // Can't move the current playing track so this translates to "move from_index 1 -> 3"
+        let result = queue.move_track(0, 3);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![3, 4, 2, 5]);
+    }
+
+    #[test]
+    fn test_move_track_up_without_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+
+        let result = queue.move_track(3, 0);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![4, 1, 2, 3, 5]);
+    }
+
+    #[test]
+    fn test_move_track_up_with_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+        queue.play_index(0);
+
+        let result = queue.move_track(3, 0);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![5, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_move_track_to_the_same_position_without_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+
+        let result = queue.move_track(2, 3);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![1, 2, 3, 4, 5]);
+    }
+
+    #[test]
+    fn test_move_track_to_the_same_position_with_current_track() {
+        let queue = QueueManager::new();
+
+        for i in 1..=5 {
+            queue.add_track(create_test_track(i));
+        }
+        queue.play_index(0);
+
+        let result = queue.move_track(0, 1);
+
+        assert!(result, "move_track should succeed");
+        assert_eq!(queue.get_state().upcoming.iter().map(|track| track.id).collect::<Vec<u64>>(), vec![2, 3, 4, 5]);
     }
 }


### PR DESCRIPTION
Hey hey!

This one's about the play queue, I noticed that moving tracks and clearing the queue could have some weird behavior; order not ending up in the way I expect.

Problems and solutions: 

1. Seems like one of the reasons for a bit of confusing behavior is that the frontend represents the queue state differently than the backend, particularly when a track is playing. My PR introduces some mapping logic in `move_track` to handle it.
1. Another is that usually you move the track to a place in between existing tracks, rather than on to them. So the resulting to-index needs to take this into account. This is why I introduce the `QueueMoveDirection` and tweak the to_index based on it.
1. Third is the clearing of the queue, if a track was playing and you afterwards enqueued new tracks the next song after the current would skip one track in the queue. Small change in `clear` to address it.

Added a few supporting unit tests as well.

There can still be some UI artifacts when moving tracks in the queue (same as before).

I'm including some screen recordings of before/after, but it's not super clear maybe still. Probably best is to try the queue yourself before and after to feel the difference.

Before: 
[move_track_before.webm](https://github.com/user-attachments/assets/381d77ee-e134-4416-994e-f778cffa15ef)

After: 
[move_track_after.webm](https://github.com/user-attachments/assets/99bf93f2-ae49-44dd-b421-207f585aa043)
