### PR TITLE
feat(settings): validate window size before saving

### DIFF
--- a/src-tauri/src/config/window_settings.rs
+++ b/src-tauri/src/config/window_settings.rs
@@ -118,6 +118,17 @@ impl WindowSettingsStore {
 
     /// Save the non-maximized window dimensions (called on resize while not maximized).
     pub fn set_window_size(&self, width: f64, height: f64) -> Result<(), String> {
+        // Validate bounds to prevent invalid values from being persisted
+        const MIN_SIZE: f64 = 100.0;
+        const MAX_SIZE: f64 = 32768.0; //max X11 window size
+
+        if width < MIN_SIZE || width > MAX_SIZE || height < MIN_SIZE || height > MAX_SIZE {
+            return Err(format!(
+                "Invalid window size: {}x{} (must be {}-{} px)",
+                width, height, MIN_SIZE, MAX_SIZE
+            ));
+        }
+
         self.conn
             .execute(
                 "UPDATE window_settings SET window_width = ?1, window_height = ?2 WHERE id = 1",


### PR DESCRIPTION
I had the issue, that qbz was segfaulting GDK, because the window size in the settings sqlite where completly off, so I thought it would be good idea to validate the values

```bash
[QBZ] NVIDIA GPU detected
[QBZ] Graphics config: wayland=true, nvidia=true, force_x11=false, hw_accel=true, fallback=false
[QBZ] Display server: Wayland
[QBZ] Wayland: compositing mode disabled (prevents protocol errors)
[QBZ] Wayland: DMA-BUF renderer disabled (prevents EGL crashes)
[QBZ] GPU rendering: partial (compositing: CPU, DMA-BUF: disabled, GL: GPU)
[2026-02-27T23:08:33.933Z INFO qbz_nix_lib] QBZ starting...
[2026-02-27T23:08:33.934Z INFO qbz_nix_lib] Audio settings: exclusive_mode=false, dac_passthrough=false, sample_rate=None
[2026-02-27T23:08:33.934Z INFO qbz_nix_lib::config::tray_settings] [TraySettings] Database initialized
[2026-02-27T23:08:33.934Z INFO qbz_nix_lib] Loaded tray settings from last active user 1824377
[2026-02-27T23:08:33.934Z INFO qbz_nix_lib] Tray settings: enable=true, minimize_to_tray=false, close_to_tray=false
[2026-02-27T23:08:33.934Z INFO qbz_nix_lib::config::window_settings] [WindowSettings] Database initialized
[2026-02-27T23:08:33.947Z INFO qbz_nix_lib] Window settings: use_system_titlebar=false, size=9084748x62267212, maximized=false
[2026-02-27T23:08:33.958Z INFO qbz_nix_lib::config::legal_settings] [LegalSettings] Database initialized
[2026-02-27T23:08:34.004Z INFO qbz_nix_lib::config::window_settings] [WindowSettings] Database initialized
[2026-02-27T23:08:34.004Z INFO qbz_cache::playback_cache] Playback cache rebuilt: 12 tracks, 729 MB
[2026-02-27T23:08:34.004Z INFO qbz_cache::playback_cache] Playback cache initialized at "/home/armin/.cache/qbz/playback" (max 800 MB)
[2026-02-27T23:08:34.011Z INFO qbz_nix_lib::player] Audio thread starting...
[2026-02-27T23:08:34.012Z INFO qbz_audio::loudness_cache] [LoudnessCache] Opened at /home/armin/.local/share/qbz/loudness_cache.db
[2026-02-27T23:08:34.012Z INFO qbz_nix_lib::player] Audio thread ready and waiting for commands
[2026-02-27T23:08:34.012Z INFO qbz_audio::loudness_analyzer] [LoudnessAnalyzer] Thread started
[2026-02-27T23:08:34.065Z INFO zbus::connection::handshake::common] write_command; command=Auth(Some(External), Some([49, 48, 48, 48]))
[2026-02-27T23:08:34.065Z INFO zbus::connection::handshake::common] write_commands; commands=[Auth(Some(External), Some([49, 48, 48, 48]))] extra_bytes=None
[2026-02-27T23:08:34.066Z INFO tracing::span] read_command;
[2026-02-27T23:08:34.066Z INFO zbus::connection::handshake::common] read_commands; n_commands=1
[2026-02-27T23:08:34.066Z INFO zbus::connection::handshake::common] write_commands; commands=[NegotiateUnixFD, Begin] extra_bytes=Some([108, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 109, 0, 0, 0, 1, 1, 111, 0, 21, 0, 0, 0, 47, 111, 114, 103, 47, 102, 114, 101, 101, 100, 101, 115, 107, 116, 111, 112, 47, 68, 66, 117, 115, 0, 0, 0, 2, 1, 115, 0, 20, 0, 0, 0, 111, 114, 103, 46, 102, 114, 101, 101, 100, 101, 115, 107, 116, 111, 112, 46, 68, 66, 117, 115, 0, 0, 0, 0, 3, 1, 115, 0, 5, 0, 0, 0, 72, 101, 108, 108, 111, 0, 0, 0, 6, 1, 115, 0, 20, 0, 0, 0, 111, 114, 103, 46, 102, 114, 101, 101, 100, 101, 115, 107, 116, 111, 112, 46, 68, 66, 117, 115, 0, 0, 0, 0])
[2026-02-27T23:08:34.066Z INFO zbus::connection::handshake::common] read_commands; n_commands=1
[2026-02-27T23:08:34.066Z INFO zbus::connection] start_object_server; started_event=Some(Event { listeners_notified: 0, listeners_total: 1 })
[2026-02-27T23:08:34.066Z INFO tracing::span] obj_server_task;
[2026-02-27T23:08:34.066Z INFO zbus::connection] monitor_name_lost; name=com.blitzfc.qbz.SingleInstance
[2026-02-27T23:08:34.072Z INFO qbz_nix_lib] Creating main window (decorations=false, kwin_ssd=false)

(qbz:22580): Gdk-WARNING **: 00:08:34.073: Native Windows wider than 65535 pixels are not supported

(qbz:22580): Gdk-WARNING **: 00:08:34.073: Native Windows taller than 65535 pixels are not supported
[2026-02-27T23:08:34.269Z INFO qbz_nix_lib::tray] Initializing system tray icon

(qbz:22580): libayatana-appindicator-WARNING **: 00:08:34.271: libayatana-appindicator is deprecated. Please use libayatana-appindicator-glib in newly written code.
[2026-02-27T23:08:34.272Z INFO qbz_nix_lib::tray] System tray icon initialized
[2026-02-27T23:08:34.273Z INFO qbz_nix_lib::media_controls] Media controls initialized successfully (MPRIS)
[2026-02-27T23:08:34.280Z INFO qbz_nix_lib::core_bridge] [CoreBridge] Creating Player with device=None, exclusive=false, dac_passthrough=false
[2026-02-27T23:08:34.280Z INFO qbz_player::player] Audio thread starting...
[2026-02-27T23:08:34.280Z INFO qbz_audio::loudness_cache] [LoudnessCache] Opened at /home/armin/.local/share/qbz/loudness_cache.db
[2026-02-27T23:08:34.280Z INFO qbz_player::player] Audio thread ready and waiting for commands
[2026-02-27T23:08:34.280Z INFO qbz_audio::loudness_analyzer] [LoudnessAnalyzer] Thread started

(qbz:22580): Gdk-CRITICAL **: 00:08:34.334: ../../../gdk/wayland/gdkdisplay-wayland.c:1452: Unable to create Cairo image surface: invalid value (typically too big) for the size of the input (surface, pattern, etc.)
fish: Job 1, 'qbz' terminated by signal SIGSEGV (Address boundary error)
```