### PR TITLE
feat(macos): add CoreAudio device probing and sample rate switching

### DIFF
--- a/crates/qbz-audio/Cargo.toml
+++ b/crates/qbz-audio/Cargo.toml
@@ -39,3 +39,8 @@ dirs = "5"
 [target.'cfg(target_os = "linux")'.dependencies]
 # ALSA for direct hardware access (bit-perfect)
 alsa = "0.9"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+# CoreAudio for device probing, sample rate switching, and (future) hog mode / exclusive mode
+# Using fork branch until https://github.com/RustAudio/coreaudio-rs/pull/149 is merged
+coreaudio-rs = { git = "https://github.com/afonsojramos/coreaudio-rs.git", branch = "feat/device-helpers" }

--- a/crates/qbz-audio/src/backend.rs
+++ b/crates/qbz-audio/src/backend.rs
@@ -391,15 +391,29 @@ impl AudioBackend for CpalDefaultBackend {
                 .map(|desc| desc.name().to_string())
                 .unwrap_or_else(|_| "Unknown Device".to_string());
             let is_default = name == default_name;
+
+            // On macOS, probe device capabilities via CoreAudio
+            #[cfg(target_os = "macos")]
+            let (supported_rates, max_rate, bus_type, is_hw) = {
+                Self::probe_macos_device(&name)
+            };
+            #[cfg(not(target_os = "macos"))]
+            let (supported_rates, max_rate, bus_type, is_hw): (
+                Option<Vec<u32>>,
+                Option<u32>,
+                Option<String>,
+                bool,
+            ) = (None, None, None, false);
+
             devices.push(AudioDevice {
                 id: name.clone(),
                 name,
                 description: None,
                 is_default,
-                max_sample_rate: None,
-                supported_sample_rates: None,
-                device_bus: None,
-                is_hardware: false,
+                max_sample_rate: max_rate,
+                supported_sample_rates: supported_rates,
+                device_bus: bus_type,
+                is_hardware: is_hw,
             });
         }
 
@@ -407,6 +421,17 @@ impl AudioBackend for CpalDefaultBackend {
     }
 
     fn create_output_stream(&self, config: &BackendConfig) -> BackendResult<MixerDeviceSink> {
+        // On macOS, switch device sample rate to match the requested rate
+        #[cfg(target_os = "macos")]
+        {
+            if let Some(ref device_id) = config.device_id {
+                Self::switch_sample_rate_if_needed(device_id, config.sample_rate);
+            } else {
+                // Switch default device rate
+                Self::switch_default_device_rate_if_needed(config.sample_rate);
+            }
+        }
+
         let device = if let Some(ref device_id) = config.device_id {
             self.host
                 .output_devices()
@@ -441,5 +466,108 @@ impl AudioBackend for CpalDefaultBackend {
 
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+#[cfg(target_os = "macos")]
+impl CpalDefaultBackend {
+    /// Probe a macOS audio device for capabilities via CoreAudio APIs.
+    /// Returns (supported_rates, max_rate, bus_type, is_hardware).
+    fn probe_macos_device(
+        device_name: &str,
+    ) -> (Option<Vec<u32>>, Option<u32>, Option<String>, bool) {
+        use crate::coreaudio_direct;
+
+        let device_id = match coreaudio_direct::find_device_by_name(device_name) {
+            Ok(Some(id)) => {
+                log::info!("[CoreAudio] Found device '{}' with ID {}", device_name, id);
+                id
+            }
+            Ok(None) => {
+                log::debug!("[CoreAudio] Device '{}' not found via CoreAudio", device_name);
+                return (None, None, None, false);
+            }
+            Err(e) => {
+                log::debug!("[CoreAudio] Error finding device '{}': {}", device_name, e);
+                return (None, None, None, false);
+            }
+        };
+
+        let supported_rates = coreaudio_direct::query_supported_sample_rates(device_id)
+            .inspect(|rates| log::info!("[CoreAudio] Device '{}' supported rates: {:?}", device_name, rates))
+            .inspect_err(|e| log::warn!("[CoreAudio] Failed to query rates for '{}': {}", device_name, e))
+            .ok()
+            .filter(|r| !r.is_empty());
+        let max_rate = supported_rates
+            .as_ref()
+            .and_then(|rates| rates.iter().max().copied());
+        let bus_type = coreaudio_direct::get_device_transport_type(device_id);
+        let is_hardware = bus_type
+            .as_deref()
+            .is_some_and(|t| t == "usb" || t == "built-in" || t == "thunderbolt" || t == "firewire");
+
+        (supported_rates, max_rate, bus_type, is_hardware)
+    }
+
+    /// Switch device sample rate before stream creation (if device supports the target rate).
+    fn switch_sample_rate_if_needed(device_name: &str, target_rate: u32) {
+        use crate::coreaudio_direct;
+
+        log::info!("[CoreAudio] Rate switch requested: device='{}' target={}Hz", device_name, target_rate);
+
+        let device_id = match coreaudio_direct::find_device_by_name(device_name) {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                log::warn!("[CoreAudio] Cannot switch rate: device '{}' not found", device_name);
+                return;
+            }
+            Err(e) => {
+                log::warn!("[CoreAudio] Cannot switch rate: {}", e);
+                return;
+            }
+        };
+
+        // Check if device supports the target rate
+        if let Ok(rates) = coreaudio_direct::query_supported_sample_rates(device_id) {
+            if !rates.contains(&target_rate) {
+                log::debug!(
+                    "[CoreAudio] Device '{}' does not support {}Hz, skipping rate switch",
+                    device_name,
+                    target_rate
+                );
+                return;
+            }
+        }
+
+        if let Err(e) = coreaudio_direct::set_nominal_sample_rate(device_id, target_rate) {
+            log::warn!("[CoreAudio] Failed to switch sample rate: {}", e);
+        }
+    }
+
+    /// Switch the default output device's sample rate.
+    fn switch_default_device_rate_if_needed(target_rate: u32) {
+        use crate::coreaudio_direct;
+
+        let device_id = match coreaudio_direct::get_default_output_device() {
+            Ok(id) => id,
+            Err(e) => {
+                log::debug!("[CoreAudio] Could not get default device for rate switch: {}", e);
+                return;
+            }
+        };
+
+        if let Ok(rates) = coreaudio_direct::query_supported_sample_rates(device_id) {
+            if !rates.contains(&target_rate) {
+                log::debug!(
+                    "[CoreAudio] Default device does not support {}Hz, skipping rate switch",
+                    target_rate
+                );
+                return;
+            }
+        }
+
+        if let Err(e) = coreaudio_direct::set_nominal_sample_rate(device_id, target_rate) {
+            log::warn!("[CoreAudio] Failed to switch default device sample rate: {}", e);
+        }
     }
 }

--- a/crates/qbz-audio/src/coreaudio_direct.rs
+++ b/crates/qbz-audio/src/coreaudio_direct.rs
@@ -1,0 +1,165 @@
+//! CoreAudio direct access for macOS
+//!
+//! Provides device capability probing and sample rate switching on macOS
+//! using the coreaudio-rs safe wrappers.
+//!
+//! Phase 1: Device probing + nominal sample rate switching (shared mode)
+//! Phase 2 (future): Hog mode + integer mode + IO proc for bit-perfect playback
+
+#[cfg(target_os = "macos")]
+use coreaudio::audio_unit::macos_helpers;
+#[cfg(target_os = "macos")]
+use coreaudio::audio_unit::Scope;
+
+/// CoreAudio device ID (re-exported so callers don't need objc2_core_audio)
+#[cfg(target_os = "macos")]
+pub type AudioDeviceID = u32;
+
+// CoreAudio transport type constants (FourCC values from AudioHardware.h)
+#[cfg(target_os = "macos")]
+mod transport_types {
+    pub const BUILT_IN: u32 = 0x626c746e;    // 'bltn'
+    pub const USB: u32 = 0x75736220;          // 'usb '
+    pub const BLUETOOTH: u32 = 0x626c7565;    // 'blue'
+    pub const BLUETOOTH_LE: u32 = 0x626c6561; // 'blea'
+    pub const HDMI: u32 = 0x68646d69;         // 'hdmi'
+    pub const DISPLAY_PORT: u32 = 0x64707274; // 'dprt'
+    pub const THUNDERBOLT: u32 = 0x7468756e;  // 'thun'
+    pub const FIREWIRE: u32 = 0x31333934;     // '1394'
+    pub const VIRTUAL: u32 = 0x76697274;      // 'virt'
+    pub const AGGREGATE: u32 = 0x67727570;    // 'grup'
+}
+
+/// Common audio sample rates to check against device capabilities
+#[cfg(target_os = "macos")]
+const COMMON_SAMPLE_RATES: &[u32] = &[
+    44100, 48000, 88200, 96000, 176400, 192000, 352800, 384000, 705600, 768000,
+];
+
+/// Query supported sample rates for a CoreAudio device.
+/// Returns discrete rates from the device's available nominal sample rate ranges.
+#[cfg(target_os = "macos")]
+pub fn query_supported_sample_rates(device_id: AudioDeviceID) -> Result<Vec<u32>, String> {
+    let ranges = macos_helpers::get_available_sample_rates(device_id)
+        .map_err(|e| format!("Failed to get sample rate ranges: {:?}", e))?;
+
+    let mut rates = Vec::new();
+    for range in &ranges {
+        if (range.mMinimum - range.mMaximum).abs() < 0.5 {
+            // Point value (min == max)
+            rates.push(range.mMinimum as u32);
+        } else {
+            // Continuous range — check which common rates fall within it
+            for &rate in COMMON_SAMPLE_RATES {
+                let rate_f = rate as f64;
+                if rate_f >= range.mMinimum && rate_f <= range.mMaximum {
+                    rates.push(rate);
+                }
+            }
+        }
+    }
+
+    rates.sort_unstable();
+    rates.dedup();
+    Ok(rates)
+}
+
+/// Set the nominal sample rate of a device.
+/// Delegates to coreaudio-rs which handles async confirmation with a 2-second timeout.
+#[cfg(target_os = "macos")]
+pub fn set_nominal_sample_rate(device_id: AudioDeviceID, target_rate: u32) -> Result<(), String> {
+    log::info!(
+        "[CoreAudio] Switching sample rate to {}Hz on device {}",
+        target_rate,
+        device_id
+    );
+
+    macos_helpers::set_device_sample_rate(device_id, target_rate as f64)
+        .map_err(|e| format!("Failed to set sample rate to {}Hz: {:?}", target_rate, e))?;
+
+    log::info!("[CoreAudio] Sample rate switched to {}Hz", target_rate);
+    Ok(())
+}
+
+/// Get the default output device ID.
+#[cfg(target_os = "macos")]
+pub fn get_default_output_device() -> Result<AudioDeviceID, String> {
+    macos_helpers::get_default_device_id(false)
+        .ok_or_else(|| "No default output device found".to_string())
+}
+
+/// Get all output device IDs.
+#[cfg(target_os = "macos")]
+pub fn get_output_device_ids() -> Result<Vec<AudioDeviceID>, String> {
+    macos_helpers::get_audio_device_ids_for_scope(Scope::Output)
+        .map_err(|e| format!("Failed to enumerate output devices: {:?}", e))
+}
+
+/// Get the name of a CoreAudio device.
+#[cfg(target_os = "macos")]
+pub fn get_device_name(device_id: AudioDeviceID) -> Result<String, String> {
+    macos_helpers::get_device_name(device_id)
+        .map_err(|e| format!("Failed to get device name: {:?}", e))
+}
+
+/// Find a CoreAudio output device ID by its name.
+#[cfg(target_os = "macos")]
+pub fn find_device_by_name(name: &str) -> Result<Option<AudioDeviceID>, String> {
+    // get_device_id_from_name: input=false means output device
+    Ok(macos_helpers::get_device_id_from_name(name, false))
+}
+
+/// Get the transport type of a device (USB, built-in, Bluetooth, etc.)
+#[cfg(target_os = "macos")]
+pub fn get_device_transport_type(device_id: AudioDeviceID) -> Option<String> {
+    let transport = macos_helpers::get_device_transport_type(device_id).ok()?;
+
+    let transport_str = if transport == transport_types::BUILT_IN {
+        "built-in"
+    } else if transport == transport_types::USB {
+        "usb"
+    } else if transport == transport_types::BLUETOOTH
+        || transport == transport_types::BLUETOOTH_LE
+    {
+        "bluetooth"
+    } else if transport == transport_types::HDMI
+        || transport == transport_types::DISPLAY_PORT
+    {
+        "hdmi"
+    } else if transport == transport_types::THUNDERBOLT {
+        "thunderbolt"
+    } else if transport == transport_types::FIREWIRE {
+        "firewire"
+    } else if transport == transport_types::VIRTUAL {
+        "virtual"
+    } else if transport == transport_types::AGGREGATE {
+        "aggregate"
+    } else {
+        "unknown"
+    };
+
+    Some(transport_str.to_string())
+}
+
+// ---- Non-macOS stubs ----
+
+/// Query supported sample rates (stub for non-macOS)
+#[cfg(not(target_os = "macos"))]
+pub fn query_supported_sample_rates(_device_name: &str) -> Result<Vec<u32>, String> {
+    Ok(Vec::new())
+}
+
+/// Get the current nominal sample rate (stub for non-macOS)
+#[cfg(not(target_os = "macos"))]
+pub fn get_nominal_sample_rate_by_name(_device_name: &str) -> Result<u32, String> {
+    Err("CoreAudio is only available on macOS".to_string())
+}
+
+/// Set the nominal sample rate (stub for non-macOS)
+#[cfg(not(target_os = "macos"))]
+pub fn set_nominal_sample_rate_by_name(
+    _device_name: &str,
+    _target_rate: u32,
+) -> Result<(), String> {
+    Err("CoreAudio is only available on macOS".to_string())
+}

--- a/crates/qbz-audio/src/lib.rs
+++ b/crates/qbz-audio/src/lib.rs
@@ -34,6 +34,7 @@ pub mod alsa_backend;
 #[cfg(target_os = "linux")]
 pub mod pulse_backend;
 pub mod alsa_direct;
+pub mod coreaudio_direct;
 pub mod analysis;
 pub mod analyzer_tap;
 pub mod diagnostic;

--- a/crates/qbz-player/src/player/mod.rs
+++ b/crates/qbz-player/src/player/mod.rs
@@ -465,8 +465,16 @@ fn try_init_stream_with_backend(
     sample_rate: u32,
     channels: u16,
 ) -> Option<Result<StreamType, String>> {
-    // Check if backend system is configured
-    let backend_type = audio_settings.backend_type?;
+    // Check if backend system is configured.
+    // On non-Linux, default to SystemDefault when not explicitly set,
+    // so macOS gets CoreAudio device probing and sample rate switching.
+    let backend_type = audio_settings.backend_type.or_else(|| {
+        if cfg!(not(target_os = "linux")) {
+            Some(qbz_audio::AudioBackendType::SystemDefault)
+        } else {
+            None
+        }
+    })?;
 
     log::info!(
         "Using backend system: {:?} (device: {:?}, plugin: {:?})",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1078,13 +1078,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "coreaudio-rs"
+version = "0.14.0"
+source = "git+https://github.com/afonsojramos/coreaudio-rs.git?branch=feat%2Fdevice-helpers#ce3fec9bce0b43ece78bb8801c87be9889e5710e"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
+ "objc2-audio-toolbox",
+ "objc2-core-audio",
+ "objc2-core-audio-types",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "cpal"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1f9c7312f19fc2fa12fd7acaf38de54e8320ba10d1a02dcbe21038def51ccb"
 dependencies = [
  "alsa 0.10.0",
- "coreaudio-rs",
+ "coreaudio-rs 0.13.0",
  "dasp_sample",
  "jni",
  "js-sys",
@@ -4496,6 +4509,7 @@ version = "0.1.0"
 dependencies = [
  "alsa 0.9.1",
  "async-trait",
+ "coreaudio-rs 0.14.0",
  "dirs 5.0.1",
  "ebur128",
  "log",


### PR DESCRIPTION
## Summary

- Adds CoreAudio device capability probing on macOS (supported sample rates, transport type, max sample rate)
- Implements automatic sample rate switching per-track — the device's nominal sample rate is changed to match the track before playback
- Auto-selects the `SystemDefault` backend on non-Linux platforms so macOS goes through the backend system (which does rate switching) instead of the legacy CPAL path

## Approach

Initially implemented using raw `coreaudio-sys` FFI bindings (~570 lines of `unsafe` code handling `AudioObjectGetPropertyData`, `CFStringRef` conversion, and manual async rate change listeners).

After reviewing `coreaudio-rs` 0.13+, discovered it already exposes most of what we need (`set_device_sample_rate`, `toggle_hog_mode`, `get_supported_physical_stream_formats`, etc.) — added by the CamillaDSP author in PRs #82/#83. The only missing helpers were `get_available_sample_rates` and `get_device_transport_type`.

Migrated to `coreaudio-rs` safe wrappers, reducing the module from ~570 to ~148 lines with zero `unsafe` blocks. The two missing helpers were contributed upstream: https://github.com/RustAudio/coreaudio-rs/pull/149

## Important: Do not merge until upstream dependency is resolved

This PR currently depends on a fork branch of `coreaudio-rs` (`afonsojramos/coreaudio-rs#feat/device-helpers`). Before merging, one of:

1. **Preferred:** Wait for [RustAudio/coreaudio-rs#149](https://github.com/RustAudio/coreaudio-rs/pull/149) to be merged and released, then update the dependency to point to crates.io
2. **Alternative:** If the upstream PR stalls, the fork branch can be used temporarily

## Files changed

- **`crates/qbz-audio/Cargo.toml`** — add `coreaudio-rs` dependency (macOS only)
- **`crates/qbz-audio/src/coreaudio_direct.rs`** — new module: CoreAudio device probing, sample rate switching, transport type detection
- **`crates/qbz-audio/src/lib.rs`** — register `coreaudio_direct` module
- **`crates/qbz-audio/src/backend.rs`** — enhance `CpalDefaultBackend` on macOS to populate device capabilities and switch sample rate before stream creation
- **`crates/qbz-player/src/player/mod.rs`** — auto-select `SystemDefault` backend on non-Linux when `backend_type` is `None`

## Test plan

- [x] Verified sample rate switching works: playing a 96kHz track switches the device rate (confirmed via Audio MIDI Setup)
- [x] Device capabilities populated in settings UI (supported rates, transport type)
- [x] No regressions on Linux (all changes are cfg-gated)
- [x] Full app compiles clean on macOS