### PR TITLE
fix(axum): convert String to Utf8Bytes after update

### DIFF
--- a/src-tauri/src/api_server/mod.rs
+++ b/src-tauri/src/api_server/mod.rs
@@ -1061,7 +1061,7 @@ async fn handle_ws(mut socket: WebSocket, mut rx: broadcast::Receiver<PlaybackEv
                     Ok(p) => p,
                     Err(_) => continue,
                 };
-                if socket.send(Message::Text(payload)).await.is_err() {
+                if socket.send(Message::Text(payload.into())).await.is_err() {
                     break;
                 }
             }


### PR DESCRIPTION
axum: 0.7.9 -> 0.8.8 introduced breaking changes related to how Messages are handled. This fixes the issue after update by adding `.into()` to convert String to Utf8Bytes.

fixes #241 