### PR TITLE
fix(macos): hide Linux-only settings and fix content padding

### DIFF
--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -4312,6 +4312,8 @@
       <span class="setting-label">{$t('settings.appearance.systemNotifications')}</span>
       <Toggle enabled={systemNotificationsEnabled} onchange={(v) => { systemNotificationsEnabled = v; setSystemNotificationsEnabled(v); }} />
     </div>
+    <!-- Title bar toggles: hidden on macOS (always uses native overlay title bar) -->
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.useSystemTitleBar')}</span>
@@ -4326,6 +4328,9 @@
       </div>
       <Toggle enabled={hideTitleBar} onchange={(v) => setHideTitleBar(v)} disabled={useSystemTitleBar} />
     </div>
+    {/if}
+    <!-- Title bar customization: hidden on macOS (uses native overlay title bar) -->
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.searchInTitleBar')}</span>
@@ -4482,6 +4487,7 @@
         disabled={hideTitleBar || useSystemTitleBar}
       />
     </div>
+    {/if}
     <div class="setting-row">
       <span class="setting-label">{$t('settings.appearance.miniplayerDefaultView')}</span>
       <Dropdown
@@ -4915,7 +4921,8 @@
   <section class="section">
     <h3 class="section-title">{$t('settings.integrations.title')}</h3>
 
-    <!-- Qobuz Link Handler -->
+    <!-- Qobuz Link Handler (Linux only — macOS registers via Info.plist at build time) -->
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.integrations.qobuzLinkHandler')}</span>
@@ -4923,6 +4930,7 @@
       </div>
       <Toggle enabled={qobuzLinkHandlerEnabled} onchange={handleQobuzLinkHandlerToggle} disabled={qobuzLinkHandlerBusy} />
     </div>
+    {/if}
 
     <!-- Qobuz Connect Device Name -->
     <div class="setting-row">

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6018,8 +6018,13 @@
 
   /* macOS: pad main content to clear native overlay title bar */
   :global(html.macos) .main-content {
-    padding-top: 32px;
-    height: calc(100vh - 104px - 32px);
+    padding-top: 16px;
+    height: calc(100vh - 104px - 16px);
+  }
+
+  /* macOS: home view handles its own spacing */
+  :global(html.macos) .main-content :global(.home-view) {
+    margin-top: -16px;
   }
 
   /* macOS: invisible drag region for window movement (overlay title bar) */

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6016,6 +6016,12 @@
     height: calc(100vh - 104px); /* Only 104px NowPlayingBar, no title bar */
   }
 
+  /* macOS: pad main content to clear native overlay title bar */
+  :global(html.macos) .main-content {
+    padding-top: 32px;
+    height: calc(100vh - 104px - 32px);
+  }
+
   /* macOS: invisible drag region for window movement (overlay title bar) */
   :global(html.macos) .macos-drag-region {
     height: 28px;


### PR DESCRIPTION
## Summary

- Guard title bar toggles (system title bar, hide title bar) and search-in-title-bar customization with `{#if !macos}` — these don't apply on macOS which uses a native overlay title bar
- Guard Qobuz link handler toggle — macOS registers URI handlers via `Info.plist` at build time, the runtime XDG toggle is Linux-only
- Add 32px top padding on `.main-content` for macOS to clear the native overlay title bar

## Test plan

- [x] On macOS: title bar toggles and link handler toggle are hidden in Settings
- [x] On macOS: main content area doesn't overlap the title bar region
- [x] On Linux: all settings remain visible and functional