### PR TITLE
feat(macos): add album artwork to notifications

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1372,7 +1372,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1626,7 +1626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2589,7 +2589,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3497,8 +3497,7 @@ dependencies = [
 [[package]]
 name = "notify-rust"
 version = "4.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+source = "git+https://github.com/afonsojramos/notify-rust?branch=feat%2Fmacos-image-path-support#c46803a015137402c761adbb7362f7e6624eb3ee"
 dependencies = [
  "futures-lite",
  "log",
@@ -3590,7 +3589,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3895,7 +3894,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -4810,7 +4809,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4847,9 +4846,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5381,7 +5380,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6667,7 +6666,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7786,7 +7785,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -152,7 +152,7 @@ alsa = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-dialog = { version = "2.6.0" }
-notify-rust = "4"
+notify-rust = { git = "https://github.com/afonsojramos/notify-rust", branch = "feat/macos-image-path-support" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tauri-plugin-dialog = { version = "2.6.0" }

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -71,8 +71,9 @@ use ashpd::desktop::Icon;
 use md5::{Digest, Md5};
 use std::collections::HashSet;
 use std::fs;
+use std::io::Write;
 #[cfg(target_os = "linux")]
-use std::io::{Cursor, Write};
+use std::io::Cursor;
 use std::path::PathBuf;
 use std::sync::Mutex;
 
@@ -801,7 +802,7 @@ const PORTAL_NOTIFICATION_ICON_MAX_EDGE: u32 = 512;
 #[cfg(target_os = "linux")]
 const PORTAL_NOTIFICATION_ICON_MAX_BYTES: usize = 4 * 1024 * 1024;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn v2_get_notification_artwork_cache_dir() -> Result<PathBuf, String> {
     let cache_dir = dirs::cache_dir()
         .ok_or_else(|| "Could not find cache directory".to_string())?
@@ -813,7 +814,7 @@ fn v2_get_notification_artwork_cache_dir() -> Result<PathBuf, String> {
     Ok(cache_dir)
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn v2_resolve_local_artwork(url: &str) -> Option<PathBuf> {
     if let Some(path) = url.strip_prefix("file://") {
         return Some(PathBuf::from(path));
@@ -825,7 +826,7 @@ fn v2_resolve_local_artwork(url: &str) -> Option<PathBuf> {
     None
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn v2_cache_notification_artwork(url: &str) -> Result<PathBuf, String> {
     if let Some(local_path) = v2_resolve_local_artwork(url) {
         if local_path.exists() {
@@ -844,14 +845,16 @@ fn v2_cache_notification_artwork(url: &str) -> Result<PathBuf, String> {
 
     let response = reqwest::blocking::Client::new()
         .get(url)
+        .header("User-Agent", "Mozilla/5.0")
         .timeout(std::time::Duration::from_secs(5))
         .send()
         .map_err(|e| format!("Failed to download artwork: {}", e))?;
 
     if !response.status().is_success() {
         return Err(format!(
-            "Failed to download artwork: HTTP {}",
-            response.status()
+            "Failed to download artwork: HTTP {} (url: {})",
+            response.status(),
+            url.split('?').next().unwrap_or(url)
         ));
     }
 
@@ -11407,16 +11410,34 @@ pub async fn v2_show_track_notification(
 
     #[cfg(target_os = "macos")]
     {
-        let _ = &artwork_url; // macOS notify-rust doesn't support custom artwork
-
         // Fire-and-forget: notification delivery shouldn't block track playback response
         tokio::task::spawn_blocking(move || {
             let _ = notify_rust::set_application("com.blitzfc.qbz");
-            if let Err(e) = notify_rust::Notification::new()
-                .summary(&title)
-                .body(&body_text)
-                .show()
-            {
+
+            // Cache artwork to disk if available (image_path needs a file path)
+            let artwork_path = artwork_url.as_deref().and_then(|url_str| {
+                match v2_cache_notification_artwork(url_str) {
+                    Ok(path) => {
+                        log::debug!("Notification artwork cached: {:?}", path);
+                        Some(path)
+                    }
+                    Err(e) => {
+                        log::debug!("Could not prepare notification artwork: {}", e);
+                        None
+                    }
+                }
+            });
+
+            let mut notification = notify_rust::Notification::new();
+            notification.summary(&title).body(&body_text);
+
+            if let Some(ref path) = artwork_path {
+                if let Some(path_str) = path.to_str() {
+                    notification.image_path(path_str);
+                }
+            }
+
+            if let Err(e) = notification.show() {
                 log::warn!("Failed to show macOS notification: {}", e);
             }
         });


### PR DESCRIPTION
## Summary

- Switch macOS notification dependency from `notify-rust = "4"` to a [fork with `image_path()` support](https://github.com/afonsojramos/notify-rust/tree/feat/macos-image-path-support) (upstream PR: https://github.com/hoodie/notify-rust/pull/264)
- Add album artwork to macOS notifications using `notify_rust::image_path()` which maps to `content_image` (right-side image in notification banners)
- Ungate shared artwork caching functions (`v2_cache_notification_artwork`, `v2_resolve_local_artwork`, `v2_get_notification_artwork_cache_dir`) for macOS — previously Linux-only
- Artwork is resolved from local cache or downloaded to `~/.cache/qbz/notification_artwork/`, then passed as a file path to the notification

## Test plan

- [x] Verified macOS notifications display album artwork in release build
- [x] Verify notifications gracefully degrade when artwork is unavailable (no image, text still shows)
- [x] Verify Linux notifications remain unaffected