### PR TITLE
feat: add Cmd+, keyboard shortcut to open settings

### DIFF
--- a/src/lib/stores/keybindingsStore.ts
+++ b/src/lib/stores/keybindingsStore.ts
@@ -102,6 +102,13 @@ export const ACTIONS: KeybindingAction[] = [
     defaultShortcut: 'Ctrl+f',
     description: 'Focus search field',
   },
+  {
+    id: 'nav.settings',
+    label: 'Settings',
+    category: 'navigation',
+    defaultShortcut: 'Ctrl+,',
+    description: 'Open settings',
+  },
 
   // UI
   {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4001,6 +4001,7 @@
         sidebarRef?.focusSearch();
       }
     });
+    registerAction('nav.settings', () => navigateTo('settings'));
     registerAction('ui.sidebar', toggleSidebar);
     registerAction('ui.focusMode', toggleFocusMode);
     registerAction('ui.miniPlayer', () => { void enterMiniplayerMode(); });


### PR DESCRIPTION
## Summary
- Adds a standard `Cmd+,` (macOS) / `Ctrl+,` (Linux/Windows) keyboard shortcut to open Settings
- Registers the `nav.settings` action in the existing keybindings system, making it user-customizable and visible in the shortcuts modal