### PR TITLE
fix: make immersive mode window draggable on macOS

### DIFF
--- a/src/lib/components/immersive/ImmersivePlayer.svelte
+++ b/src/lib/components/immersive/ImmersivePlayer.svelte
@@ -866,6 +866,11 @@
     app-region: drag;
   }
 
+  /* macOS: overlay titlebar needs drag region above all UI (matches homepage pattern) */
+  :global(html.macos) .immersive-drag-region {
+    z-index: 9999;
+  }
+
   @keyframes fadeIn {
     from {
       opacity: 0;


### PR DESCRIPTION
## Summary
- Boosts the immersive drag region z-index to 9999 on macOS, matching the homepage pattern
- On macOS, the overlay titlebar has no native drag area, so the app provides its own drag region — the immersive mode's drag region was at z-index 15, too low to sit above other UI elements (header at z-index 20)