### PR TITLE
feat(settings): use menu bar terminology and hide redundant tray settings on macOS

### DIFF
--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -4516,15 +4516,16 @@
       <Toggle enabled={purchasesEnabled} onchange={handlePurchasesToggle} />
     </div>
 
-    <!-- System Tray subsection -->
-    <h4 class="subsection-title">{$t('settings.appearance.tray.title')}</h4>
+    <!-- System Tray / Menu Bar subsection -->
+    <h4 class="subsection-title">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.titleMacos' : 'settings.appearance.tray.title')}</h4>
     <div class="setting-row">
       <div class="setting-info">
-        <span class="setting-label">{$t('settings.appearance.tray.enableTray')}</span>
-        <span class="setting-desc">{$t('settings.appearance.tray.enableTrayDesc')}</span>
+        <span class="setting-label">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.enableTrayMacos' : 'settings.appearance.tray.enableTray')}</span>
+        <span class="setting-desc">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.enableTrayDescMacos' : 'settings.appearance.tray.enableTrayDesc')}</span>
       </div>
       <Toggle enabled={enableTray} onchange={(v) => handleEnableTrayChange(v)} />
     </div>
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.tray.minimizeToTray')}</span>
@@ -4539,6 +4540,7 @@
       </div>
       <Toggle enabled={closeToTray} onchange={(v) => handleCloseToTrayChange(v)} disabled={!enableTray} />
     </div>
+    {/if}
 
     <!-- Immersive subsection -->
     <h4 class="subsection-title">{$t('settings.appearance.immersive.title')}</h4>

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -969,8 +969,11 @@
       "forceX11Desc": "X11 (XWayland) statt nativem Wayland verwenden. Hilft bei Abstürzen mit bestimmten NVIDIA/Wayland-Konfigurationen. Neustart erforderlich. Override: QBZ_FORCE_X11=0 qbz",
       "tray": {
         "title": "Systemtray",
+        "titleMacos": "Menüleiste",
         "enableTray": "Tray-Symbol aktivieren",
+        "enableTrayMacos": "Menüleisten-Symbol aktivieren",
         "enableTrayDesc": "Symbol im Systemtray anzeigen (Neustart erforderlich)",
+        "enableTrayDescMacos": "Symbol in der Menüleiste anzeigen (Neustart erforderlich)",
         "minimizeToTray": "In den Tray minimieren",
         "minimizeToTrayDesc": "Fenster beim Minimieren in den Tray verschieben",
         "closeToTray": "In den Systemtray schließen",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1018,8 +1018,11 @@
       "forceX11Desc": "Use X11 (XWayland) instead of native Wayland. Helps with crashes on some NVIDIA/Wayland setups. Requires restart. Override: QBZ_FORCE_X11=0 qbz",
       "tray": {
         "title": "System Tray",
+        "titleMacos": "Menu Bar",
         "enableTray": "Enable tray icon",
+        "enableTrayMacos": "Enable menu bar icon",
         "enableTrayDesc": "Show icon in system tray (requires restart)",
+        "enableTrayDescMacos": "Show icon in menu bar (requires restart)",
         "minimizeToTray": "Minimize to tray",
         "minimizeToTrayDesc": "Hide window to tray when minimizing",
         "closeToTray": "Close to tray",

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -1018,8 +1018,11 @@
       "forceX11Desc": "Usar X11 (XWayland) en lugar de Wayland nativo. Ayuda con crashes en configuraciones NVIDIA/Wayland. Requiere reinicio. Override: QBZ_FORCE_X11=0 qbz",
       "tray": {
         "title": "Bandeja del Sistema",
+        "titleMacos": "Barra de Menú",
         "enableTray": "Habilitar icono de bandeja",
+        "enableTrayMacos": "Habilitar icono en barra de menú",
         "enableTrayDesc": "Mostrar icono en la bandeja del sistema (requiere reinicio)",
+        "enableTrayDescMacos": "Mostrar icono en la barra de menú (requiere reinicio)",
         "minimizeToTray": "Minimizar a bandeja",
         "minimizeToTrayDesc": "Ocultar ventana a la bandeja al minimizar",
         "closeToTray": "Cerrar a bandeja",

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -993,8 +993,11 @@
       "forceX11Desc": "Utiliser X11 (XWayland) au lieu de Wayland natif. Aide avec les plantages sur certaines configurations NVIDIA/Wayland. Redémarrage requis. Override : QBZ_FORCE_X11=0 qbz",
       "tray": {
         "title": "Barre d'état système",
+        "titleMacos": "Barre des menus",
         "enableTray": "Activer l'icône dans la barre système",
+        "enableTrayMacos": "Activer l'icône dans la barre des menus",
         "enableTrayDesc": "Afficher l'icône dans la barre système (nécessite un redémarrage)",
+        "enableTrayDescMacos": "Afficher l'icône dans la barre des menus (nécessite un redémarrage)",
         "minimizeToTray": "Réduire à la barre d'état",
         "minimizeToTrayDesc": "Masquer la fenêtre dans la barre d'état lors de la minimisation",
         "closeToTray": "Réduire dans la barre d'état système",

--- a/src/lib/i18n/locales/pt.json
+++ b/src/lib/i18n/locales/pt.json
@@ -1011,8 +1011,11 @@
       "forceX11Desc": "Usar X11 (XWayland) em vez do Wayland nativo. Ajuda com travamentos em algumas configurações NVIDIA/Wayland. Requer reinicialização. Substituir: QBZ_FORCE_X11=0 qbz",
       "tray": {
         "title": "Bandeja do Sistema",
+        "titleMacos": "Barra de Menus",
         "enableTray": "Ativar ícone na bandeja",
+        "enableTrayMacos": "Ativar ícone na barra de menus",
         "enableTrayDesc": "Mostrar ícone na bandeja do sistema (requer reinicialização)",
+        "enableTrayDescMacos": "Mostrar ícone na barra de menus (requer reinicialização)",
         "minimizeToTray": "Minimizar para a bandeja",
         "minimizeToTrayDesc": "Ocultar janela na bandeja ao minimizar",
         "closeToTray": "Fechar para a bandeja",


### PR DESCRIPTION
## Summary
- On macOS, renames "System Tray" section to "Menu Bar" and updates the "Enable tray icon" label/description to use "menu bar" terminology across all 5 locales (en, de, es, fr, pt)
- Hides the "Minimize to tray" and "Close to tray" toggles on macOS, since macOS apps already stay running when windows are closed or minimized — making these settings redundant
- Follows the existing `document.documentElement.classList.contains('macos')` gating pattern used elsewhere in SettingsView

## Test plan
- [x] On macOS: verify only "Menu Bar" section with "Enable menu bar icon" toggle is shown
- [x] On Linux: verify all three toggles still appear under "System Tray" with original text
- [x] Verify each locale (en, de, es, fr, pt) displays correct translated menu bar text on macOS