### PR TITLE
fix(deps): use released coreaudio-rs and notify-rust instead of forks

### DIFF
--- a/crates/qbz-audio/Cargo.toml
+++ b/crates/qbz-audio/Cargo.toml
@@ -42,5 +42,4 @@ alsa = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 # CoreAudio for device probing, sample rate switching, and (future) hog mode / exclusive mode
-# Using fork branch until https://github.com/RustAudio/coreaudio-rs/pull/149 is merged
-coreaudio-rs = { git = "https://github.com/afonsojramos/coreaudio-rs.git", branch = "feat/device-helpers" }
+coreaudio-rs = "0.14.1"

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3539,8 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "notify-rust"
-version = "4.12.0"
-source = "git+https://github.com/afonsojramos/notify-rust?branch=feat%2Fmacos-image-path-support#c46803a015137402c761adbb7362f7e6624eb3ee"
+version = "4.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9612133a804b4bc753f9f806de73fc9730b7694eb1bada2dc252cce022638be8"
 dependencies = [
  "futures-lite",
  "log",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -194,7 +194,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
  "wl-clipboard-rs",
  "x11rb",
 ]
@@ -1097,8 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.14.0"
-source = "git+https://github.com/afonsojramos/coreaudio-rs.git?branch=feat%2Fdevice-helpers#ce3fec9bce0b43ece78bb8801c87be9889e5710e"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16dd574a72a021b90c7656c474ea31d11a2f0366a8eff574186e761e0b9e3586"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -1405,7 +1406,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1668,7 +1669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2631,7 +2632,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3631,7 +3632,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -3946,7 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4545,7 +4546,7 @@ version = "0.1.0"
 dependencies = [
  "alsa 0.9.1",
  "async-trait",
- "coreaudio-rs 0.14.0",
+ "coreaudio-rs 0.14.1",
  "dirs 5.0.1",
  "ebur128",
  "log",
@@ -4863,7 +4864,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4900,9 +4901,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5445,7 +5446,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6766,7 +6767,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7894,7 +7895,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -151,7 +151,7 @@ alsa = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tauri-plugin-dialog = { version = "2.6.0" }
-notify-rust = { git = "https://github.com/afonsojramos/notify-rust", branch = "feat/macos-image-path-support" }
+notify-rust = "4.13.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tauri-plugin-dialog = { version = "2.6.0" }


### PR DESCRIPTION
## Summary
- Replaces the `coreaudio-rs` git fork dependency (`afonsojramos/coreaudio-rs` branch `feat/device-helpers`) with the official crates.io release `0.14.1` — [RustAudio/coreaudio-rs#149](https://github.com/RustAudio/coreaudio-rs/pull/149) has been merged and released upstream
- Replaces the `notify-rust` git fork dependency (`afonsojramos/notify-rust` branch `feat/macos-image-path-support`) with the official crates.io release `4.13.0` — [hoodie/notify-rust#264](https://github.com/hoodie/notify-rust/pull/264) has been merged and released upstream