### PR TITLE
Fix gapless playback in local library and gapless looping in repeat mode one

### DIFF
--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -58,7 +58,6 @@ use crate::offline_cache::OfflineCacheState;
 use crate::playback_context::{ContentSource, ContextType, PlaybackContext};
 use crate::plex::{PlexMusicSection, PlexPlayResult, PlexServerInfo, PlexTrack};
 use crate::qconnect_service::{QconnectServiceState, QconnectVisibleQueueProjection};
-use crate::queue::{RepeatMode as QueueRepeatMode};
 use crate::reco_store::{HomeResolved, HomeSeeds, RecoEventInput, RecoState};
 use crate::runtime::{
     CommandRequirement, DegradedReason, RuntimeError, RuntimeEvent, RuntimeManagerState,
@@ -6058,7 +6057,6 @@ pub async fn v2_set_repeat_mode(
     bridge: State<'_, CoreBridgeState>,
     qconnect: State<'_, QconnectServiceState>,
     runtime: State<'_, RuntimeManagerState>,
-    app_state: State<'_, AppState>,
 ) -> Result<(), RuntimeError> {
     runtime
         .manager()
@@ -6080,9 +6078,6 @@ pub async fn v2_set_repeat_mode(
 
     let bridge = bridge.get().await;
     bridge.set_repeat_mode(mode).await;
-
-    let queue_repeat_mode = repeat_mode_to_queue_repeat_mode(mode);
-    app_state.queue.set_repeat(queue_repeat_mode);
     Ok(())
 }
 
@@ -6163,14 +6158,6 @@ pub async fn v2_clear_queue(
     let bridge = bridge.get().await;
     bridge.clear_queue().await;
     Ok(())
-}
-
-fn repeat_mode_to_queue_repeat_mode (mode: RepeatMode) -> QueueRepeatMode {
-    match mode {
-        RepeatMode::Off => QueueRepeatMode::Off,
-        RepeatMode::All => QueueRepeatMode::All,
-        RepeatMode::One => QueueRepeatMode::One,
-    }
 }
 
 async fn apply_qconnect_shuffle_mode(
@@ -7441,11 +7428,11 @@ pub async fn v2_play_next_gapless(
     let bridge_guard = bridge.get().await;
     let player = bridge_guard.player();
     let current_track_id = player.state.current_track_id();
-    let repeat_mode = app_state.queue.get_repeat();
+    let repeat_mode = bridge_guard.get_queue_state().await.repeat;
 
     // Defensive guard: never queue the currently playing track as "next".
     // This avoids infinite one-track loops when frontend queue state is stale.
-    if current_track_id != 0 && repeat_mode != QueueRepeatMode::One && current_track_id == track_id {
+    if current_track_id != 0 && repeat_mode != RepeatMode::One && current_track_id == track_id {
         log::warn!(
             "[V2/GAPLESS] Ignoring play_next_gapless for current track {}",
             track_id

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -7719,12 +7719,10 @@ pub async fn v2_play_next_gapless(
     }
 
     // Check local library
-    // Convert u64 to i64 for library query
     let track_id_i64 = track_id_to_play
         .try_into()
         .map_err(|_| RuntimeError::Internal("Track ID too large for i64".to_string()))?;
 
-    // Query V2 multi-track API with a single ID
     let tracks = v2_library_get_tracks_by_ids(vec![track_id_i64], library_state.clone())
         .await
         .map_err(|e| RuntimeError::Internal(format!("Failed to get local track: {}", e)))?;

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -7614,6 +7614,7 @@ pub async fn v2_play_next_gapless(
     bridge: State<'_, CoreBridgeState>,
     offline_cache: State<'_, OfflineCacheState>,
     app_state: State<'_, AppState>,
+    library_state: State<'_, LibraryState>,
 ) -> Result<bool, RuntimeError> {
     log::info!("[V2] Command: play_next_gapless for track {}", track_id);
 
@@ -7683,6 +7684,30 @@ pub async fn v2_play_next_gapless(
                 audio_data.len()
             );
             player
+                .play_next(audio_data, track_id)
+                .map_err(RuntimeError::Internal)?;
+            return Ok(true);
+        }
+    }
+
+    // Check local library
+    // Convert u64 to i64 for library query
+    let track_id_i64 = track_id
+        .try_into()
+        .map_err(|_| RuntimeError::Internal("Track ID too large for i64".to_string()))?;
+
+    // Query V2 multi-track API with a single ID
+    let tracks = v2_library_get_tracks_by_ids(vec![track_id_i64], library_state.clone())
+        .await
+        .map_err(|e| RuntimeError::Internal(format!("Failed to get local track: {}", e)))?;
+
+    if let Some(local_track) = tracks.into_iter().next() {
+        let path = std::path::Path::new(&local_track.file_path);
+        if path.exists() {
+            log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id);
+            let audio_data = std::fs::read(path)
+                .map_err(|e| RuntimeError::Internal(format!("Failed to read local file: {}", e)))?;
+            bridge.get().await.player()
                 .play_next(audio_data, track_id)
                 .map_err(RuntimeError::Internal)?;
             return Ok(true);

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -4020,7 +4020,6 @@ pub async fn v2_library_play_track(
     library_state: State<'_, LibraryState>,
     bridge: State<'_, CoreBridgeState>,
     runtime: State<'_, RuntimeManagerState>,
-    app_state: State<'_, AppState>,
 ) -> Result<(), String> {
     runtime
         .manager()
@@ -4040,15 +4039,6 @@ pub async fn v2_library_play_track(
         return Err(format!("File not found: {}", track.file_path));
     }
     let audio_data = std::fs::read(file_path).map_err(|e| format!("Failed to read file: {}", e))?;
-
-    let cache = app_state.audio_cache.clone();
-    if let Ok(track_id_u64) = u64::try_from(track_id) {
-        if !cache.contains(track_id_u64) {
-            cache.insert(track_id_u64, audio_data.clone());
-            log::info!("[V2/CACHED] Track {} stored in memory cache", track_id_u64);
-        }
-    }
-
     let bridge = bridge.get().await;
     bridge
         .player()

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -58,6 +58,7 @@ use crate::offline_cache::OfflineCacheState;
 use crate::playback_context::{ContentSource, ContextType, PlaybackContext};
 use crate::plex::{PlexMusicSection, PlexPlayResult, PlexServerInfo, PlexTrack};
 use crate::qconnect_service::{QconnectServiceState, QconnectVisibleQueueProjection};
+use crate::queue::{RepeatMode as QueueRepeatMode};
 use crate::reco_store::{HomeResolved, HomeSeeds, RecoEventInput, RecoState};
 use crate::runtime::{
     CommandRequirement, DegradedReason, RuntimeError, RuntimeEvent, RuntimeManagerState,
@@ -4223,6 +4224,7 @@ pub async fn v2_library_play_track(
     library_state: State<'_, LibraryState>,
     bridge: State<'_, CoreBridgeState>,
     runtime: State<'_, RuntimeManagerState>,
+    app_state: State<'_, AppState>,
 ) -> Result<(), String> {
     runtime
         .manager()
@@ -4242,6 +4244,15 @@ pub async fn v2_library_play_track(
         return Err(format!("File not found: {}", track.file_path));
     }
     let audio_data = std::fs::read(file_path).map_err(|e| format!("Failed to read file: {}", e))?;
+
+    let cache = app_state.audio_cache.clone();
+    if let Ok(track_id_u64) = u64::try_from(track_id) {
+        if !cache.contains(track_id_u64) {
+            cache.insert(track_id_u64, audio_data.clone());
+            log::info!("[V2/CACHED] Track {} stored in memory cache", track_id_u64);
+        }
+    }
+
     let bridge = bridge.get().await;
     bridge
         .player()
@@ -6250,6 +6261,7 @@ pub async fn v2_set_repeat_mode(
     bridge: State<'_, CoreBridgeState>,
     qconnect: State<'_, QconnectServiceState>,
     runtime: State<'_, RuntimeManagerState>,
+    app_state: State<'_, AppState>,
 ) -> Result<(), RuntimeError> {
     runtime
         .manager()
@@ -6271,6 +6283,9 @@ pub async fn v2_set_repeat_mode(
 
     let bridge = bridge.get().await;
     bridge.set_repeat_mode(mode).await;
+
+    let queue_repeat_mode = repeat_mode_to_queue_repeat_mode(mode);
+    app_state.queue.set_repeat(queue_repeat_mode);
     Ok(())
 }
 
@@ -6351,6 +6366,14 @@ pub async fn v2_clear_queue(
     let bridge = bridge.get().await;
     bridge.clear_queue().await;
     Ok(())
+}
+
+fn repeat_mode_to_queue_repeat_mode (mode: RepeatMode) -> QueueRepeatMode {
+    match mode {
+        RepeatMode::Off => QueueRepeatMode::Off,
+        RepeatMode::All => QueueRepeatMode::All,
+        RepeatMode::One => QueueRepeatMode::One,
+    }
 }
 
 async fn apply_qconnect_shuffle_mode(
@@ -7621,6 +7644,11 @@ pub async fn v2_play_next_gapless(
     let bridge_guard = bridge.get().await;
     let player = bridge_guard.player();
     let current_track_id = player.state.current_track_id();
+    let repeat_mode = app_state.queue.get_repeat();
+    let track_id_to_play = match repeat_mode {
+        QueueRepeatMode::One => current_track_id,
+        _ => track_id
+    };
 
     // Defensive guard: never queue the currently playing track as "next".
     // This avoids infinite one-track loops when frontend queue state is stale.
@@ -7637,7 +7665,7 @@ pub async fn v2_play_next_gapless(
         let cached_path = {
             let db_opt = offline_cache.db.lock().await;
             if let Some(db) = db_opt.as_ref() {
-                if let Ok(Some(file_path)) = db.get_file_path(track_id) {
+                if let Ok(Some(file_path)) = db.get_file_path(track_id_to_play) {
                     Some(file_path)
                 } else {
                     None
@@ -7649,12 +7677,12 @@ pub async fn v2_play_next_gapless(
         if let Some(file_path) = cached_path {
             let path = std::path::Path::new(&file_path);
             if path.exists() {
-                log::info!("[V2/GAPLESS] Track {} from OFFLINE cache", track_id);
+                log::info!("[V2/GAPLESS] Track {} from OFFLINE cache", track_id_to_play);
                 let audio_data = std::fs::read(path).map_err(|e| {
                     RuntimeError::Internal(format!("Failed to read cached file: {}", e))
                 })?;
                 player
-                    .play_next(audio_data, track_id)
+                    .play_next(audio_data, track_id_to_play)
                     .map_err(RuntimeError::Internal)?;
                 return Ok(true);
             }
@@ -7663,28 +7691,28 @@ pub async fn v2_play_next_gapless(
 
     // Check memory cache (L1)
     let cache = app_state.audio_cache.clone();
-    if let Some(cached) = cache.get(track_id) {
+    if let Some(cached) = cache.get(track_id_to_play) {
         log::info!(
             "[V2/GAPLESS] Track {} from MEMORY cache ({} bytes)",
-            track_id,
+            track_id_to_play,
             cached.size_bytes
         );
         player
-            .play_next(cached.data, track_id)
+            .play_next(cached.data, track_id_to_play)
             .map_err(RuntimeError::Internal)?;
         return Ok(true);
     }
 
     // Check playback cache (L2 - disk)
     if let Some(playback_cache) = cache.get_playback_cache() {
-        if let Some(audio_data) = playback_cache.get(track_id) {
+        if let Some(audio_data) = playback_cache.get(track_id_to_play) {
             log::info!(
                 "[V2/GAPLESS] Track {} from DISK cache ({} bytes)",
-                track_id,
+                track_id_to_play,
                 audio_data.len()
             );
             player
-                .play_next(audio_data, track_id)
+                .play_next(audio_data, track_id_to_play)
                 .map_err(RuntimeError::Internal)?;
             return Ok(true);
         }
@@ -7692,7 +7720,7 @@ pub async fn v2_play_next_gapless(
 
     // Check local library
     // Convert u64 to i64 for library query
-    let track_id_i64 = track_id
+    let track_id_i64 = track_id_to_play
         .try_into()
         .map_err(|_| RuntimeError::Internal("Track ID too large for i64".to_string()))?;
 
@@ -7704,11 +7732,11 @@ pub async fn v2_play_next_gapless(
     if let Some(local_track) = tracks.into_iter().next() {
         let path = std::path::Path::new(&local_track.file_path);
         if path.exists() {
-            log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id);
+            log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id_to_play);
             let audio_data = std::fs::read(path)
                 .map_err(|e| RuntimeError::Internal(format!("Failed to read local file: {}", e)))?;
             bridge.get().await.player()
-                .play_next(audio_data, track_id)
+                .play_next(audio_data, track_id_to_play)
                 .map_err(RuntimeError::Internal)?;
             return Ok(true);
         }
@@ -7716,7 +7744,7 @@ pub async fn v2_play_next_gapless(
 
     log::info!(
         "[V2/GAPLESS] Track {} not in any cache, gapless not possible",
-        track_id
+        track_id_to_play
     );
     Ok(false)
 }

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -7719,24 +7719,23 @@ pub async fn v2_play_next_gapless(
     }
 
     // Check local library
-    let track_id_i64 = track_id_to_play
-        .try_into()
-        .map_err(|_| RuntimeError::Internal("Track ID too large for i64".to_string()))?;
-
-    let tracks = v2_library_get_tracks_by_ids(vec![track_id_i64], library_state.clone())
-        .await
-        .map_err(|e| RuntimeError::Internal(format!("Failed to get local track: {}", e)))?;
-
-    if let Some(local_track) = tracks.into_iter().next() {
-        let path = std::path::Path::new(&local_track.file_path);
-        if path.exists() {
-            log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id_to_play);
-            let audio_data = std::fs::read(path)
-                .map_err(|e| RuntimeError::Internal(format!("Failed to read local file: {}", e)))?;
-            bridge.get().await.player()
-                .play_next(audio_data, track_id_to_play)
-                .map_err(RuntimeError::Internal)?;
-            return Ok(true);
+    if let Ok(track_id_i64) = track_id_to_play.try_into() {
+        if let Ok(tracks) = 
+            v2_library_get_tracks_by_ids(vec![track_id_i64], library_state.clone())
+            .await 
+        {
+            if let Some(local_track) = tracks.into_iter().next() {
+                let path = std::path::Path::new(&local_track.file_path);
+                if path.exists() {
+                    log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id_to_play);
+                    let audio_data = std::fs::read(path)
+                        .map_err(|e| RuntimeError::Internal(format!("Failed to read local file: {}", e)))?;
+                    bridge.get().await.player()
+                        .play_next(audio_data, track_id_to_play)
+                        .map_err(RuntimeError::Internal)?;
+                    return Ok(true);
+                }
+            }
         }
     }
 

--- a/src-tauri/src/commands_v2.rs
+++ b/src-tauri/src/commands_v2.rs
@@ -7442,14 +7442,10 @@ pub async fn v2_play_next_gapless(
     let player = bridge_guard.player();
     let current_track_id = player.state.current_track_id();
     let repeat_mode = app_state.queue.get_repeat();
-    let track_id_to_play = match repeat_mode {
-        QueueRepeatMode::One => current_track_id,
-        _ => track_id
-    };
 
     // Defensive guard: never queue the currently playing track as "next".
     // This avoids infinite one-track loops when frontend queue state is stale.
-    if current_track_id != 0 && current_track_id == track_id {
+    if current_track_id != 0 && repeat_mode != QueueRepeatMode::One && current_track_id == track_id {
         log::warn!(
             "[V2/GAPLESS] Ignoring play_next_gapless for current track {}",
             track_id
@@ -7462,7 +7458,7 @@ pub async fn v2_play_next_gapless(
         let cached_path = {
             let db_opt = offline_cache.db.lock().await;
             if let Some(db) = db_opt.as_ref() {
-                if let Ok(Some(file_path)) = db.get_file_path(track_id_to_play) {
+                if let Ok(Some(file_path)) = db.get_file_path(track_id) {
                     Some(file_path)
                 } else {
                     None
@@ -7474,12 +7470,12 @@ pub async fn v2_play_next_gapless(
         if let Some(file_path) = cached_path {
             let path = std::path::Path::new(&file_path);
             if path.exists() {
-                log::info!("[V2/GAPLESS] Track {} from OFFLINE cache", track_id_to_play);
+                log::info!("[V2/GAPLESS] Track {} from OFFLINE cache", track_id);
                 let audio_data = std::fs::read(path).map_err(|e| {
                     RuntimeError::Internal(format!("Failed to read cached file: {}", e))
                 })?;
                 player
-                    .play_next(audio_data, track_id_to_play)
+                    .play_next(audio_data, track_id)
                     .map_err(RuntimeError::Internal)?;
                 return Ok(true);
             }
@@ -7488,35 +7484,35 @@ pub async fn v2_play_next_gapless(
 
     // Check memory cache (L1)
     let cache = app_state.audio_cache.clone();
-    if let Some(cached) = cache.get(track_id_to_play) {
+    if let Some(cached) = cache.get(track_id) {
         log::info!(
             "[V2/GAPLESS] Track {} from MEMORY cache ({} bytes)",
-            track_id_to_play,
+            track_id,
             cached.size_bytes
         );
         player
-            .play_next(cached.data, track_id_to_play)
+            .play_next(cached.data, track_id)
             .map_err(RuntimeError::Internal)?;
         return Ok(true);
     }
 
     // Check playback cache (L2 - disk)
     if let Some(playback_cache) = cache.get_playback_cache() {
-        if let Some(audio_data) = playback_cache.get(track_id_to_play) {
+        if let Some(audio_data) = playback_cache.get(track_id) {
             log::info!(
                 "[V2/GAPLESS] Track {} from DISK cache ({} bytes)",
-                track_id_to_play,
+                track_id,
                 audio_data.len()
             );
             player
-                .play_next(audio_data, track_id_to_play)
+                .play_next(audio_data, track_id)
                 .map_err(RuntimeError::Internal)?;
             return Ok(true);
         }
     }
 
     // Check local library
-    if let Ok(track_id_i64) = track_id_to_play.try_into() {
+    if let Ok(track_id_i64) = track_id.try_into() {
         if let Ok(tracks) = 
             v2_library_get_tracks_by_ids(vec![track_id_i64], library_state.clone())
             .await 
@@ -7524,11 +7520,11 @@ pub async fn v2_play_next_gapless(
             if let Some(local_track) = tracks.into_iter().next() {
                 let path = std::path::Path::new(&local_track.file_path);
                 if path.exists() {
-                    log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id_to_play);
+                    log::info!("[V2/GAPLESS] Track {} from LOCAL library", track_id);
                     let audio_data = std::fs::read(path)
                         .map_err(|e| RuntimeError::Internal(format!("Failed to read local file: {}", e)))?;
                     bridge.get().await.player()
-                        .play_next(audio_data, track_id_to_play)
+                        .play_next(audio_data, track_id)
                         .map_err(RuntimeError::Internal)?;
                     return Ok(true);
                 }
@@ -7538,7 +7534,7 @@ pub async fn v2_play_next_gapless(
 
     log::info!(
         "[V2/GAPLESS] Track {} not in any cache, gapless not possible",
-        track_id_to_play
+        track_id
     );
     Ok(false)
 }

--- a/src/lib/stores/playerStore.ts
+++ b/src/lib/stores/playerStore.ts
@@ -792,6 +792,7 @@ async function handlePlaybackEvent(event: PlaybackEvent): Promise<void> {
           })
           .finally(() => {
             gaplessRequestInFlight = false;
+            gaplessAttemptTrackId = null;
           });
       }
     }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4471,13 +4471,13 @@
       try {
         const queueState = getQueueState();
         if (queueState.queue.length > 0) {
-          const firstId = Number(queueState.queue[0].id);
           const currentId = currentTrack?.id ?? null;
 
           if (queueState.repeatMode == 'one') {
             return currentId;
           }
           
+          const firstId = Number(queueState.queue[0].id);
           if (!Number.isNaN(firstId) && firstId > 0 && firstId !== currentId) {
             return firstId;
           }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4473,6 +4473,11 @@
         if (queueState.queue.length > 0) {
           const firstId = Number(queueState.queue[0].id);
           const currentId = currentTrack?.id ?? null;
+
+          if (queueState.repeatMode == 'one') {
+            return currentId;
+          }
+          
           if (!Number.isNaN(firstId) && firstId > 0 && firstId !== currentId) {
             return firstId;
           }


### PR DESCRIPTION
Fix for gapless playback in local library:

Previously, gapless playback relied on audio data being present in a cache, which is not the case for the local library. Added a check to the v2_play_next_gapless function to check the local library after the caches and play the track if present.


Included a fix for gapless playback in repeat mode one which affects both local library and streaming:

Previously, if gapless playback was enabled and repeat mode was set to "one" (useful for looping a track seamlessly), the repeat would fail and the next track would play instead, leaving the now playing and seek bar UI stuck at the end of the track that was meant to be repeated. This was fixed by returning the current ID explicitly in the setGaplessGetNextTrackId callback, along with skipping the check for state frontend queue state (firstId != currentId) in the backend if the repeat mode is set to "one".

