### PR TITLE
feat: add in-app auto-updater via tauri-plugin-updater

### DIFF
--- a/.github/workflows/release-linux-aarch64.yml
+++ b/.github/workflows/release-linux-aarch64.yml
@@ -71,6 +71,9 @@ jobs:
         run: npm run build
 
       - name: Build Tauri (deb + rpm + appimage)
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles deb,rpm,appimage
 
       - name: Collect artifacts
@@ -81,6 +84,7 @@ jobs:
           cp -v src-tauri/target/release/bundle/deb/*.deb dist/ || true
           cp -v src-tauri/target/release/bundle/rpm/*.rpm dist/ || true
           cp -v src-tauri/target/release/bundle/appimage/*.AppImage dist/ || true
+          cp -v src-tauri/target/release/bundle/appimage/*.AppImage.sig dist/ || true
 
           # Create AUR tarball
           ARCH=aarch64

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -99,6 +99,9 @@ jobs:
         run: npm ci
 
       - name: Build DEB/RPM/AppImage
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         run: npm run tauri build -- --bundles deb,rpm,appimage
 
       - name: Collect artifacts
@@ -110,6 +113,7 @@ jobs:
           cp -v src-tauri/target/release/bundle/deb/*.deb dist/ || true
           cp -v src-tauri/target/release/bundle/rpm/*.rpm dist/ || true
           cp -v src-tauri/target/release/bundle/appimage/*.AppImage dist/ || true
+          cp -v src-tauri/target/release/bundle/appimage/*.AppImage.sig dist/ || true
 
           # Create tarball for AUR with proper structure
           TARBALL_DIR="qbz_${VERSION}_amd64"

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -95,13 +95,20 @@ jobs:
       - name: Install JS dependencies
         run: npm ci
 
-      - name: Build DMG
-        run: npm run tauri build -- --target ${{ matrix.target }} --bundles dmg
+      - name: Build macOS bundles
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: npm run tauri build -- --target ${{ matrix.target }}
 
       - name: Collect artifacts
         run: |
           mkdir -p dist
+          # DMG for manual distribution
           cp -v src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg dist/ || true
+          # .app.tar.gz + .sig for auto-updater
+          cp -v src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz dist/ || true
+          cp -v src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz.sig dist/ || true
           ls -la dist
 
       - name: Upload artifacts

--- a/.github/workflows/release-updater-manifest.yml
+++ b/.github/workflows/release-updater-manifest.yml
@@ -1,0 +1,170 @@
+name: Generate Updater Manifest
+
+on:
+  workflow_run:
+    workflows:
+      - release-macos
+      - release-linux
+      - "Linux ARM64 (aarch64) Build"
+    types:
+      - completed
+
+concurrency:
+  group: updater-manifest-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  generate-manifest:
+    # Only run on successful tag-triggered builds (not manual dispatches)
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Resolve version from tag
+        id: version
+        run: |
+          TAG="${{ github.event.workflow_run.head_branch }}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for all platform builds to finish
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Wait up to 20 minutes for .sig files from all platforms
+          REQUIRED_SIGS=("aarch64.app.tar.gz.sig" "x64.app.tar.gz.sig" "AppImage.sig")
+          MAX_ATTEMPTS=40
+          SLEEP_SECONDS=30
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            ASSETS=$(gh release view "$TAG" --repo "${{ github.repository }}" --json assets -q '.assets[].name' 2>/dev/null || echo "")
+
+            FOUND_ALL=true
+            for sig_suffix in "${REQUIRED_SIGS[@]}"; do
+              if ! echo "$ASSETS" | grep -q "$sig_suffix"; then
+                FOUND_ALL=false
+                break
+              fi
+            done
+
+            if [ "$FOUND_ALL" = true ]; then
+              echo "All signature files found on attempt $attempt"
+              break
+            fi
+
+            if [ "$attempt" -eq "$MAX_ATTEMPTS" ]; then
+              echo "Warning: Not all .sig files found after $MAX_ATTEMPTS attempts. Generating manifest with available assets."
+              break
+            fi
+
+            echo "Attempt $attempt/$MAX_ATTEMPTS: waiting for all .sig files..."
+            sleep $SLEEP_SECONDS
+          done
+
+      - name: Generate latest.json
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          REPO="${{ github.repository }}"
+          RELEASE_URL="https://github.com/${REPO}/releases/download/${TAG}"
+
+          # Get release info
+          RELEASE_JSON=$(gh release view "$TAG" --repo "$REPO" --json body,publishedAt)
+          NOTES=$(echo "$RELEASE_JSON" | jq -r '.body // ""')
+          PUB_DATE=$(echo "$RELEASE_JSON" | jq -r '.publishedAt // ""')
+
+          # Download all .sig files
+          mkdir -p sigs
+          ASSETS=$(gh release view "$TAG" --repo "$REPO" --json assets -q '.assets[].name')
+
+          for asset in $ASSETS; do
+            if [[ "$asset" == *.sig ]]; then
+              gh release download "$TAG" --repo "$REPO" --pattern "$asset" --dir sigs
+            fi
+          done
+
+          ls -la sigs/
+
+          # Build platform entries
+          # Helper: read sig content for a glob pattern, return empty string if not found
+          read_sig() {
+            local sig_file
+            for pattern in "$@"; do
+              sig_file=$(find sigs -name "$pattern" -print -quit 2>/dev/null)
+              if [ -n "$sig_file" ] && [ -f "$sig_file" ]; then
+                cat "$sig_file"
+                return
+              fi
+            done
+            echo ""
+          }
+
+          # Find asset names matching patterns (extended regex)
+          find_asset() {
+            local pattern="$1"
+            echo "$ASSETS" | grep -E "$pattern" | head -1
+          }
+
+          # Build platforms JSON
+          PLATFORMS="{}"
+
+          # macOS aarch64 (.app.tar.gz for updater)
+          MACOS_ARM_TAR=$(find_asset "aarch64.app.tar.gz$")
+          MACOS_ARM_SIG=$(read_sig "*aarch64.app.tar.gz.sig")
+          if [ -n "$MACOS_ARM_TAR" ] && [ -n "$MACOS_ARM_SIG" ]; then
+            PLATFORMS=$(echo "$PLATFORMS" | jq --arg url "${RELEASE_URL}/${MACOS_ARM_TAR}" --arg sig "$MACOS_ARM_SIG" \
+              '. + {"darwin-aarch64": {"signature": $sig, "url": $url}}')
+          fi
+
+          # macOS x86_64 (.app.tar.gz for updater)
+          MACOS_X64_TAR=$(find_asset "(x64|x86_64).app.tar.gz$")
+          MACOS_X64_SIG=$(read_sig "*x64.app.tar.gz.sig" "*x86_64.app.tar.gz.sig")
+          if [ -n "$MACOS_X64_TAR" ] && [ -n "$MACOS_X64_SIG" ]; then
+            PLATFORMS=$(echo "$PLATFORMS" | jq --arg url "${RELEASE_URL}/${MACOS_X64_TAR}" --arg sig "$MACOS_X64_SIG" \
+              '. + {"darwin-x86_64": {"signature": $sig, "url": $url}}')
+          fi
+
+          # Linux x86_64 AppImage
+          LINUX_X64_APPIMAGE=$(find_asset "(amd64|x86_64).AppImage$")
+          LINUX_X64_SIG=$(read_sig "*amd64.AppImage.sig" "*x86_64.AppImage.sig")
+          if [ -n "$LINUX_X64_APPIMAGE" ] && [ -n "$LINUX_X64_SIG" ]; then
+            PLATFORMS=$(echo "$PLATFORMS" | jq --arg url "${RELEASE_URL}/${LINUX_X64_APPIMAGE}" --arg sig "$LINUX_X64_SIG" \
+              '. + {"linux-x86_64": {"signature": $sig, "url": $url}}')
+          fi
+
+          # Linux aarch64 AppImage
+          LINUX_ARM_APPIMAGE=$(find_asset "aarch64.AppImage$")
+          LINUX_ARM_SIG=$(read_sig "*aarch64.AppImage.sig")
+          if [ -n "$LINUX_ARM_APPIMAGE" ] && [ -n "$LINUX_ARM_SIG" ]; then
+            PLATFORMS=$(echo "$PLATFORMS" | jq --arg url "${RELEASE_URL}/${LINUX_ARM_APPIMAGE}" --arg sig "$LINUX_ARM_SIG" \
+              '. + {"linux-aarch64": {"signature": $sig, "url": $url}}')
+          fi
+
+          # Assemble final latest.json
+          jq -n \
+            --arg version "$VERSION" \
+            --arg notes "$NOTES" \
+            --arg pub_date "$PUB_DATE" \
+            --argjson platforms "$PLATFORMS" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' \
+            > latest.json
+
+          echo "Generated latest.json:"
+          cat latest.json
+
+      - name: Upload latest.json to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Delete existing latest.json if present (from a previous run)
+          gh release delete-asset "$TAG" latest.json --repo "${{ github.repository }}" --yes 2>/dev/null || true
+          # Upload the new one
+          gh release upload "$TAG" latest.json --repo "${{ github.repository }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,67 +1,71 @@
 {
   "name": "qbz-nix",
-  "version": "1.2.4",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "qbz-nix",
-      "version": "1.2.4",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@icons-pack/svelte-simple-icons": "^7.2.0",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-clipboard-manager": "^2",
-        "@tauri-apps/plugin-dialog": "^2.7.0",
+        "@tauri-apps/plugin-dialog": "^2.5.0",
         "@tauri-apps/plugin-opener": "^2",
-        "@tauri-apps/plugin-os": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "lucide-svelte": "^1.0.1",
         "svelte-i18n": "^4.0.0"
       },
       "devDependencies": {
         "@sveltejs/adapter-static": "^3.0.6",
-        "@sveltejs/kit": "^2.57.0",
+        "@sveltejs/kit": "^2.55.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
         "@tauri-apps/cli": "^2",
         "@testing-library/svelte": "^5.3.1",
-        "jsdom": "^29.0.2",
-        "svelte": "^5.55.2",
+        "jsdom": "^27.4.0",
+        "svelte": "^5.55.0",
         "svelte-check": "^4.4.6",
         "typescript": "~5.9.3",
-        "vite": "^8.0.8",
+        "vite": "^8.0.3",
         "vitest": "^4.1.2"
       }
     },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@asamuzakjp/css-color": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.6.tgz",
-      "integrity": "sha512-BXWCh8dHs9GOfpo/fWGDJtDmleta2VePN9rn6WQt3GjEbxzutVF4t0x2pmH+7dbMCLtuv3MlwqRsAuxlzFXqFg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@csstools/css-calc": "^3.1.1",
-        "@csstools/css-color-parser": "^4.0.2",
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.7.tgz",
-      "integrity": "sha512-d2BgqDUOS1Hfp4IzKUZqCNz+Kg3Y88AkaBvJK/ZVSQPU1f7OpPNi7nQTH6/oI47Dkdg+Z3e8Yp6ynOu4UMINAQ==",
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
         "bidi-js": "^1.0.3",
-        "css-tree": "^3.2.1",
-        "is-potential-custom-element-name": "^1.0.1"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
       }
     },
     "node_modules/@asamuzakjp/nwsapi": {
@@ -106,23 +110,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bramus/specificity": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
-      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-tree": "^3.0.0"
-      },
-      "bin": {
-        "specificity": "bin/cli.js"
-      }
-    },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
-      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
       "dev": true,
       "funding": [
         {
@@ -136,13 +127,13 @@
       ],
       "license": "MIT-0",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-calc": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
-      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
       "dev": true,
       "funding": [
         {
@@ -156,17 +147,17 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
-      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
       "dev": true,
       "funding": [
         {
@@ -180,21 +171,21 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.2",
-        "@csstools/css-calc": "^3.1.1"
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-parser-algorithms": "^4.0.0",
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-parser-algorithms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
-      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
       "dev": true,
       "funding": [
         {
@@ -208,16 +199,16 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "@csstools/css-tokenizer": "^4.0.0"
+        "@csstools/css-tokenizer": "^3.0.4"
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
-      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
       "dev": true,
       "funding": [
         {
@@ -230,19 +221,14 @@
         }
       ],
       "license": "MIT-0",
-      "peerDependencies": {
-        "css-tree": "^3.2.1"
-      },
-      "peerDependenciesMeta": {
-        "css-tree": {
-          "optional": true
-        }
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/css-tokenizer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
-      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
       "dev": true,
       "funding": [
         {
@@ -256,36 +242,39 @@
       ],
       "license": "MIT",
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=18"
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
+        "@emnapi/wasi-threads": "1.2.0",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
+      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -707,9 +696,9 @@
       }
     },
     "node_modules/@exodus/bytes": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
-      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.9.0.tgz",
+      "integrity": "sha512-lagqsvnk09NKogQaN/XrtlWeUF8SRhT12odMvbTIIaVObqzwAogL6jhR4DAp0gPuKoM1AOVrKUshJpRdpMFrww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -835,9 +824,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
+      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -853,9 +842,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -868,9 +857,9 @@
       "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
       "cpu": [
         "arm64"
       ],
@@ -884,9 +873,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
       "cpu": [
         "arm64"
       ],
@@ -900,9 +889,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
       "cpu": [
         "x64"
       ],
@@ -916,9 +905,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
       "cpu": [
         "x64"
       ],
@@ -932,9 +921,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
+      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
       "cpu": [
         "arm"
       ],
@@ -948,9 +937,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
       "cpu": [
         "arm64"
       ],
@@ -964,9 +953,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
       "cpu": [
         "arm64"
       ],
@@ -980,9 +969,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
       "cpu": [
         "ppc64"
       ],
@@ -996,9 +985,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
       "cpu": [
         "s390x"
       ],
@@ -1012,9 +1001,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
+      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
       "cpu": [
         "x64"
       ],
@@ -1028,9 +1017,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
+      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
       "cpu": [
         "x64"
       ],
@@ -1044,9 +1033,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
+      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
       "cpu": [
         "arm64"
       ],
@@ -1060,27 +1049,25 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
+      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
       "cpu": [
         "wasm32"
       ],
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@napi-rs/wasm-runtime": "^1.1.1"
       },
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
       "cpu": [
         "arm64"
       ],
@@ -1094,9 +1081,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
+      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
       "cpu": [
         "x64"
       ],
@@ -1110,9 +1097,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
+      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
       "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
@@ -1141,9 +1128,9 @@
       }
     },
     "node_modules/@sveltejs/kit": {
-      "version": "2.57.0",
-      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.57.0.tgz",
-      "integrity": "sha512-TMiqCTy9ZW4KBHvmTgeWU/hF6jcFpeMgR+9ekE06uhhGnbUZ7wpIY6l1Uk4ThRzlWYJnCVfzmtVNaHaDjaSiSg==",
+      "version": "2.55.0",
+      "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.55.0.tgz",
+      "integrity": "sha512-MdFRjevVxmAknf2NbaUkDF16jSIzXMWd4Nfah0Qp8TtQVoSp3bV4jKt8mX7z7qTUTWvgSaxtR0EG5WJf53gcuA==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
@@ -1169,7 +1156,7 @@
         "@opentelemetry/api": "^1.0.0",
         "@sveltejs/vite-plugin-svelte": "^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0",
         "svelte": "^4.0.0 || ^5.0.0-next.0",
-        "typescript": "^5.3.3 || ^6.0.0",
+        "typescript": "^5.3.3",
         "vite": "^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
@@ -1437,12 +1424,12 @@
       }
     },
     "node_modules/@tauri-apps/plugin-dialog": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.7.0.tgz",
-      "integrity": "sha512-4nS/hfGMGCXiAS3LtVjH9AgsSAPJeG/7R+q8agTFqytjnMa4Zq95Bq8WzVDkckpanX+yyRHXnRtrKXkANKDHvw==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-dialog/-/plugin-dialog-2.6.0.tgz",
+      "integrity": "sha512-q4Uq3eY87TdcYzXACiYSPhmpBA76shgmQswGkSVio4C82Sz2W4iehe9TnKYwbq7weHiL88Yw19XZm7v28+Micg==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@tauri-apps/api": "^2.10.1"
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {
@@ -1454,13 +1441,22 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
-    "node_modules/@tauri-apps/plugin-os": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-os/-/plugin-os-2.3.2.tgz",
-      "integrity": "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A==",
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -1575,19 +1571,6 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
     },
     "node_modules/@vitest/expect": {
       "version": "4.1.2",
@@ -1724,6 +1707,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -1854,17 +1847,33 @@
       }
     },
     "node_modules/css-tree": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
-      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "mdn-data": "2.27.1",
-        "source-map-js": "^1.2.1"
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
       },
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/d": {
@@ -1881,17 +1890,45 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
-      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.0"
+        "whatwg-url": "^15.1.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/decimal.js": {
@@ -2076,13 +2113,12 @@
       }
     },
     "node_modules/esrap": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.4.tgz",
-      "integrity": "sha512-suICpxAmZ9A8bzJjEl/+rLJiDKC0X4gYWUxT6URAWBLvlXmtbZd5ySMu/N2ZGEtMCAmflUDPSehrP9BQcsGcSg==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.3.tgz",
+      "integrity": "sha512-8fOS+GIGCQZl/ZIlhl59htOlms6U8NvX6ZYgYHpRU/b6tVSh3uHkOHZikl3D4cMbYM0JlpBe+p/BkZEi8J9XIQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15",
-        "@typescript-eslint/types": "^8.2.0"
+        "@jridgewell/sourcemap-codec": "^1.4.15"
       }
     },
     "node_modules/estree-walker": {
@@ -2176,6 +2212,34 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/intl-messageformat": {
       "version": "10.7.18",
       "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
@@ -2218,36 +2282,35 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.0.2",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
-      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@asamuzakjp/css-color": "^5.1.5",
-        "@asamuzakjp/dom-selector": "^7.0.6",
-        "@bramus/specificity": "^2.4.2",
-        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
-        "@exodus/bytes": "^1.15.0",
-        "css-tree": "^3.2.1",
-        "data-urls": "^7.0.0",
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
         "decimal.js": "^10.6.0",
         "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
         "is-potential-custom-element-name": "^1.0.1",
-        "lru-cache": "^11.2.7",
         "parse5": "^8.0.0",
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
-        "tough-cookie": "^6.0.1",
-        "undici": "^7.24.5",
+        "tough-cookie": "^6.0.0",
         "w3c-xmlserializer": "^5.0.0",
-        "webidl-conversions": "^8.0.1",
-        "whatwg-mimetype": "^5.0.0",
-        "whatwg-url": "^16.0.1",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
         "xml-name-validator": "^5.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
         "canvas": "^3.0.0"
@@ -2523,9 +2586,9 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.2.tgz",
-      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2570,9 +2633,9 @@
       }
     },
     "node_modules/mdn-data": {
-      "version": "2.27.1",
-      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
-      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
       "dev": true,
       "license": "CC0-1.0"
     },
@@ -2612,6 +2675,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2770,13 +2840,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.12",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
+      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.12"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -2785,21 +2855,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
       }
     },
     "node_modules/sade": {
@@ -2878,9 +2948,9 @@
       "license": "MIT"
     },
     "node_modules/svelte": {
-      "version": "5.55.2",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.2.tgz",
-      "integrity": "sha512-z41M/hi0ZPTzrwVKLvB/R1/Oo08gL1uIib8HZ+FncqxxtY9MLb01emg2fqk+WLZ/lNrrtNDFh7BZLDxAHvMgLw==",
+      "version": "5.55.0",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.0.tgz",
+      "integrity": "sha512-SThllKq6TRMBwPtat7ASnm/9CDXnIhBR0NPGw0ujn2DVYx9rVwsPZxDaDQcYGdUz/3BYVsCzdq7pZarRQoGvtw==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -2894,7 +2964,7 @@
         "clsx": "^2.1.1",
         "devalue": "^5.6.4",
         "esm-env": "^1.2.1",
-        "esrap": "^2.2.4",
+        "esrap": "^2.2.2",
         "is-reference": "^3.0.3",
         "locate-character": "^3.0.0",
         "magic-string": "^0.30.11",
@@ -3035,22 +3105,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
-      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.19"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3064,9 +3134,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
-      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -3115,26 +3185,16 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/undici": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
-      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
-      }
-    },
     "node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
+      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
+        "rolldown": "1.0.0-rc.12",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -3152,7 +3212,7 @@
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
         "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0 || ^0.28.0",
+        "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -3327,28 +3387,27 @@
       }
     },
     "node_modules/whatwg-mimetype": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
-      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
       }
     },
     "node_modules/whatwg-url": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
-      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@exodus/bytes": "^1.11.0",
         "tr46": "^6.0.0",
-        "webidl-conversions": "^8.0.1"
+        "webidl-conversions": "^8.0.0"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/why-is-node-running": {
@@ -3366,6 +3425,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbz-nix",
-  "version": "1.2.4",
+  "version": "1.2.2",
   "description": "Native high-fidelity client for Qobuz™ subscribers on Linux with Hi-Fi audio support (uses the Qobuz API; not certified by Qobuz)",
   "type": "module",
   "scripts": {
@@ -29,23 +29,24 @@
     "@icons-pack/svelte-simple-icons": "^7.2.0",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-clipboard-manager": "^2",
-    "@tauri-apps/plugin-dialog": "^2.7.0",
+    "@tauri-apps/plugin-dialog": "^2.5.0",
     "@tauri-apps/plugin-opener": "^2",
-    "@tauri-apps/plugin-os": "^2",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "lucide-svelte": "^1.0.1",
     "svelte-i18n": "^4.0.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "^3.0.6",
-    "@sveltejs/kit": "^2.57.0",
+    "@sveltejs/kit": "^2.55.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tauri-apps/cli": "^2",
     "@testing-library/svelte": "^5.3.1",
-    "jsdom": "^29.0.2",
-    "svelte": "^5.55.2",
+    "jsdom": "^27.4.0",
+    "svelte": "^5.55.0",
     "svelte-check": "^4.4.6",
     "typescript": "~5.9.3",
-    "vite": "^8.0.8",
+    "vite": "^8.0.3",
     "vitest": "^4.1.2"
   },
   "overrides": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -167,6 +167,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1386,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3417,6 +3437,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3924,6 +3950,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4122,6 +4160,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4899,7 +4951,9 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-opener",
  "tauri-plugin-os",
+ "tauri-plugin-process",
  "tauri-plugin-single-instance",
+ "tauri-plugin-updater",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -5416,15 +5470,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http 0.6.8",
@@ -5664,6 +5723,33 @@ dependencies = [
  "web-time",
  "zeroize",
 ]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -6579,6 +6665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6835,6 +6932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-plugin-single-instance"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6848,6 +6955,39 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus 5.14.0",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest 0.13.2",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -8007,6 +8147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8900,6 +9049,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "xdg-home"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9168,6 +9327,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -39,6 +39,8 @@ tauri-plugin-opener = "2"
 tauri-plugin-os = "2"
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
 tauri-plugin-deep-link = "2"
+tauri-plugin-updater = "2"
+tauri-plugin-process = "2"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -36,6 +36,8 @@
     "os:default",
     "dialog:default",
     "clipboard-manager:default",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "updater:default",
+    "process:allow-restart"
   ]
 }

--- a/src-tauri/src/commands_v2/legacy_compat.rs
+++ b/src-tauri/src/commands_v2/legacy_compat.rs
@@ -1198,6 +1198,11 @@ pub async fn v2_remote_control_get_pairing_qr(
 }
 
 #[tauri::command]
+pub fn v2_is_auto_update_eligible() -> bool {
+    crate::updates::is_auto_update_eligible()
+}
+
+#[tauri::command]
 pub fn v2_is_running_in_flatpak() -> bool {
     crate::flatpak::is_running_in_flatpak()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -751,6 +751,8 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_updater::Builder::new().build())
+        .plugin(tauri_plugin_process::init())
         .manage(AppState::with_device_and_settings(
             saved_device,
             audio_settings,
@@ -1490,6 +1492,7 @@ pub fn run() {
             commands_v2::v2_has_whats_new_been_shown,
             commands_v2::v2_mark_whats_new_shown,
             commands_v2::v2_mark_flatpak_welcome_shown,
+            commands_v2::v2_is_auto_update_eligible,
             commands_v2::v2_get_backend_logs,
             commands_v2::v2_upload_logs_to_paste,
             commands_v2::v2_get_download_settings,

--- a/src-tauri/src/updates/mod.rs
+++ b/src-tauri/src/updates/mod.rs
@@ -14,6 +14,9 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+#[cfg(target_os = "linux")]
+use std::env;
+
 const GITHUB_RELEASES_URL: &str = "https://api.github.com/repos/vicrodh/qbz/releases";
 const UPDATE_MIN_AGE_HOURS: i64 = 12;
 const NETWORK_TIMEOUT_SECONDS: u64 = 4;
@@ -649,4 +652,32 @@ pub async fn fetch_release_for_version(
         return Ok(None);
     }
     Ok(to_release_info(release))
+}
+
+/// Determine if the current install method supports in-app auto-updating.
+///
+/// Auto-update is supported for:
+/// - macOS (always — updater uses .app.tar.gz bundles)
+/// - Linux AppImage (detected via APPIMAGE env var)
+///
+/// Not supported for Flatpak, Snap, DEB, RPM, AUR, Gentoo (they have their own update channels).
+pub fn is_auto_update_eligible() -> bool {
+    #[cfg(target_os = "macos")]
+    {
+        return true;
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        if crate::flatpak::is_flatpak() || crate::snap::is_snap() {
+            return false;
+        }
+        // APPIMAGE env var is always set by the AppImage runtime
+        return env::var("APPIMAGE").is_ok();
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+    {
+        false
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -36,11 +36,18 @@
       "desktop": {
         "schemes": ["qobuzapp"]
       }
+    },
+    "updater": {
+      "endpoints": [
+        "https://github.com/vicrodh/qbz/releases/latest/download/latest.json"
+      ],
+      "pubkey": "PLACEHOLDER_PUBLIC_KEY"
     }
   },
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/src/lib/components/updates/UpdateAvailableModal.svelte
+++ b/src/lib/components/updates/UpdateAvailableModal.svelte
@@ -1,25 +1,30 @@
 <script lang="ts">
   import Modal from '../Modal.svelte';
-  import { t } from '$lib/i18n';
 
   interface Props {
     isOpen: boolean;
     currentVersion: string;
     newVersion: string;
+    autoUpdateEligible?: boolean;
     onClose: () => void;
     onVisitReleasePage: () => void;
+    onAutoUpdate?: () => void;
   }
 
-  let { isOpen, currentVersion, newVersion, onClose, onVisitReleasePage }: Props = $props();
+  let { isOpen, currentVersion, newVersion, autoUpdateEligible = false, onClose, onVisitReleasePage, onAutoUpdate }: Props = $props();
 
   function handleVisit(): void {
     onVisitReleasePage();
   }
+
+  function handleAutoUpdate(): void {
+    onAutoUpdate?.();
+  }
 </script>
 
-<Modal {isOpen} onClose={onClose} title={ $t('updates.newReleaseAvailable') } maxWidth="560px">
+<Modal {isOpen} onClose={onClose} title="New release available" maxWidth="560px">
   <div class="update-modal">
-    <p class="lead">{$t('updates.newVersionReleased')}</p>
+    <p class="lead">A new version of QBZ has been released</p>
 
     <div class="version-row" aria-label="Version change">
       <span class="version-chip">v{currentVersion}</span>
@@ -28,14 +33,19 @@
     </div>
 
     <button class="download-btn" onclick={handleVisit} type="button">
-      {$t('actions.downloadOnGitHub')}
+      View on GitHub
     </button>
   </div>
 
   {#snippet footer()}
     <div class="footer-actions">
-      <button class="btn btn-ghost" type="button" onclick={onClose}>{$t('actions.close')}</button>
-      <button class="btn btn-primary" type="button" onclick={handleVisit}>{$t('actions.visitReleasePage')}</button>
+      <button class="btn btn-ghost" type="button" onclick={onClose}>Close</button>
+      {#if autoUpdateEligible}
+        <button class="btn btn-ghost" type="button" onclick={handleVisit}>Visit release page</button>
+        <button class="btn btn-primary" type="button" onclick={handleAutoUpdate}>Download &amp; Install</button>
+      {:else}
+        <button class="btn btn-primary" type="button" onclick={handleVisit}>Visit release page</button>
+      {/if}
     </div>
   {/snippet}
 </Modal>

--- a/src/lib/components/updates/UpdateCheckResultModal.svelte
+++ b/src/lib/components/updates/UpdateCheckResultModal.svelte
@@ -1,33 +1,43 @@
 <script lang="ts">
   import Modal from '../Modal.svelte';
   import type { UpdateCheckStatus } from '$lib/stores/updatesStore';
-  import { t } from '$lib/i18n';
 
   interface Props {
     isOpen: boolean;
     status: UpdateCheckStatus;
     newVersion: string;
+    autoUpdateEligible?: boolean;
     onClose: () => void;
     onVisitReleasePage: () => void;
+    onAutoUpdate?: () => void;
   }
 
-  let { isOpen, status, newVersion, onClose, onVisitReleasePage }: Props = $props();
+  let { isOpen, status, newVersion, autoUpdateEligible = false, onClose, onVisitReleasePage, onAutoUpdate }: Props = $props();
+
+  function handleAutoUpdate(): void {
+    onAutoUpdate?.();
+  }
 </script>
 
-<Modal {isOpen} onClose={onClose} title={ $t('updates.checkForUpdates') } maxWidth="460px">
+<Modal {isOpen} onClose={onClose} title="Check for updates" maxWidth="460px">
   <div class="result-body">
     {#if status === 'update_available'}
-      <p class="message">{$t('updates.newVersionAvailable', { values: { version: newVersion } })}</p>
+      <p class="message">New version available: v{newVersion}</p>
     {:else}
-      <p class="message">{$t('updates.noUpdatesFound')}</p>
+      <p class="message">No updates found.</p>
     {/if}
   </div>
 
   {#snippet footer()}
     <div class="footer-actions">
-      <button class="btn btn-ghost" type="button" onclick={onClose}>{$t('actions.close')}</button>
+      <button class="btn btn-ghost" type="button" onclick={onClose}>Close</button>
       {#if status === 'update_available'}
-        <button class="btn btn-primary" type="button" onclick={onVisitReleasePage}>{$t('actions.visitReleasePage')}</button>
+        {#if autoUpdateEligible}
+          <button class="btn btn-ghost" type="button" onclick={onVisitReleasePage}>Visit release page</button>
+          <button class="btn btn-primary" type="button" onclick={handleAutoUpdate}>Download &amp; Install</button>
+        {:else}
+          <button class="btn btn-primary" type="button" onclick={onVisitReleasePage}>Visit release page</button>
+        {/if}
       {/if}
     </div>
   {/snippet}

--- a/src/lib/components/updates/UpdateProgressModal.svelte
+++ b/src/lib/components/updates/UpdateProgressModal.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import Modal from '../Modal.svelte';
+  import type { AutoUpdateProgress } from '$lib/services/updatesService';
+
+  interface Props {
+    isOpen: boolean;
+    progress: AutoUpdateProgress;
+    onCancel: () => void;
+    onFallbackManual: () => void;
+  }
+
+  let { isOpen, progress, onCancel, onFallbackManual }: Props = $props();
+
+  function formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+
+  const progressPercent = $derived(
+    progress.state === 'downloading' && progress.totalBytes != null
+      ? Math.min(100, Math.round((progress.downloadedBytes / progress.totalBytes) * 100))
+      : undefined,
+  );
+
+  const statusText = $derived.by(() => {
+    switch (progress.state) {
+      case 'checking':
+        return 'Checking for updates...';
+      case 'downloading':
+        return progressPercent !== undefined ? `Downloading update... ${progressPercent}%` : 'Downloading update...';
+      case 'installing':
+        return 'Installing update...';
+      case 'restarting':
+        return 'Restarting...';
+      case 'error':
+        return 'Update failed';
+    }
+  });
+
+  const canCancel = $derived(progress.state === 'downloading' || progress.state === 'checking');
+</script>
+
+<Modal {isOpen} onClose={canCancel ? onCancel : () => {}} title="Updating QBZ" maxWidth="460px">
+  <div class="progress-body">
+    <p class="status-text">{statusText}</p>
+
+    {#if progress.state === 'downloading'}
+      <div class="progress-bar-track">
+        <div
+          class="progress-bar-fill"
+          style:width={progressPercent !== undefined ? `${progressPercent}%` : '100%'}
+          class:indeterminate={progressPercent === undefined}
+        ></div>
+      </div>
+      {#if progress.totalBytes != null}
+        <p class="byte-count">
+          {formatBytes(progress.downloadedBytes)} / {formatBytes(progress.totalBytes)}
+        </p>
+      {/if}
+    {/if}
+
+    {#if progress.state === 'checking' || progress.state === 'installing' || progress.state === 'restarting'}
+      <div class="progress-bar-track">
+        <div class="progress-bar-fill indeterminate"></div>
+      </div>
+    {/if}
+
+    {#if progress.state === 'error'}
+      <p class="error-message">{progress.error}</p>
+    {/if}
+  </div>
+
+  {#snippet footer()}
+    <div class="footer-actions">
+      {#if progress.state === 'error'}
+        <button class="btn btn-ghost" type="button" onclick={onCancel}>Close</button>
+        <button class="btn btn-primary" type="button" onclick={onFallbackManual}>Download manually</button>
+      {:else if canCancel}
+        <button class="btn btn-ghost" type="button" onclick={onCancel}>Cancel</button>
+      {/if}
+    </div>
+  {/snippet}
+</Modal>
+
+<style>
+  .progress-body {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 12px;
+    padding: 12px 0;
+  }
+
+  .status-text {
+    margin: 0;
+    color: var(--text-primary);
+    font-weight: 500;
+    font-size: 15px;
+  }
+
+  .progress-bar-track {
+    width: 100%;
+    height: 6px;
+    background: var(--bg-tertiary);
+    border-radius: 3px;
+    overflow: hidden;
+  }
+
+  .progress-bar-fill {
+    height: 100%;
+    background: var(--accent-primary);
+    border-radius: 3px;
+    transition: width 0.2s ease;
+  }
+
+  .progress-bar-fill.indeterminate {
+    width: 30%;
+    animation: indeterminate 1.5s ease-in-out infinite;
+  }
+
+  @keyframes indeterminate {
+    0% {
+      transform: translateX(-100%);
+    }
+    100% {
+      transform: translateX(400%);
+    }
+  }
+
+  .byte-count {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 13px;
+  }
+
+  .error-message {
+    margin: 0;
+    color: var(--text-error, #ef4444);
+    font-size: 13px;
+    word-break: break-word;
+  }
+
+  .footer-actions {
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+</style>

--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -13,7 +13,6 @@
   import RemoteControlSetupGuide from '../RemoteControlSetupGuide.svelte';
   import LogsModal from '../LogsModal.svelte';
   import DiagnosticsPanel from '../DiagnosticsPanel.svelte';
-  import { platform } from '$lib/utils/platform';
   import VolumeSlider from '../VolumeSlider.svelte';
   import UpdateCheckResultModal from '../updates/UpdateCheckResultModal.svelte';
   import WhatsNewModal from '../updates/WhatsNewModal.svelte';
@@ -133,6 +132,7 @@
     fetchReleaseForVersion,
     getCurrentVersion as getUpdatesCurrentVersion,
     getPreferences as getUpdatePreferences,
+    isAutoUpdateEligible,
     initUpdatesStore,
     setCheckOnLaunch,
     setShowWhatsNewOnLaunch,
@@ -140,7 +140,9 @@
     type UpdateCheckStatus,
     type UpdatePreferences
   } from '$lib/stores/updatesStore';
-  import { openReleasePageAndAcknowledge } from '$lib/services/updatesService';
+  import { openReleasePageAndAcknowledge, performAutoUpdate } from '$lib/services/updatesService';
+  import type { AutoUpdateProgress } from '$lib/services/updatesService';
+  import UpdateProgressModal from '../updates/UpdateProgressModal.svelte';
   import {
     getCount as getBlacklistCount,
     isEnabled as isBlacklistEnabled,
@@ -327,6 +329,8 @@
   let isSettingsWhatsNewOpen = $state(false);
   let settingsWhatsNewRelease = $state<ReleaseInfo | null>(null);
   let isFetchingChangelog = $state(false);
+  let isSettingsAutoUpdating = $state(false);
+  let settingsAutoUpdateProgress = $state<AutoUpdateProgress>({ state: 'checking' });
 
   // Blacklist state
   let blacklistCount = $state(getBlacklistCount());
@@ -464,6 +468,29 @@
     if (!updateResultRelease) return;
     void openReleasePageAndAcknowledge(updateResultRelease);
     isUpdateResultOpen = false;
+  }
+
+  function handleSettingsAutoUpdate(): void {
+    isUpdateResultOpen = false;
+    isSettingsAutoUpdating = true;
+    settingsAutoUpdateProgress = { state: 'checking' };
+    void performAutoUpdate(
+      (progress) => {
+        if (isSettingsAutoUpdating) settingsAutoUpdateProgress = progress;
+      },
+      () => !isSettingsAutoUpdating,
+    );
+  }
+
+  function handleSettingsAutoUpdateCancel(): void {
+    isSettingsAutoUpdating = false;
+  }
+
+  function handleSettingsAutoUpdateFallback(): void {
+    isSettingsAutoUpdating = false;
+    if (updateResultRelease) {
+      void openReleasePageAndAcknowledge(updateResultRelease);
+    }
   }
 
   async function handleShowCurrentChangelog(): Promise<void> {
@@ -1471,11 +1498,9 @@
       updatesCurrentVersion = getUpdatesCurrentVersion();
     });
 
-    // Detect sandbox environments (Linux-only)
-    if (platform === 'linux') {
-      loadFlatpakStatus();
-      loadSnapStatus();
-    }
+    // Detect sandbox environments
+    loadFlatpakStatus();
+    loadSnapStatus();
 
     // Check for legacy cached files
     checkLegacyCachedFiles();
@@ -3885,7 +3910,6 @@
       />
     </div>
     {/if}
-    {#if platform === 'linux'}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.audio.audioBackend')}</span>
@@ -3919,7 +3943,6 @@
         {/if}
       </div>
     </div>
-    {/if}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.audio.outputDevice')}</span>
@@ -3988,7 +4011,6 @@
         </div>
       {/if}
     </div>
-    {#if platform === 'linux'}
     {#if showAlsaPluginSelector}
     <div class="setting-row">
       <div class="setting-info">
@@ -4014,7 +4036,6 @@
       <Toggle enabled={alsaHardwareVolume} onchange={handleAlsaHardwareVolumeChange} />
     </div>
     {/if}
-    {/if}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.audio.exclusiveMode')} <span class="help-tip" title={$t('settings.audio.exclusiveModeHelp')}>(?)</span></span>
@@ -4032,7 +4053,6 @@
     {#if dacPassthrough}
     <small class="setting-note">{$t('settings.audio.dacPassthroughNote')}</small>
     {/if}
-    {#if platform === 'linux'}
     {#if isFlatpak && selectedBackend === 'PipeWire' && dacPassthrough}
     <div class="flatpak-warning">
       <div class="warning-icon">⚠️</div>
@@ -4053,7 +4073,6 @@
     </div>
     {#if pwForceBitperfect}
     <small class="setting-note">{$t('settings.audio.pwForceBitperfectNote')}</small>
-    {/if}
     {/if}
     {/if}
     <div class="setting-row">
@@ -4378,7 +4397,7 @@
       <Toggle enabled={systemNotificationsEnabled} onchange={(v) => { systemNotificationsEnabled = v; setSystemNotificationsEnabled(v); }} />
     </div>
     <!-- Title bar toggles: hidden on macOS (always uses native overlay title bar) -->
-    {#if platform !== 'macos'}
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.useSystemTitleBar')}</span>
@@ -4395,7 +4414,7 @@
     </div>
     {/if}
     <!-- Title bar customization: hidden on macOS (uses native overlay title bar) -->
-    {#if platform !== 'macos'}
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.searchInTitleBar')}</span>
@@ -4582,15 +4601,15 @@
     </div>
 
     <!-- System Tray / Menu Bar subsection -->
-    <h4 class="subsection-title">{$t(platform === 'macos' ? 'settings.appearance.tray.titleMacos' : 'settings.appearance.tray.title')}</h4>
+    <h4 class="subsection-title">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.titleMacos' : 'settings.appearance.tray.title')}</h4>
     <div class="setting-row">
       <div class="setting-info">
-        <span class="setting-label">{$t(platform === 'macos' ? 'settings.appearance.tray.enableTrayMacos' : 'settings.appearance.tray.enableTray')}</span>
-        <span class="setting-desc">{$t(platform === 'macos' ? 'settings.appearance.tray.enableTrayDescMacos' : 'settings.appearance.tray.enableTrayDesc')}</span>
+        <span class="setting-label">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.enableTrayMacos' : 'settings.appearance.tray.enableTray')}</span>
+        <span class="setting-desc">{$t(document.documentElement.classList.contains('macos') ? 'settings.appearance.tray.enableTrayDescMacos' : 'settings.appearance.tray.enableTrayDesc')}</span>
       </div>
       <Toggle enabled={enableTray} onchange={(v) => handleEnableTrayChange(v)} />
     </div>
-    {#if platform !== 'macos'}
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.tray.minimizeToTray')}</span>
@@ -4618,8 +4637,7 @@
       />
     </div>
 
-    <!-- Composition subsection (collapsible, Linux-only: GDK/GSK/X11/Wayland/DMA-BUF) -->
-    {#if platform === 'linux'}
+    <!-- Composition subsection (collapsible) -->
     <div class="collapsible-section composition-subsection">
       <button class="section-title-btn" onclick={() => compositionCollapsed = !compositionCollapsed}>
         <div class="section-title-row">
@@ -4770,7 +4788,6 @@
         </div>
       {/if}
     </div>
-    {/if}
 
     <div class="setting-row">
       <div class="setting-info">
@@ -4990,8 +5007,8 @@
   <section class="section">
     <h3 class="section-title">{$t('settings.integrations.title')}</h3>
 
-    <!-- Qobuz Link Handler (Linux only — macOS registers via Info.plist, Windows via registry) -->
-    {#if platform === 'linux'}
+    <!-- Qobuz Link Handler (Linux only — macOS registers via Info.plist at build time) -->
+    {#if !document.documentElement.classList.contains('macos')}
     <div class="setting-row">
       <div class="setting-info">
         <span class="setting-label">{$t('settings.integrations.qobuzLinkHandler')}</span>
@@ -5444,10 +5461,19 @@
       isOpen={isUpdateResultOpen}
       status={updateResultStatus}
       newVersion={updateResultRelease?.version ?? ''}
+      autoUpdateEligible={isAutoUpdateEligible()}
       onClose={handleCloseUpdateResult}
       onVisitReleasePage={handleVisitReleaseFromResult}
+      onAutoUpdate={handleSettingsAutoUpdate}
     />
   {/if}
+
+  <UpdateProgressModal
+    isOpen={isSettingsAutoUpdating}
+    progress={settingsAutoUpdateProgress}
+    onCancel={handleSettingsAutoUpdateCancel}
+    onFallbackManual={handleSettingsAutoUpdateFallback}
+  />
 
   {#if settingsWhatsNewRelease}
     <WhatsNewModal

--- a/src/lib/services/updatesService.ts
+++ b/src/lib/services/updatesService.ts
@@ -1,5 +1,7 @@
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
+import { check } from '@tauri-apps/plugin-updater';
+import { relaunch } from '@tauri-apps/plugin-process';
 import {
   acknowledgeRelease,
   checkForUpdates,
@@ -314,5 +316,81 @@ export async function disableUpdateChecks(): Promise<void> {
     await setCheckOnLaunch(false);
   } catch (error) {
     console.debug('[Updates] Failed to disable update checks:', error);
+  }
+}
+
+// ==================== Auto-update ====================
+
+export type AutoUpdateProgress =
+  | { state: 'checking' }
+  | { state: 'downloading'; downloadedBytes: number; totalBytes?: number }
+  | { state: 'installing' }
+  | { state: 'restarting' }
+  | { state: 'error'; error: string };
+
+let autoUpdateInProgress = false;
+
+export function isAutoUpdateInProgress(): boolean {
+  return autoUpdateInProgress;
+}
+
+/**
+ * Perform an in-app auto-update: download, install, and relaunch.
+ *
+ * Pass a `cancelled` function that returns true to abort before relaunch.
+ * Returns true if the update was initiated (app will restart), false otherwise.
+ */
+export async function performAutoUpdate(
+  onProgress: (progress: AutoUpdateProgress) => void,
+  isCancelled?: () => boolean,
+): Promise<boolean> {
+  if (autoUpdateInProgress) {
+    console.debug('[Updates] Auto-update already in progress');
+    return false;
+  }
+  autoUpdateInProgress = true;
+  try {
+    onProgress({ state: 'checking' });
+    const update = await check();
+    if (!update) {
+      return false;
+    }
+
+    if (isCancelled?.()) return false;
+
+    let totalBytes: number | undefined;
+    let downloadedBytes = 0;
+
+    onProgress({ state: 'downloading', downloadedBytes: 0 });
+
+    await update.downloadAndInstall((event) => {
+      switch (event.event) {
+        case 'Started':
+          totalBytes = event.data.contentLength ?? undefined;
+          onProgress({ state: 'downloading', downloadedBytes: 0, totalBytes });
+          break;
+        case 'Progress':
+          downloadedBytes += event.data.chunkLength;
+          onProgress({ state: 'downloading', downloadedBytes, totalBytes });
+          break;
+        case 'Finished':
+          onProgress({ state: 'installing' });
+          break;
+      }
+    });
+
+    // Guard against relaunch if user cancelled while download was in flight
+    if (isCancelled?.()) return false;
+
+    onProgress({ state: 'restarting' });
+    await relaunch();
+    return true;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[Updates] Auto-update failed:', message);
+    onProgress({ state: 'error', error: message });
+    return false;
+  } finally {
+    autoUpdateInProgress = false;
   }
 }

--- a/src/lib/stores/updatesStore.ts
+++ b/src/lib/stores/updatesStore.ts
@@ -1,5 +1,4 @@
 import { invoke } from '@tauri-apps/api/core';
-import { skipIfRemote } from '$lib/services/commandRouter';
 
 export interface UpdatePreferences {
   checkOnLaunch: boolean;
@@ -31,8 +30,10 @@ let preferences: UpdatePreferences = {
 };
 
 let currentVersion = '';
+let autoUpdateEligible = false;
 let versionLoaded = false;
 let prefsLoaded = false;
+let eligibilityLoaded = false;
 
 const listeners = new Set<() => void>();
 
@@ -63,8 +64,11 @@ export function getCurrentVersion(): string {
   return currentVersion;
 }
 
+export function isAutoUpdateEligible(): boolean {
+  return autoUpdateEligible;
+}
+
 export async function initUpdatesStore(): Promise<void> {
-  if (skipIfRemote()) return;
   // get_current_version never needs a session (compile-time value).
   // Only fetch once.
   if (!versionLoaded) {
@@ -73,6 +77,16 @@ export async function initUpdatesStore(): Promise<void> {
       versionLoaded = true;
     } catch (error) {
       console.error('[Updates] Failed to get current version:', error);
+    }
+  }
+
+  // Auto-update eligibility is a compile-time + runtime check (no session needed).
+  if (!eligibilityLoaded) {
+    try {
+      autoUpdateEligible = await invoke<boolean>('v2_is_auto_update_eligible');
+      eligibilityLoaded = true;
+    } catch (error) {
+      console.debug('[Updates] Failed to check auto-update eligibility:', error);
     }
   }
 
@@ -92,7 +106,6 @@ export async function initUpdatesStore(): Promise<void> {
 }
 
 export async function refreshUpdatePreferences(): Promise<void> {
-  if (skipIfRemote()) return;
   try {
     preferences = await invoke<UpdatePreferences>('v2_get_update_preferences');
     notify();
@@ -102,7 +115,6 @@ export async function refreshUpdatePreferences(): Promise<void> {
 }
 
 export async function setCheckOnLaunch(enabled: boolean): Promise<void> {
-  if (skipIfRemote()) return;
   try {
     await invoke('v2_set_update_check_on_launch', { enabled });
     preferences.checkOnLaunch = enabled;
@@ -114,7 +126,6 @@ export async function setCheckOnLaunch(enabled: boolean): Promise<void> {
 }
 
 export async function setShowWhatsNewOnLaunch(enabled: boolean): Promise<void> {
-  if (skipIfRemote()) return;
   try {
     await invoke('v2_set_show_whats_new_on_launch', { enabled });
     preferences.showWhatsNewOnLaunch = enabled;
@@ -126,7 +137,6 @@ export async function setShowWhatsNewOnLaunch(enabled: boolean): Promise<void> {
 }
 
 export async function checkForUpdates(mode: 'launch' | 'manual'): Promise<UpdateCheckResult> {
-  if (skipIfRemote()) return { status: 'no_updates', currentVersion: '', release: null };
   const result = await invoke<UpdateCheckResult>('v2_check_for_updates', { mode });
   return {
     ...result,
@@ -135,7 +145,6 @@ export async function checkForUpdates(mode: 'launch' | 'manual'): Promise<Update
 }
 
 export async function fetchReleaseForVersion(version: string): Promise<ReleaseInfo | null> {
-  if (skipIfRemote()) return null;
   try {
     const release = await invoke<ReleaseInfo | null>('v2_fetch_release_for_version', { version });
     return release ?? null;
@@ -146,17 +155,14 @@ export async function fetchReleaseForVersion(version: string): Promise<ReleaseIn
 }
 
 export async function acknowledgeRelease(version: string): Promise<void> {
-  if (skipIfRemote()) return;
   await invoke('v2_acknowledge_release', { version });
 }
 
 export async function ignoreRelease(version: string): Promise<void> {
-  if (skipIfRemote()) return;
   await invoke('v2_ignore_release', { version });
 }
 
 export async function hasWhatsNewBeenShown(version: string): Promise<boolean> {
-  if (skipIfRemote()) return false;
   try {
     return await invoke<boolean>('v2_has_whats_new_been_shown', { version });
   } catch (error) {
@@ -166,7 +172,6 @@ export async function hasWhatsNewBeenShown(version: string): Promise<boolean> {
 }
 
 export async function markWhatsNewShown(version: string): Promise<void> {
-  if (skipIfRemote()) return;
   try {
     await invoke('v2_mark_whats_new_shown', { version });
   } catch (error) {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -154,7 +154,6 @@
   import { loadAlbumFavorites } from '$lib/stores/albumFavoritesStore';
   import { loadArtistFavorites } from '$lib/stores/artistFavoritesStore';
   import { getDefaultFavoritesTab } from '$lib/utils/favorites';
-  import { platform } from '$lib/utils/platform';
   import type { FavoritesPreferences, ResolvedMusician } from '$lib/types';
 
   // Navigation state management
@@ -221,7 +220,6 @@
     clearQueue,
     playQueueIndex,
     nextTrack,
-    nextTrackGuarded,
     previousTrack,
     moveQueueTrack,
     setLocalTrackIds,
@@ -442,7 +440,7 @@
   import KeybindingsSettings from '$lib/components/KeybindingsSettings.svelte';
   import LinkResolverModal from '$lib/components/LinkResolverModal.svelte';
   import type { ReleaseInfo } from '$lib/stores/updatesStore';
-  import { refreshUpdatePreferences, resetUpdatesStore } from '$lib/stores/updatesStore';
+  import { refreshUpdatePreferences, resetUpdatesStore, isAutoUpdateEligible } from '$lib/stores/updatesStore';
   import { getShowPurchases, setShowPurchases, rehydratePurchasesStore } from '$lib/stores/purchasesStore';
   import {
     decideLaunchModals,
@@ -451,8 +449,11 @@
     markFlatpakWelcomeShown,
     markSnapWelcomeShown,
     openReleasePageAndAcknowledge,
+    performAutoUpdate,
     resetLaunchFlow,
   } from '$lib/services/updatesService';
+  import type { AutoUpdateProgress } from '$lib/services/updatesService';
+  import UpdateProgressModal from '$lib/components/updates/UpdateProgressModal.svelte';
 
   // Offline state
   import {
@@ -481,6 +482,7 @@
   // Title Bar State (from titleBarStore subscription)
   let showTitleBar = $state(shouldShowTitleBar());
   let showWindowControls = $state(getShowWindowControls());
+  const isMacOS = typeof document !== 'undefined' && document.documentElement.classList.contains('macos');
 
   // Search Bar Location State
   let searchBarLocationPref = $state(getSearchBarLocation());
@@ -518,6 +520,10 @@
   // Sequential modal queue: Flatpak → What's new → Update available
   let pendingWhatsNewRelease = $state<ReleaseInfo | null>(null);
   let pendingUpdateRelease = $state<ReleaseInfo | null>(null);
+
+  // Auto-update state
+  let isAutoUpdating = $state(false);
+  let autoUpdateProgress = $state<AutoUpdateProgress>({ state: 'checking' });
 
   // Global back-to-top button
   let mainContentEl: HTMLElement | null = $state(null);
@@ -805,6 +811,34 @@
 
   function handleReminderDisableUpdates(): void {
     void disableUpdateChecks();
+  }
+
+  function handleAutoUpdate(): void {
+    isUpdateModalOpen = false;
+    isAutoUpdating = true;
+    autoUpdateProgress = { state: 'checking' };
+    void performAutoUpdate(
+      (progress) => {
+        if (isAutoUpdating) autoUpdateProgress = progress;
+      },
+      () => !isAutoUpdating,
+    );
+  }
+
+  function handleAutoUpdateCancel(): void {
+    isAutoUpdating = false;
+    // Re-open the update modal so user can choose another action
+    if (updateRelease) {
+      isUpdateModalOpen = true;
+    }
+  }
+
+  function handleAutoUpdateFallbackManual(): void {
+    isAutoUpdating = false;
+    if (updateRelease) {
+      void openReleasePageAndAcknowledge(updateRelease);
+      updateRelease = null;
+    }
   }
 
   function handleFlatpakWelcomeClose(): void {
@@ -4370,7 +4404,7 @@
         return;
       }
       const previousTrackId = currentTrack?.id ?? null;
-      const nextTrackResult = await nextTrackGuarded();
+      const nextTrackResult = await nextTrack();
       if (nextTrackResult) {
         // Defensive fallback for issue #80:
         // if backend returns same track on auto-advance while repeat-one is off,
@@ -4384,7 +4418,7 @@
             '[Player] Auto-advance returned same track id, forcing one extra nextTrack()',
             previousTrackId
           );
-          const forcedNext = await nextTrackGuarded();
+          const forcedNext = await nextTrack();
           if (forcedNext && forcedNext.id !== previousTrackId) {
             await playQueueTrack(forcedNext);
             return;
@@ -4472,13 +4506,8 @@
       try {
         const queueState = getQueueState();
         if (queueState.queue.length > 0) {
-          const currentId = currentTrack?.id ?? null;
-
-          if (queueState.repeatMode == 'one') {
-            return currentId;
-          }
-          
           const firstId = Number(queueState.queue[0].id);
+          const currentId = currentTrack?.id ?? null;
           if (!Number.isNaN(firstId) && firstId > 0 && firstId !== currentId) {
             return firstId;
           }
@@ -4502,7 +4531,7 @@
       if (qconnectSuppressLocalPlaybackAutomation) return;
       console.log('[Gapless] Handling transition to track', trackId);
       // Advance the queue to match backend state
-      const advanced = await nextTrackGuarded();
+      const advanced = await nextTrack();
       if (advanced && advanced.id === trackId) {
         // Queue advanced successfully — update UI metadata
         await playQueueTrack(advanced, undefined, true);
@@ -4889,7 +4918,7 @@
 {:else}
   <div class="app" class:no-titlebar={!showTitleBar} class:floating={isWindowFloating}>
     <!-- macOS: drag region for window movement (overlay title bar has no native drag area) -->
-    {#if !showTitleBar && platform === 'macos'}
+    {#if !showTitleBar && isMacOS}
       <div class="macos-drag-region" data-tauri-drag-region></div>
     {/if}
     <!-- Custom Title Bar (CSD) -->
@@ -5767,7 +5796,6 @@
         {volume}
         onVolumeChange={handleVolumeChange}
         onToggleMute={handleToggleMute}
-        volumeLocked={isAlsaDirectHw && !qconnectPeerRendererActive}
         {isShuffle}
         onToggleShuffle={toggleShuffle}
         {repeatMode}
@@ -5884,8 +5912,10 @@
         isOpen={isUpdateModalOpen}
         currentVersion={updatesCurrentVersion}
         newVersion={updateRelease.version}
+        autoUpdateEligible={isAutoUpdateEligible()}
         onClose={handleUpdateClose}
         onVisitReleasePage={handleUpdateVisit}
+        onAutoUpdate={handleAutoUpdate}
       />
 
       <UpdateReminderModal
@@ -5894,6 +5924,13 @@
         onRemindLater={handleReminderLater}
         onIgnoreRelease={handleReminderIgnoreRelease}
         onDisableAllUpdates={handleReminderDisableUpdates}
+      />
+
+      <UpdateProgressModal
+        isOpen={isAutoUpdating}
+        progress={autoUpdateProgress}
+        onCancel={handleAutoUpdateCancel}
+        onFallbackManual={handleAutoUpdateFallbackManual}
       />
     {/if}
 
@@ -6009,7 +6046,7 @@
     display: flex;
     flex: 1;
     min-width: 0;
-    height: calc(100vh - var(--player-bar-height, 104px) - 44px);
+    height: calc(100vh - 148px); /* 104px NowPlayingBar + 44px TitleBar */
     overflow: hidden;
     position: relative;
   }
@@ -6017,7 +6054,7 @@
   .main-content {
     flex: 1;
     min-width: 0;
-    height: calc(100vh - var(--player-bar-height, 104px) - 44px);
+    height: calc(100vh - 148px); /* 104px NowPlayingBar + 44px TitleBar */
     overflow: hidden; /* Views handle their own scrolling */
     padding-right: 8px; /* Gap between scrollbar and window edge */
     background-color: var(--bg-primary, #0f0f0f);
@@ -6026,7 +6063,7 @@
   /* Adjust heights when title bar is hidden */
   .app.no-titlebar .content-area,
   .app.no-titlebar .main-content {
-    height: calc(100vh - var(--player-bar-height, 104px));
+    height: calc(100vh - 104px); /* Only 104px NowPlayingBar, no title bar */
   }
 
   /* macOS: pad main content to clear native overlay title bar */


### PR DESCRIPTION
## Summary

- Add `tauri-plugin-updater` for in-app download-and-install updates on macOS and Linux AppImage installs
- Detect install method at runtime via `is_auto_update_eligible()` — auto-update for macOS and AppImage only, fallback to "Visit release page" for Flatpak, Snap, DEB, RPM, AUR, Gentoo
- New `UpdateProgressModal` with download progress bar, status transitions, cancellation guard, and "Download manually" error fallback
- Update release workflows to sign artifacts (`TAURI_SIGNING_PRIVATE_KEY`) and produce `.app.tar.gz` on macOS
- New `release-updater-manifest.yml` workflow consolidates `.sig` files from all platforms into a single `latest.json`

## Setup required before first release

1. Generate signing keys: `bunx tauri signer generate -w ~/.tauri/qbz.key`
2. Replace `PLACEHOLDER_PUBLIC_KEY` in `src-tauri/tauri.conf.json` with the generated public key
3. Add GitHub Actions secrets: `TAURI_SIGNING_PRIVATE_KEY` and `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`

## Test plan

- [ ] Generate signing keys and replace placeholder pubkey
- [ ] Build locally with `TAURI_SIGNING_PRIVATE_KEY` set, verify `.app.tar.gz.sig` (macOS) and `.AppImage.sig` (Linux) are produced
- [ ] Test eligibility: macOS → true, AppImage → true, Flatpak/Snap → false
- [ ] Test non-eligible installs see unchanged UI (no "Download & Install" button)
- [ ] Test cancel during download does not trigger relaunch
- [ ] Test error fallback shows "Download manually" button