### PR TITLE
feat(auth): support token login

### DIFF
--- a/src-tauri/src/commands_v2/runtime.rs
+++ b/src-tauri/src/commands_v2/runtime.rs
@@ -578,6 +578,151 @@ pub async fn v2_start_oauth_login(
     finalize_oauth_login(&code, &app, &runtime, &app_state, &core_bridge, &legal_state).await
 }
 
+/// Login using an existing Qobuz `user_auth_token`.
+#[tauri::command]
+pub async fn v2_login_with_token(
+    app: tauri::AppHandle,
+    token: String,
+    runtime: State<'_, RuntimeManagerState>,
+    app_state: State<'_, AppState>,
+    core_bridge: State<'_, CoreBridgeState>,
+    legal_state: State<'_, LegalSettingsState>,
+) -> Result<V2LoginResponse, String> {
+    let trimmed = token.trim();
+    if trimmed.is_empty() {
+        return Ok(V2LoginResponse {
+            success: false,
+            user_name: None,
+            user_id: None,
+            subscription: None,
+            subscription_valid_until: None,
+            error: Some("Please enter a Qobuz user_auth_token.".to_string()),
+            error_code: Some("token_missing".to_string()),
+        });
+    }
+
+    let session = {
+        let client = app_state.client.read().await;
+        match client.login_with_token(trimmed).await {
+            Ok(session) => session,
+            Err(e) => {
+                return Ok(V2LoginResponse {
+                    success: false,
+                    user_name: None,
+                    user_id: None,
+                    subscription: None,
+                    subscription_valid_until: None,
+                    error: Some(e.to_string()),
+                    error_code: Some("token_login_failed".to_string()),
+                });
+            }
+        }
+    };
+
+    let manager = runtime.manager();
+    manager.set_legacy_auth(true, Some(session.user_id)).await;
+    let _ = app.emit(
+        "runtime:event",
+        RuntimeEvent::AuthChanged {
+            logged_in: true,
+            user_id: Some(session.user_id),
+        },
+    );
+
+    // Convert api::models::UserSession -> qbz_models::UserSession for CoreBridge.
+    let core_session: UserSession =
+        match serde_json::to_value(&session).and_then(serde_json::from_value) {
+            Ok(s) => s,
+            Err(e) => {
+                log::error!("[Token] Failed to convert session for CoreBridge: {}", e);
+                rollback_auth_state(&manager, &app).await;
+                return Ok(V2LoginResponse {
+                    success: false,
+                    user_name: None,
+                    user_id: None,
+                    subscription: None,
+                    subscription_valid_until: None,
+                    error: Some(format!("Session conversion error: {}", e)),
+                    error_code: Some("internal_error".to_string()),
+                });
+            }
+        };
+
+    // Inject session into CoreBridge.
+    if let Some(bridge) = core_bridge.try_get().await {
+        match bridge.login_with_session(core_session).await {
+            Ok(_) => manager.set_corebridge_auth(true).await,
+            Err(e) => {
+                log::error!("[Token] CoreBridge session injection failed: {}", e);
+                rollback_auth_state(&manager, &app).await;
+                let _ = app.emit(
+                    "runtime:event",
+                    RuntimeEvent::CoreBridgeAuthFailed {
+                        error: e.to_string(),
+                    },
+                );
+                return Ok(V2LoginResponse {
+                    success: false,
+                    user_name: Some(session.display_name),
+                    user_id: Some(session.user_id),
+                    subscription: Some(session.subscription_label),
+                    subscription_valid_until: session.subscription_valid_until,
+                    error: Some(format!("V2 authentication failed: {}", e)),
+                    error_code: Some("v2_auth_failed".to_string()),
+                });
+            }
+        }
+    } else {
+        rollback_auth_state(&manager, &app).await;
+        return Ok(V2LoginResponse {
+            success: false,
+            user_name: Some(session.display_name),
+            user_id: Some(session.user_id),
+            subscription: Some(session.subscription_label),
+            subscription_valid_until: session.subscription_valid_until,
+            error: Some("V2 CoreBridge not initialized".to_string()),
+            error_code: Some("v2_not_initialized".to_string()),
+        });
+    }
+
+    if let Err(e) = crate::session_lifecycle::activate_session(&app, session.user_id).await {
+        log::error!("[Token] Session activation failed: {}", e);
+        rollback_auth_state(&manager, &app).await;
+        return Ok(V2LoginResponse {
+            success: false,
+            user_name: Some(session.display_name.clone()),
+            user_id: Some(session.user_id),
+            subscription: Some(session.subscription_label.clone()),
+            subscription_valid_until: session.subscription_valid_until.clone(),
+            error: Some(format!("Session activation failed: {}", e)),
+            error_code: Some("session_activation_failed".to_string()),
+        });
+    }
+
+    // Persist token for runtime_bootstrap session restore.
+    if let Err(e) = crate::credentials::save_oauth_token(&session.user_auth_token) {
+        log::warn!("[Token] Failed to persist token: {}", e);
+    }
+
+    accept_tos_best_effort(&legal_state);
+    let _ = app.emit(
+        "runtime:event",
+        RuntimeEvent::RuntimeReady {
+            user_id: session.user_id,
+        },
+    );
+
+    Ok(V2LoginResponse {
+        success: true,
+        user_name: Some(session.display_name),
+        user_id: Some(session.user_id),
+        subscription: Some(session.subscription_label),
+        subscription_valid_until: session.subscription_valid_until,
+        error: None,
+        error_code: None,
+    })
+}
+
 /// Complete the OAuth login flow after obtaining an authorization code.
 ///
 /// Cancel the system browser OAuth flow.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1229,6 +1229,7 @@ pub fn run() {
             qbzd_discovery::v2_qbzd_start_discovery,
             qbzd_discovery::v2_qbzd_stop_discovery,
             qbzd_discovery::v2_qbzd_get_devices,
+            commands_v2::v2_login_with_token,
             commands_v2::v2_get_user_info,
             commands_v2::v2_save_credentials,
             commands_v2::v2_clear_saved_credentials,

--- a/src/lib/components/views/LoginView.svelte
+++ b/src/lib/components/views/LoginView.svelte
@@ -23,12 +23,15 @@
   let isSystemBrowserLoading = $state(false);
   let showCaptchaHint = $state(false);
   let captchaHintTimerId: ReturnType<typeof setTimeout> | null = null;
+  let isTokenLoading = $state(false);
   let isInitializing = $state(true);
   let initStatus = $state('Connecting to Qobuz™...');
   let error = $state<string | null>(null);
   let initError = $state<string | null>(null);
   let isTimedOut = $state(false);
   let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let qobuzToken = $state('');
+  let showTokenLogin = $state(false);
 
   const LOGIN_TIMEOUT_MS = 60000; // 60 seconds
 
@@ -221,6 +224,10 @@
     } else if (response.error_code === 'oauth_cancelled') {
       error = null;
       showCaptchaHint = true;
+    } else if (response.error_code === 'token_missing') {
+      error = $t('auth.tokenMissing');
+    } else if (response.error_code === 'token_login_failed') {
+      error = response.error || $t('auth.tokenLoginError');
     } else {
       error = response.error || 'Login failed';
     }
@@ -312,74 +319,106 @@
       isSystemBrowserLoading = false;
     }
   }
+
+  async function handleTokenLogin() {
+    if (!get(qobuzTosAccepted)) {
+      error = $t('legal.tosRequiredToLogin');
+      return;
+    }
+
+    isTokenLoading = true;
+    error = null;
+
+    try {
+      await setTosAcceptance(true);
+    } catch { /* continue */ }
+
+    try {
+      const response = await invoke<OAuthResponse>('v2_login_with_token', {
+        token: qobuzToken
+      });
+      if (handleOAuthResponse(response)) {
+        qobuzToken = '';
+      }
+    } catch (err) {
+      console.error('Token login error:', err);
+      error = formatErrorMessage(err);
+    } finally {
+      isTokenLoading = false;
+    }
+  }
+
+  function toggleTokenLogin() {
+    showTokenLogin = !showTokenLogin;
+  }
 </script>
 
 <div class="login-wrapper">
   <TitleBar />
   <div class="login-view">
     <div class="login-card">
-    <!-- Logo -->
-    <div class="logo">
-      <img src="/logo.png" alt="QBZ Logo" class="logo-img" />
-    </div>
+      <!-- Logo -->
+      <div class="logo">
+        <img src="/logo.png" alt="QBZ Logo" class="logo-img" />
+      </div>
 
-    {#if isTimedOut}
-      <div class="timeout-box">
-        <p class="timeout-title">Connection is taking too long</p>
-        <p class="timeout-detail">
-          Unable to connect to Qobuz™ after 60 seconds. This could be a network issue or Qobuz™ may be temporarily unavailable.
-        </p>
-        <div class="timeout-actions">
-          <button class="retry-btn" onclick={handleRetryLogin}>{ $t('actions.tryAgain') }</button>
-          <button class="offline-btn" onclick={handleStartOffline}>{ $t('actions.startOffline') }</button>
-        </div>
-      </div>
-    {:else if isInitializing}
-      <div class="initializing">
-        <div class="spinner"></div>
-        <p>{initStatus}</p>
-      </div>
-    {:else if initError}
-      <div class="error-box">
-        <p>{$t('auth.connectionFailed')}</p>
-        <p class="error-detail">{initError}</p>
-        <div class="timeout-actions">
-          <button class="retry-btn" onclick={initializeClient}>{$t('actions.retry')}</button>
-          <button class="offline-btn" onclick={handleStartOffline}>{$t('offline.startWithoutLogin')}</button>
-        </div>
-      </div>
-    {:else}
-      <div class="login-body">
-        <div class="login-actions">
-          <div class="remember-me tos-remember">
-            <label>
-              <input type="checkbox" bind:checked={$qobuzTosAccepted} disabled={isOAuthLoading || isSystemBrowserLoading} />
-              <span>
-                {$t('legal.tosAgreementPrefix')}
-                <a href="https://www.qobuz.com/us-en/legal/terms" target="_blank" rel="noopener">
-                  {$t('legal.tosLinkText')}
-                </a>
-              </span>
-            </label>
+      {#if isTimedOut}
+        <div class="timeout-box">
+          <p class="timeout-title">Connection is taking too long</p>
+          <p class="timeout-detail">
+            Unable to connect to Qobuz™ after 60 seconds. This could be a network issue or Qobuz™ may be temporarily unavailable.
+          </p>
+          <div class="timeout-actions">
+            <button class="retry-btn" onclick={handleRetryLogin}>{ $t('actions.tryAgain') }</button>
+            <button class="offline-btn" onclick={handleStartOffline}>{ $t('actions.startOffline') }</button>
           </div>
+        </div>
+      {:else if isInitializing}
+        <div class="initializing">
+          <div class="spinner"></div>
+          <p>{initStatus}</p>
+        </div>
+      {:else if initError}
+        <div class="error-box">
+          <p>{$t('auth.connectionFailed')}</p>
+          <p class="error-detail">{initError}</p>
+          <div class="timeout-actions">
+            <button class="retry-btn" onclick={initializeClient}>{$t('actions.retry')}</button>
+            <button class="offline-btn" onclick={handleStartOffline}>{$t('offline.startWithoutLogin')}</button>
+          </div>
+        </div>
+      {:else}
+        <div class="login-body">
+          <div class="login-actions">
+            <div class="remember-me tos-remember">
+              <label>
+                <input type="checkbox" bind:checked={$qobuzTosAccepted} disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading} />
+                <span>
+                  {$t('legal.tosAgreementPrefix')}
+                  <a href="https://www.qobuz.com/us-en/legal/terms" target="_blank" rel="noopener">
+                    {$t('legal.tosLinkText')}
+                  </a>
+                </span>
+              </label>
+            </div>
 
-          {#if error}
-            <div class="error-message">{error}</div>
-          {/if}
-
-          <button
-            type="button"
-            class="oauth-btn"
-            disabled={isOAuthLoading || isSystemBrowserLoading || !$qobuzTosAccepted}
-            onclick={handleOAuthLogin}
-          >
-            {#if isOAuthLoading}
-              <div class="spinner small"></div>
-              <span>{$t('auth.oauthLoading')}</span>
-            {:else}
-              <span>{$t('auth.oauthButton')}</span>
+            {#if error}
+              <div class="error-message">{error}</div>
             {/if}
-          </button>
+
+            <button
+              type="button"
+              class="oauth-btn"
+              disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading || !$qobuzTosAccepted}
+              onclick={handleOAuthLogin}
+            >
+              {#if isOAuthLoading}
+                <div class="spinner small"></div>
+                <span>{$t('auth.oauthLoading')}</span>
+              {:else}
+                <span>{$t('auth.oauthButton')}</span>
+              {/if}
+            </button>
 
           {#if isOAuthLoading}
             <p class="cancel-link">
@@ -400,47 +439,87 @@
             </div>
           {/if}
 
-          <p class="system-browser-link">
-            {#if isSystemBrowserLoading}
-              <small>
-                <span class="link-button">{$t('auth.systemBrowserLoading')}</span>
-                &nbsp;
-                <button type="button" class="link-button" onclick={handleCancelSystemBrowserLogin}>
-                  {$t('actions.cancel')}
-                </button>
-              </small>
-            {:else}
+            <p class="system-browser-link">
+              {#if isSystemBrowserLoading}
+                <small>
+                  <span class="link-button">{$t('auth.systemBrowserLoading')}</span>
+                  &nbsp;
+                  <button type="button" class="link-button" onclick={handleCancelSystemBrowserLogin}>
+                    {$t('actions.cancel')}
+                  </button>
+                </small>
+              {:else}
+                <small>
+                  <button
+                    type="button"
+                    class="link-button"
+                    disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading || !$qobuzTosAccepted}
+                    onclick={handleSystemBrowserLogin}
+                  >
+                    {$t('auth.systemBrowserButton')}
+                  </button>
+                </small>
+              {/if}
+            </p>
+
+            <p class="token-link">
               <small>
                 <button
                   type="button"
                   class="link-button"
-                  disabled={isOAuthLoading || isSystemBrowserLoading || !$qobuzTosAccepted}
-                  onclick={handleSystemBrowserLogin}
+                  disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading}
+                  onclick={toggleTokenLogin}
                 >
-                  {$t('auth.systemBrowserButton')}
+                  {$t('auth.tokenButton')}
                 </button>
               </small>
+            </p>
+
+            {#if showTokenLogin}
+              <div class="token-login">
+                <label class="token-label" for="qobuz-token">{$t('auth.tokenLabel')}</label>
+                <textarea
+                  id="qobuz-token"
+                  class="token-input"
+                  bind:value={qobuzToken}
+                  rows="3"
+                  placeholder={$t('auth.tokenPlaceholder')}
+                  disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading}
+                ></textarea>
+                <button
+                  type="button"
+                  class="token-btn"
+                  disabled={isOAuthLoading || isSystemBrowserLoading || isTokenLoading || !$qobuzTosAccepted || qobuzToken.trim().length === 0}
+                  onclick={handleTokenLogin}
+                >
+                  {#if isTokenLoading}
+                    <div class="spinner small"></div>
+                    <span>{$t('auth.tokenLoading')}</span>
+                  {:else}
+                    <span>{$t('auth.tokenButton')}</span>
+                  {/if}
+                </button>
+                <p class="token-help">{$t('auth.tokenHelp')}</p>
+              </div>
             {/if}
-          </p>
 
-          <p class="offline-link">
-            <small>
-              <button type="button" class="link-button" onclick={handleStartOffline}>
-                {$t('offline.startWithoutLogin')}
-              </button>
-            </small>
-          </p>
+            <p class="offline-link">
+              <small>
+                <button type="button" class="link-button" onclick={handleStartOffline}>
+                  {$t('offline.startWithoutLogin')}
+                </button>
+              </small>
+            </p>
+          </div>
+
+          <div class="login-footer">
+            <p class="footer-copy">
+              {$t('auth.activeSubscriptionRequired')}<br />
+              {$t('auth.APIUse')} {$t('legal.trademarkNotice')}
+            </p>
+          </div>
         </div>
-
-        <div class="login-footer">
-          <p class="footer-copy">
-            {$t('auth.activeSubscriptionRequired')}<br />
-            {$t('auth.APIUse')} {$t('legal.trademarkNotice')}
-          </p>
-        </div>
-      </div>
-
-    {/if}
+      {/if}
     </div>
   </div>
 </div>
@@ -461,19 +540,19 @@
     background-color: var(--bg-primary);
   }
 
-	  .login-card {
-	    width: 100%;
-	    max-width: 720px;
-	    padding: 52px;
-	    background-color: var(--bg-secondary);
-	    border-radius: 16px;
-	    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-	    display: flex;
-	    flex-direction: column;
-	    min-height: min(480px, 70vh);
-	    max-height: 90vh;
-	    overflow-y: auto;
-	  }
+  .login-card {
+    width: 100%;
+    max-width: 720px;
+    padding: 52px;
+    background-color: var(--bg-secondary);
+    border-radius: 16px;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+    display: flex;
+    flex-direction: column;
+    min-height: min(480px, 70vh);
+    max-height: 90vh;
+    overflow-y: auto;
+  }
 
   .logo {
     text-align: center;
@@ -711,6 +790,80 @@
   .offline-link {
     margin-top: 4px;
     text-align: center;
+  }
+
+  .token-link {
+    margin-top: -8px;
+    text-align: center;
+  }
+
+  .token-login {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    margin-top: 12px;
+    padding: 14px;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.08));
+    border-radius: 10px;
+    background: rgba(255, 255, 255, 0.02);
+  }
+
+  .token-label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-primary);
+  }
+
+  .token-input {
+    width: 100%;
+    resize: vertical;
+    min-height: 88px;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color, rgba(255, 255, 255, 0.12));
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-family: 'Source Sans 3', monospace;
+    font-size: 13px;
+  }
+
+  .token-input:disabled {
+    opacity: 0.7;
+    cursor: not-allowed;
+  }
+
+  .token-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    min-height: 44px;
+    padding: 10px 18px;
+    border: 1px solid var(--accent-primary);
+    border-radius: 8px;
+    background: transparent;
+    color: var(--accent-primary);
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 150ms ease, color 150ms ease, opacity 150ms ease;
+  }
+
+  .token-btn:hover:not(:disabled) {
+    background: var(--accent-primary);
+    color: #fff;
+  }
+
+  .token-btn:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+
+  .token-help {
+    margin: 0;
+    font-size: 12px;
+    line-height: 1.45;
+    color: var(--text-muted);
   }
 
   .link-button {

--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -1453,6 +1453,13 @@
     "systemBrowserLoading": "Warte auf Anmeldung...",
     "captchaHint": "Probleme mit dem Captcha? Der eingebaute Browser unterstützt es möglicherweise nicht gut.",
     "trySystemBrowser": "Abbrechen und Systembrowser verwenden",
+    "tokenLabel": "Qobuz-Token",
+    "tokenPlaceholder": "Fügen Sie hier Ihren Qobuz user_auth_token ein",
+    "tokenButton": "Mit Token anmelden",
+    "tokenLoading": "Anmeldung mit Token...",
+    "tokenHelp": "Verwenden Sie einen gültigen Qobuz user_auth_token. QBZ prüft ihn bei Qobuz und speichert ihn für zukünftige Starts.",
+    "tokenMissing": "Bitte fügen Sie einen Qobuz user_auth_token ein.",
+    "tokenLoginError": "Token-Anmeldung fehlgeschlagen. Bitte prüfen Sie den Token und versuchen Sie es erneut.",
     "activeSubscriptionRequired": "QBZ erfordert ein aktives Qobuz™-Abonnement. Ihre Anmeldedaten werden direkt an Qobuz™ gesendet.",
     "APIUse": "Diese Anwendung verwendet die Qobuz-API, ist jedoch nicht von Qobuz zertifiziert."
   },

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -1476,6 +1476,13 @@
     "systemBrowserLoading": "Waiting for login...",
     "captchaHint": "Having trouble with captcha? The built-in browser may not support it well.",
     "trySystemBrowser": "Cancel and try your system browser instead",
+    "tokenLabel": "Qobuz token",
+    "tokenPlaceholder": "Paste your Qobuz user_auth_token here",
+    "tokenButton": "Sign in with token",
+    "tokenLoading": "Signing in with token...",
+    "tokenHelp": "Use a valid Qobuz user_auth_token. QBZ will verify it with Qobuz and save it for future launches.",
+    "tokenMissing": "Please paste a Qobuz user_auth_token.",
+    "tokenLoginError": "Token login failed. Please verify the token and try again.",
     "activeSubscriptionRequired": "QBZ requires an active Qobuz™ subscription. Your credentials are sent directly to Qobuz™.",
     "APIUse": "This application uses the Qobuz API but is not certified by Qobuz."
   },

--- a/src/lib/i18n/locales/es.json
+++ b/src/lib/i18n/locales/es.json
@@ -1476,6 +1476,13 @@
     "systemBrowserLoading": "Esperando inicio de sesión...",
     "captchaHint": "¿Problemas con el captcha? El navegador integrado puede no soportarlo bien.",
     "trySystemBrowser": "Cancelar y usar tu navegador del sistema",
+    "tokenLabel": "Token de Qobuz",
+    "tokenPlaceholder": "Pega aquí tu Qobuz user_auth_token",
+    "tokenButton": "Iniciar sesión con token",
+    "tokenLoading": "Iniciando sesión con token...",
+    "tokenHelp": "Usa un Qobuz user_auth_token válido. QBZ lo verificará con Qobuz y lo guardará para futuros inicios.",
+    "tokenMissing": "Pega un Qobuz user_auth_token.",
+    "tokenLoginError": "El inicio de sesión con token falló. Verifica el token e inténtalo de nuevo.",
     "activeSubscriptionRequired": "QBZ requiere una suscripción activa a Qobuz™. Tus datos de acceso se envían directamente a Qobuz™.",
     "APIUse": "Esta aplicación utiliza la API de Qobuz, pero no está certificada por Qobuz."
   },

--- a/src/lib/i18n/locales/fr.json
+++ b/src/lib/i18n/locales/fr.json
@@ -1453,6 +1453,13 @@
     "systemBrowserLoading": "En attente de connexion...",
     "captchaHint": "Des difficultés avec le captcha ? Le navigateur intégré peut ne pas bien le gérer.",
     "trySystemBrowser": "Annuler et utiliser votre navigateur système",
+    "tokenLabel": "Jeton Qobuz",
+    "tokenPlaceholder": "Collez votre Qobuz user_auth_token ici",
+    "tokenButton": "Se connecter avec un jeton",
+    "tokenLoading": "Connexion avec le jeton...",
+    "tokenHelp": "Utilisez un Qobuz user_auth_token valide. QBZ le vérifiera auprès de Qobuz et l'enregistrera pour les prochains lancements.",
+    "tokenMissing": "Veuillez coller un Qobuz user_auth_token.",
+    "tokenLoginError": "La connexion par jeton a échoué. Vérifiez le jeton et réessayez.",
     "activeSubscriptionRequired": "QBZ requiert un abonnement à Qobuz™ actif. Vos identifiants sont directement envoyés à Qobuz™.",
     "APIUse": "Cette application utilise l'API Qobuz™ mais n'est pas certifiée par Qobuz™."
   },

--- a/src/lib/i18n/locales/pt.json
+++ b/src/lib/i18n/locales/pt.json
@@ -1476,6 +1476,13 @@
     "systemBrowserLoading": "Aguardando login...",
     "captchaHint": "Problemas com o captcha? O navegador integrado pode não suportá-lo bem.",
     "trySystemBrowser": "Cancelar e usar o navegador do sistema",
+    "tokenLabel": "Token do Qobuz",
+    "tokenPlaceholder": "Cole seu Qobuz user_auth_token aqui",
+    "tokenButton": "Entrar com token",
+    "tokenLoading": "Entrando com token...",
+    "tokenHelp": "Use um Qobuz user_auth_token valido. O QBZ vai verificá-lo com o Qobuz e salvá-lo para as próximas execuções.",
+    "tokenMissing": "Cole um Qobuz user_auth_token.",
+    "tokenLoginError": "Falha ao entrar com token. Verifique o token e tente novamente.",
     "activeSubscriptionRequired": "O QBZ requer uma assinatura ativa do Qobuz™. Suas credenciais são enviadas diretamente ao Qobuz™.",
     "APIUse": "Este aplicativo utiliza a API do Qobuz, mas não é certificado pelo Qobuz."
   },


### PR DESCRIPTION
## Summary
- add token-based authentication support in backend auth commands
- implement token login UX in  with updated auth state handling
- register command wiring updates in the Tauri entrypoint
- add localized copy for the token login flow across all languages 

## Why
This enables users to authenticate directly with a token-based flow, improving compatibility with environments where username/password sign-in is not preferred.

## Testing
- [ran release-flatpak on gh actions]( https://github.com/x4714/qbz/actions/runs/24293164981
)
- tested token login 
## Screenshot of login ui
<img width="649" height="605" alt="image" src="https://github.com/user-attachments/assets/79b0ba71-cd69-479a-ae31-7c8ba7dc9d1d" />
