### PR TITLE
fix(build): drop x86-64-v3 so pre-Haswell Intel Macs can run qbz

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,14 +6,19 @@
 # clears 400+ MB/s. For HiRes (200 MB+ tracks) this is the difference
 # between a 20-second gap and a sub-second one.
 #
-# Two things needed on x86_64:
-# 1. `target-cpu=x86-64-v3` = Haswell microarchitecture baseline
-#    (2013+). Every CPU QBZ realistically runs on supports it. This
-#    gives AVX2, BMI2, etc. for general codegen.
-# 2. `target-feature=+aes,+ssse3` to explicitly enable the AES-NI
-#    instruction set — which is NOT included in x86-64-v3 as a
-#    microarch level. Without this flag the `aes` crate's hardware
-#    dispatch never gets compiled in, no matter how capable the CPU.
+# We enable `+aes,+ssse3` as target-features so the `aes` crate's
+# hardware dispatch compiles in the AES-NI code path. The `aes` crate
+# uses `cpufeatures` at runtime to pick the hardware path only when
+# the CPU actually supports it, so enabling the feature at build time
+# is safe on older CPUs — they fall through to the software path.
+#
+# We deliberately do NOT set `target-cpu=x86-64-v3`. That microarch
+# level (Haswell, 2013+) makes LLVM emit AVX2/BMI2/FMA across all
+# codegen, which traps with SIGILL on pre-Haswell hardware (e.g.
+# 2012 Ivy Bridge Macs: GitHub discussion #343). QBZ has no hand-written SIMD
+# or autovectorizable hot loops that benefit materially from v3, so
+# the compatibility cost outweighs the win. AES-NI — the one
+# measurable perf improvement — is preserved by `+aes` on its own.
 #
 # IMPORTANT: these flags MUST be scoped to x86_64 targets. Using
 # `[build] rustflags = ...` applies them to every target, which on
@@ -23,4 +28,4 @@
 # get their own AES/crypto extensions automatically via `aes` crate's
 # armv8 path — we don't need to force anything there.
 [target.'cfg(target_arch = "x86_64")']
-rustflags = ["-C", "target-cpu=x86-64-v3", "-C", "target-feature=+aes,+ssse3"]
+rustflags = ["-C", "target-feature=+aes,+ssse3"]


### PR DESCRIPTION
## Summary

- Drop `target-cpu=x86-64-v3` from `.cargo/config.toml`, keeping only `target-feature=+aes,+ssse3`.
- The v3 baseline (Haswell, 2013+) makes LLVM emit AVX2/BMI2/FMA across the entire binary, which traps with `SIGILL` on any pre-Haswell Intel Mac.
- AES-NI — the only measurable perf win from the original change — is preserved by `+aes` via the `aes` crate's `cpufeatures` runtime dispatch.

## Crash evidence

Reported in [discussion #343](https://github.com/vicrodh/qbz/discussions/343#discussioncomment-16683365). The crash report (QBZ 1.2.8, macOS 10.15.8, `MacBookPro9,1` — a 2012 Ivy Bridge i7) shows:

```
Exception Type:  EXC_BAD_INSTRUCTION (SIGILL)
Thread 0 Crashed:: main
0  com.blitzfc.qbz  env_filter::filter::Builder::parse
1  com.blitzfc.qbz  env_logger::logger::Builder::parse_filters
2  com.blitzfc.qbz  qbz_nix_lib::run
3  com.blitzfc.qbz  qbz::main
```

Illegal instruction at the first real line of `main()`. Ivy Bridge has AVX but no AVX2/BMI/FMA — the very first v3-only instruction traps. `rax: 0xaaaaaaaaaaaaaaab` (the BMI/multiply constant for ÷3) is consistent with a BMI instruction executing.

## Why the perf trade-off is fine

QBZ has no hand-written SIMD and no obviously autovectorizable hot loops:

- AES decrypt (qbz-cmaf) — driven by `+aes`, not by v3. Preserved.
- Audio decode (symphonia) — mostly scalar integer. Negligible v3 benefit.
- FFT visualiser (spectrum-analyzer) — tiny fraction of wall time.
- PDF render (mupdf) — C library, unaffected by rustc flags.
- HTTP / JSON / UI glue — not CPU-bound.

If a future hot loop ever warrants AVX2, the right pattern is per-function `#[target_feature]` with runtime dispatch — not a global microarch bump that breaks older hardware.

## Test plan

- [ ] CI green on `macos-latest` for both `x86_64-apple-darwin` and `aarch64-apple-darwin` (the ARM path was the reason #2a9f90e3 scoped the flags to `cfg(target_arch = "x86_64")` originally — scoping is preserved here).
- [ ] User on the affected 2012 MacBook Pro confirms the nightly x86_64 DMG no longer SIGILLs on launch.
- [ ] AES-NI dispatch still engaged on Haswell+ (verifiable by `aes` crate runtime path — unchanged, since `+aes` target-feature is retained).

Closes #353