### PR TITLE
fix(qobuz): dedup user playlists by (name, owner.id)

### DIFF
--- a/crates/qbz-qobuz/src/client.rs
+++ b/crates/qbz-qobuz/src/client.rs
@@ -1999,27 +1999,39 @@ impl QobuzClient {
             .and_then(|p| p.get("items"))
             .ok_or_else(|| ApiError::ApiResponse("No playlists in response".to_string()))?;
 
-        let mut playlists: Vec<Playlist> = serde_json::from_value(playlists.clone())?;
+        let playlists: Vec<Playlist> = serde_json::from_value(playlists.clone())?;
         let original_len = playlists.len();
         // Qobuz's /playlist/getUserPlaylists returns the same logical playlist with two
         // distinct numerical IDs (different ID ranges). The official web UI dedupes these.
         // Dedup at the API boundary by (name, owner.id) so callers see one entry per
         // logical playlist, while still allowing legitimately-same-named playlists from
         // different owners (e.g., followed) to coexist.
-        let mut seen: std::collections::HashSet<(String, u64)> =
-            std::collections::HashSet::new();
-        playlists.retain(|p| {
+        //
+        // Pick a deterministic canonical row for each duplicate group so the exposed
+        // playlist.id is stable across API response reordering. Use the smallest
+        // numerical playlist ID as the canonical representative.
+        let mut deduped: Vec<Playlist> = Vec::with_capacity(original_len);
+        let mut seen: std::collections::HashMap<(String, u64), usize> =
+            std::collections::HashMap::new();
+        for p in playlists {
             let key = (p.name.trim().to_lowercase(), p.owner.id);
-            seen.insert(key)
-        });
-        if playlists.len() != original_len {
+            if let Some(&idx) = seen.get(&key) {
+                if p.id < deduped[idx].id {
+                    deduped[idx] = p;
+                }
+            } else {
+                seen.insert(key, deduped.len());
+                deduped.push(p);
+            }
+        }
+        if deduped.len() != original_len {
             log::info!(
-                "get_user_playlists: deduped {} -> {} playlists by (name, owner.id)",
+                "get_user_playlists: deduped {} -> {} playlists by (name, owner.id) using smallest playlist id as canonical",
                 original_len,
-                playlists.len()
+                deduped.len()
             );
         }
-        Ok(playlists)
+        Ok(deduped)
     }
 
     /// Search playlists

--- a/crates/qbz-qobuz/src/client.rs
+++ b/crates/qbz-qobuz/src/client.rs
@@ -1999,7 +1999,27 @@ impl QobuzClient {
             .and_then(|p| p.get("items"))
             .ok_or_else(|| ApiError::ApiResponse("No playlists in response".to_string()))?;
 
-        Ok(serde_json::from_value(playlists.clone())?)
+        let mut playlists: Vec<Playlist> = serde_json::from_value(playlists.clone())?;
+        let original_len = playlists.len();
+        // Qobuz's /playlist/getUserPlaylists returns the same logical playlist with two
+        // distinct numerical IDs (different ID ranges). The official web UI dedupes these.
+        // Dedup at the API boundary by (name, owner.id) so callers see one entry per
+        // logical playlist, while still allowing legitimately-same-named playlists from
+        // different owners (e.g., followed) to coexist.
+        let mut seen: std::collections::HashSet<(String, u64)> =
+            std::collections::HashSet::new();
+        playlists.retain(|p| {
+            let key = (p.name.trim().to_lowercase(), p.owner.id);
+            seen.insert(key)
+        });
+        if playlists.len() != original_len {
+            log::info!(
+                "get_user_playlists: deduped {} -> {} playlists by (name, owner.id)",
+                original_len,
+                playlists.len()
+            );
+        }
+        Ok(playlists)
     }
 
     /// Search playlists


### PR DESCRIPTION

## Summary

- Fixes the "every playlist appears twice" bug in the Sidebar, Playlist Manager, and Following sub-tab (see issue #382).
- Qobuz's `/playlist/getUserPlaylists` returns the same logical playlist with two distinct numerical IDs (different ID ranges, identical `name` and `owner.id`); a dedup-by-`id` cannot collapse them.
- Replaces the direct `serde_json::from_value` with a `(name.trim().to_lowercase(), owner.id)` dedup in `QobuzClient::get_user_playlists` so every downstream caller sees one entry per logical playlist. Includes legitimately-same-named-but-different-owner playlists (e.g., followed) by including `owner.id` in the key.

Verified locally on an affected account: 295 raw → 152 logical playlists, matching what play.qobuz.com displays.

Closes #382.

## Diff

`crates/qbz-qobuz/src/client.rs` (around line 1999 on v1.2.10):

```diff
diff --git a/crates/qbz-qobuz/src/client.rs b/crates/qbz-qobuz/src/client.rs
@@ -1999,7 +1999,27 @@ impl QobuzClient {
             .and_then(|p| p.get("items"))
             .ok_or_else(|| ApiError::ApiResponse("No playlists in response".to_string()))?;

-        Ok(serde_json::from_value(playlists.clone())?)
+        let mut playlists: Vec<Playlist> = serde_json::from_value(playlists.clone())?;
+        let original_len = playlists.len();
+        // Qobuz's /playlist/getUserPlaylists returns the same logical playlist with two
+        // distinct numerical IDs (different ID ranges). The official web UI dedupes these.
+        // Dedup at the API boundary by (name, owner.id) so callers see one entry per
+        // logical playlist, while still allowing legitimately-same-named playlists from
+        // different owners (e.g., followed) to coexist.
+        let mut seen: std::collections::HashSet<(String, u64)> =
+            std::collections::HashSet::new();
+        playlists.retain(|p| {
+            let key = (p.name.trim().to_lowercase(), p.owner.id);
+            seen.insert(key)
+        });
+        if playlists.len() != original_len {
+            log::info!(
+                "get_user_playlists: deduped {} -> {} playlists by (name, owner.id)",
+                original_len,
+                playlists.len()
+            );
+        }
+        Ok(playlists)
     }
```

## Test plan

- [ ] On an account that exhibits the bug, sign in to qbz, open the Sidebar — each playlist should appear once.
- [ ] Open the Playlist Manager — each playlist should appear once.
- [ ] Open Favorites > Following — each followed playlist should appear once.
- [ ] Hit the refresh / pull-to-reload action; counts should match the initial load (no flicker / no doubling).
- [ ] Confirm the `get_user_playlists: deduped N -> M playlists by (name, owner.id)` info-level log fires once per fetch on affected accounts (and not at all on accounts where N == M).
- [ ] On an account with two playlists that legitimately share a name from different owners (e.g., a followed playlist with the same name as a user-owned one), confirm both still appear.
- [ ] `cargo test -p qbz-qobuz` passes.

No new dependencies; stdlib `HashSet` only.
