### PR TITLE
fix(audio): populate macOS output device picker

### DIFF
--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -2822,11 +2822,14 @@
 
   async function handleRefreshDevices() {
     if (isLoadingDevices) return;
-    const backendType = selectedBackend === 'ALSA Direct' ? 'Alsa' :
-                        selectedBackend === 'PipeWire' ? 'PipeWire' :
-                        selectedBackend === 'PulseAudio' ? 'Pulse' : null;
-    if (backendType) {
-      await loadBackendDevices(backendType);
+    // Look up the backend_type for the currently-selected backend.
+    // Works for every backend that v2_get_available_backends returned
+    // (PipeWire/ALSA Direct/PulseAudio on Linux, System Audio on
+    // macOS/Windows). 'Auto' has no entry, so refresh stays a no-op
+    // there — matches the existing Linux behavior.
+    const backend = availableBackends.find(b => b.name === selectedBackend);
+    if (backend) {
+      await loadBackendDevices(backend.backend_type);
     }
   }
 
@@ -2899,6 +2902,16 @@
             }
           }
         }
+      } else if (platform !== 'linux' && availableBackends.length === 1) {
+        // Non-Linux platforms expose a single backend (CoreAudio on
+        // macOS, WASAPI on Windows). Pick it automatically so the
+        // device picker is populated — there is no meaningful "Auto"
+        // choice when only one backend exists, and leaving it on
+        // "Auto" leaves the picker stuck at "System Default" only.
+        const onlyBackend = availableBackends[0];
+        selectedBackend = onlyBackend.name;
+        await loadBackendDevices(onlyBackend.backend_type);
+        outputDevice = 'System Default';
       } else {
         selectedBackend = 'Auto';
         // Auto mode: always use System Default (no device selection)


### PR DESCRIPTION
## Summary

On macOS the output device picker in **Settings → Audio** showed only "System Default" — users could not pick AirPods, built-in speakers, USB DACs, or any other CoreAudio device. This was a frontend wiring gap; the Rust side already enumerates all CoreAudio devices and `CpalDefaultBackend::create_output_stream` already honors a named `device_id`.

## Cause

The picker dropdown is fed by `backendDevices`, which is populated by `loadBackendDevices(backendType)`. On Linux, `availableBackends` exposes PipeWire / ALSA / Pulse and `loadAudioSettings` auto-loads devices for the saved (or detected) backend. On macOS the only backend is `SystemDefault` ("System Audio"), but:

- `loadAudioSettings` fell through to the `'Auto'` branch when no backend was saved (first launch on macOS), leaving `backendDevices = []` and the dropdown stuck on `['System Default']`.
- `handleRefreshDevices` only matched `'PipeWire' | 'ALSA Direct' | 'PulseAudio'`, so the refresh button was a no-op on macOS.

## Fix

Two surgical edits in `src/lib/components/views/SettingsView.svelte`:

1. **`loadAudioSettings`** — when no backend is saved AND only one is available (macOS / Windows: just `SystemDefault`), auto-select it and call `loadBackendDevices` with its `backend_type`. Linux is unaffected because at least ALSA is always present (typically PipeWire + ALSA + Pulse), so `availableBackends.length > 1` and we keep the existing `'Auto'` semantics.
2. **`handleRefreshDevices`** — replace the hardcoded backend-name switch with a generic lookup against `availableBackends`. Now refresh works for `'System Audio'` (and any future backend) without further changes.

## Test plan

- [x] **macOS, first launch**: open Settings → Audio. Output Device dropdown lists CoreAudio devices (AirPods, built-in speakers, USB devices, etc.) in addition to "System Default".
- [x] **macOS**: pick a non-default device → audio routes there immediately, no restart needed.
- [x] **macOS**: click the refresh button after connecting a Bluetooth device → list updates.


## Out of scope

- macOS hog mode / bit-perfect output — intentionally deferred -> Will start this work on Tuesday as my Zen DAC 3 arrives then 😁
- The `audio:device-missing` toast — discovered during implementation that `emit_missing_if_needed` in `src-tauri/src/audio_device_watch.rs` is dead code on every platform (no call site emits the event). That is a cross-platform follow-up, not a macOS regression.