### PR TITLE
fix(audio): eliminate macOS track-change crackle

### DIFF
--- a/crates/qbz-player/src/player/mod.rs
+++ b/crates/qbz-player/src/player/mod.rs
@@ -2098,9 +2098,16 @@ impl Player {
                                 .playback_start_millis
                                 .store(0, Ordering::SeqCst);
                             thread_state.position_at_start.store(0, Ordering::SeqCst);
-                            // Drop the stream to release the device and stop background CPU use.
-                            drop(stream_opt.take());
-                            *pause_suspend_deadline = None;
+                            // Defer dropping the stream so a Play immediately following Stop
+                            // (the frontend's track-change pattern is Stop → Play, not append)
+                            // can reuse the open device. Tearing CoreAudio down between every
+                            // track was producing the audible click on track change. The idle
+                            // loop's pause-suspend handler (below) drops the stream when this
+                            // deadline fires; Play / Resume / Seek / ReinitDevice all clear
+                            // the deadline so they reuse or replace the stream as needed.
+                            *pause_suspend_deadline = Some(
+                                Instant::now() + Duration::from_millis(PAUSE_SUSPEND_DELAY_MS),
+                            );
                             // Reset PipeWire clock if bit-perfect was active
                             #[cfg(target_os = "linux")]
                             if thread_settings

--- a/crates/qbz-player/src/player/mod.rs
+++ b/crates/qbz-player/src/player/mod.rs
@@ -1403,12 +1403,15 @@ impl Player {
                                 return;
                             };
 
-                            // Stop previous engine and wait for sink to release resources
+                            // Stop previous engine and wait for sink to release resources.
+                            // The 50ms sleep is an ALSA-only workaround for snd_pcm_open()
+                            // racing the previous PCM handle's release. On CoreAudio (macOS)
+                            // and WASAPI (Windows) the host stream stays open across track
+                            // changes, so the sleep just feeds 50ms of silence into the
+                            // mixer — audible as a click at each end of the gap.
                             if let Some(engine) = current_engine.take() {
                                 engine.stop();
-                                // Small delay to allow the audio sink to fully release its
-                                // reference to the mixer before creating a new player.
-                                // This prevents "resource busy" errors on rapid track switches.
+                                #[cfg(target_os = "linux")]
                                 std::thread::sleep(Duration::from_millis(50));
                             }
 
@@ -1760,9 +1763,12 @@ impl Player {
                                 return;
                             };
 
-                            // Stop previous engine
+                            // Stop previous engine. ALSA-only sleep — see Play handler
+                            // above for rationale (CoreAudio/WASAPI don't race here and the
+                            // 50ms gap is audible as a click).
                             if let Some(engine) = current_engine.take() {
                                 engine.stop();
+                                #[cfg(target_os = "linux")]
                                 std::thread::sleep(Duration::from_millis(50));
                             }
 


### PR DESCRIPTION
## Summary

Eliminates the audible click heard between tracks on macOS. The artifact was particularly noticeable on Bluetooth headphones — the wireless codec/transport layer makes device tear-down/reopen cycles audibly clicky — but also present on USB DACs.

Two independent fixes that compose; the second is the dominant one.

## The fixes

### gate 50ms post-stop sleep behind `cfg(target_os = "linux")`

Two stream-recreation sites in `crates/qbz-player/src/player/mod.rs` had `engine.stop()` followed by `std::thread::sleep(Duration::from_millis(50))`. The sleep is an ALSA-only workaround for `snd_pcm_open()` racing the previous PCM handle's release (EBUSY). On CoreAudio (macOS) and WASAPI (Windows) the host stream stays open across track changes, so the sleep just feeds 50ms of silence into the open mixer — audible as a click on each end of the gap. Linux behavior is byte-identical.

### defer host-stream drop on Stop (the dominant fix)

The `Stop` handler was calling `drop(stream_opt.take())` immediately, which on CoreAudio dispatches `AudioOutputUnitStop` + dispose and a ~150ms reopen on the next `Play`. The frontend issues `Stop` → `Play` for **every** track change, so every transition was tearing the audio device down and reopening it.

Reuses the existing `pause_suspend_deadline` machinery: `Stop` now schedules a 2s deferred drop. `Play` / `Resume` / `Seek` / `ReinitDevice` already clear that deadline, so a track-change `Play` arriving within 2s reuses the open device. Real user-initiated stops still release the device after 2s, matching the existing `Pause` behavior.

## Test plan

- [x] **macOS — Bluetooth (Bose NC 700 Headphones)**: track changes click-free (this was the most noticeable case before the fix)
- [x] **macOS — DAC**: track changes click-free
- [x] **Linux — PipeWire**: no regression on track changes

## Behavior change to note

The audio device is now held open for 2s after `Stop` (was: released immediately). Mirrors what `Pause` already does today. On exclusive-mode ALSA Direct setups, another app can't grab the hardware for 2s after QBZ stops — same trade-off the existing Pause handler already makes.

## Out of scope

- Different-rate track transitions (e.g. 44.1 → 96): stream is intentionally recreated in the DAC passthrough / ALSA Direct paths, so a residual click could persist there.
- macOS hog mode / bit-perfect output: complementary work in flight from @Vudgekek.