### PR TITLE
feat(titlebar): unify macOS layout with Linux qbz titlebar

### DIFF
--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2430,11 +2430,6 @@
     height: calc(100vh - 104px); /* Only 104px NowPlayingBar, no title bar */
   }
 
-  /* macOS: pad top of sidebar to clear native traffic light buttons */
-  :global(html.macos) .sidebar.no-titlebar {
-    padding-top: 32px;
-  }
-
   .content {
     flex: 1;
     overflow: hidden;

--- a/src/lib/components/Sidebar.svelte
+++ b/src/lib/components/Sidebar.svelte
@@ -2430,6 +2430,12 @@
     height: calc(100vh - 104px); /* Only 104px NowPlayingBar, no title bar */
   }
 
+  /* macOS hidden mode: pad sidebar top so search clears the traffic lights
+     that the OS still draws via TitleBarStyle::Overlay. */
+  :global(html.macos) .sidebar.no-titlebar {
+    padding-top: 36px;
+  }
+
   .content {
     flex: 1;
     overflow: hidden;

--- a/src/lib/components/TitleBar.svelte
+++ b/src/lib/components/TitleBar.svelte
@@ -4,6 +4,7 @@
   import { invoke } from '@tauri-apps/api/core';
   import { onMount } from 'svelte';
   import { t } from '$lib/i18n';
+  import { platform } from '$lib/utils/platform';
   import type { ButtonColorSet } from '$lib/stores/windowControlsStore';
   import type { Snippet } from 'svelte';
   import {
@@ -239,6 +240,7 @@
   class:controls-left={controlsPosition === 'left'}
   class:variant-full={variant === 'full'}
   class:variant-stripped={variant === 'stripped'}
+  class:macos={platform === 'macos'}
   {...variant === 'full' ? { 'data-tauri-drag-region': '' } : {}}
 >
   <!-- Left zone -->
@@ -328,6 +330,14 @@
     box-shadow: none;
     -webkit-app-region: no-drag;
     app-region: no-drag;
+  }
+
+  /* macOS: TitleBarStyle::Overlay paints the traffic lights at the top-left of
+     the window, on top of our content. Reserve ~84px on the left zone so the
+     lights don't collide with nav/search. The reserved area stays a drag
+     region (it's part of zone-left). */
+  .titlebar.macos .zone-left {
+    padding-left: 84px;
   }
 
   /* 3-zone layout: left and right zones are equal width, center is fixed */

--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -4711,7 +4711,9 @@
         />
       </div>
     {/if}
-    <!-- Title bar mode: hidden on macOS (always uses native overlay title bar) -->
+    <!-- Title bar mode: Linux-only. macOS stays pinned at 'qbz' since the
+         other modes ('system', 'plasma', 'hidden') describe Linux WM
+         behaviors that don't apply on Darwin. -->
     {#if platform !== 'macos'}
     <div class="setting-row">
       <div class="setting-info">
@@ -4746,8 +4748,9 @@
       </span>
     </div>
     {/if}
-    <!-- Title bar customization: hidden on macOS (uses native overlay title bar) -->
-    {#if platform !== 'macos'}
+    <!-- Search-in-titlebar and nav-in-titlebar: now available on macOS too,
+         since the qbz strip mounts there and can host them next to the
+         native traffic lights. -->
     <div class="setting-row" class:disabled-section={!supportsTitlebarFeatures}>
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.searchInTitleBar')}</span>
@@ -4840,6 +4843,10 @@
       />
     </div>
     {/if}
+    <!-- Window-controls customization: still Linux-only. macOS draws native
+         traffic lights via TitleBarStyle::Overlay, so position/style/size/
+         color settings would have no effect. -->
+    {#if platform !== 'macos'}
     <div class="setting-row" class:disabled-section={!isQbzMode}>
       <div class="setting-info">
         <span class="setting-label">{$t('settings.appearance.windowControlsPosition')}</span>

--- a/src/lib/components/views/SettingsView.svelte
+++ b/src/lib/components/views/SettingsView.svelte
@@ -4711,9 +4711,21 @@
         />
       </div>
     {/if}
-    <!-- Title bar mode: Linux-only. macOS stays pinned at 'qbz' since the
-         other modes ('system', 'plasma', 'hidden') describe Linux WM
-         behaviors that don't apply on Darwin. -->
+    <!-- macOS: only the 'qbz' ↔ 'hidden' axis is meaningful. 'system' /
+         'plasma' describe Linux WM behaviors that don't apply on Darwin,
+         so we expose a single Toggle instead of the full mode dropdown. -->
+    {#if platform === 'macos'}
+    <div class="setting-row">
+      <div class="setting-info">
+        <span class="setting-label">{$t('settings.appearance.hideTitleBar')}</span>
+        <span class="setting-desc">{$t('settings.appearance.hideTitleBarDesc')}</span>
+      </div>
+      <Toggle
+        enabled={titlebarMode === 'hidden'}
+        onchange={(v) => setMode(v ? 'hidden' : 'qbz')}
+      />
+    </div>
+    {/if}
     {#if platform !== 'macos'}
     <div class="setting-row">
       <div class="setting-info">

--- a/src/lib/stores/titleBarStore.ts
+++ b/src/lib/stores/titleBarStore.ts
@@ -90,8 +90,10 @@ export function getMode(): TitlebarMode {
 
 /**
  * Whether the custom TitleBar.svelte component should mount.
- * - macOS always uses native overlay → false.
- * - 'qbz' → true (full variant).
+ * - 'qbz' → true (full variant). macOS always falls here: mode selection
+ *   is hidden in settings on macOS, so it stays at the 'qbz' default and
+ *   the strip mounts with native traffic lights overlaid on its left zone
+ *   (see TitleBar.svelte's `.titlebar.macos` rule).
  * - 'plasma' or 'system' → true ONLY if the stripped strip would carry
  *   content (search-in-titlebar OR at least one nav item). Both render
  *   the strip below their respective OS chrome (KWin SSD via Xwayland
@@ -99,7 +101,6 @@ export function getMode(): TitlebarMode {
  * - 'hidden' → false.
  */
 export function shouldShowTitleBar(): boolean {
-  if (platform === 'macos') return false;
   if (mode === 'hidden') return false;
   if (mode === 'qbz') return true;
   // mode === 'plasma' or 'system' — both render the stripped strip below
@@ -142,6 +143,9 @@ export function setShowWindowControls(value: boolean): void {
  * controls are forced off regardless of the user pref.
  */
 export function getEffectiveShowWindowControls(): boolean {
+  // macOS draws native traffic lights via TitleBarStyle::Overlay, so the
+  // custom controls would visually collide with them.
+  if (platform === 'macos') return false;
   if (mode !== 'qbz') return false;
   return showWindowControls;
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -184,7 +184,6 @@
   import { loadAwardFavorites } from '$lib/stores/awardFavoritesStore';
   import { resolveAwardIdByName } from '$lib/stores/awardCatalogStore';
   import { getDefaultFavoritesTab } from '$lib/utils/favorites';
-  import { platform } from '$lib/utils/platform';
   import { formatTrackTitle } from '$lib/utils/trackTitle';
   import type { FavoritesPreferences, ResolvedMusician } from '$lib/types';
 
@@ -5725,10 +5724,6 @@
     class:match-chrome={matchSystemChrome && showTitleBar && windowTransparent}
     style="--chrome-radius: {chromeRadiusPx}px;"
   >
-    <!-- macOS: drag region for window movement (overlay title bar has no native drag area) -->
-    {#if !showTitleBar && platform === 'macos'}
-      <div class="macos-drag-region" data-tauri-drag-region></div>
-    {/if}
     <!-- Custom Title Bar (CSD) -->
     {#if showTitleBar}
       <TitleBar
@@ -7166,28 +7161,6 @@
   .app.no-titlebar .content-area,
   .app.no-titlebar .main-content {
     height: calc(100vh - var(--player-bar-height, 104px));
-  }
-
-  /* macOS: pad main content to clear native overlay title bar */
-  :global(html.macos) .main-content {
-    padding-top: 16px;
-    height: calc(100vh - 104px - 16px);
-  }
-
-  /* macOS: home view handles its own spacing */
-  :global(html.macos) .main-content :global(.home-view) {
-    margin-top: -16px;
-  }
-
-  /* macOS: invisible drag region for window movement (overlay title bar) */
-  :global(html.macos) .macos-drag-region {
-    height: 28px;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 9999;
-    -webkit-app-region: drag;
   }
 
   .view-error {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7184,9 +7184,10 @@
   }
 
   /* macOS hidden mode: invisible drag region for window movement, mirrors
-     the band the qbz strip would otherwise occupy. */
+     the band the qbz strip would otherwise occupy. Height matches the
+     sidebar's top padding so the entire traffic-light row is draggable. */
   :global(html.macos) .macos-drag-region {
-    height: 28px;
+    height: 36px;
     width: 100%;
     position: absolute;
     top: 0;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7184,10 +7184,9 @@
   }
 
   /* macOS hidden mode: invisible drag region for window movement, mirrors
-     the band the qbz strip would otherwise occupy. Height matches the
-     sidebar's top padding so the entire traffic-light row is draggable. */
+     the band the qbz strip would otherwise occupy. */
   :global(html.macos) .macos-drag-region {
-    height: 36px;
+    height: 32px;
     width: 100%;
     position: absolute;
     top: 0;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -184,6 +184,7 @@
   import { loadAwardFavorites } from '$lib/stores/awardFavoritesStore';
   import { resolveAwardIdByName } from '$lib/stores/awardCatalogStore';
   import { getDefaultFavoritesTab } from '$lib/utils/favorites';
+  import { platform } from '$lib/utils/platform';
   import { formatTrackTitle } from '$lib/utils/trackTitle';
   import type { FavoritesPreferences, ResolvedMusician } from '$lib/types';
 
@@ -5724,6 +5725,14 @@
     class:match-chrome={matchSystemChrome && showTitleBar && windowTransparent}
     style="--chrome-radius: {chromeRadiusPx}px;"
   >
+    <!-- macOS: when the user hides the qbz strip (mode='hidden'), the OS
+         still draws traffic lights via TitleBarStyle::Overlay on top of
+         the sidebar. This invisible band gives the window something to
+         drag and reserves the same vertical real estate the strip would
+         have. -->
+    {#if !showTitleBar && platform === 'macos'}
+      <div class="macos-drag-region" data-tauri-drag-region></div>
+    {/if}
     <!-- Custom Title Bar (CSD) -->
     {#if showTitleBar}
       <TitleBar
@@ -7161,6 +7170,29 @@
   .app.no-titlebar .content-area,
   .app.no-titlebar .main-content {
     height: calc(100vh - var(--player-bar-height, 104px));
+  }
+
+  /* macOS hidden mode: pad main content to clear native overlay traffic
+     lights. Only fires when the qbz strip isn't mounted. */
+  :global(html.macos) .app.no-titlebar .main-content {
+    padding-top: 16px;
+    height: calc(100vh - 104px - 16px);
+  }
+
+  :global(html.macos) .app.no-titlebar .main-content :global(.home-view) {
+    margin-top: -16px;
+  }
+
+  /* macOS hidden mode: invisible drag region for window movement, mirrors
+     the band the qbz strip would otherwise occupy. */
+  :global(html.macos) .macos-drag-region {
+    height: 28px;
+    width: 100%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+    -webkit-app-region: drag;
   }
 
   .view-error {


### PR DESCRIPTION
## Summary

Managed to find a way to use macOS traffic lights without the previous limitations: the qbz custom titlebar now mounts on macOS too, with the native traffic lights overlaid into a reserved 84px slot on the left of the strip. macOS picks up the same defaults as Linux out of the box (search and Discover/Favorites/Library/My QBZ rendered in the strip, sidebar reduced to playlists), and the search/nav-in-titlebar settings are now exposed in the macOS Settings UI. 

For users who prefer the original chrome-less look, a new "Hide title bar" toggle in macOS settings flips the underlying mode to `'hidden'`, restoring the lights-overlay-on-sidebar layout (with the drag band and sidebar top padding restored under that one branch). The bulk of the change is still *deleting* macOS-only branches: the always-on `macos-drag-region` overlay, the unconditional `:global(html.macos)` `.main-content` padding hacks, and the dead `.sidebar.no-titlebar` padding rule are gone — what remains is gated on `mode === 'hidden'`. Two minimal platform branches stay in the always-on path: the 84px reservation in `TitleBar.svelte` and `getEffectiveShowWindowControls()` returning false on macOS so we don't paint custom min/max/close on top of the OS-drawn lights.

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/951739ea-4dca-4b3a-bfec-71e670412153" />

<img width="1624" height="1061" alt="image" src="https://github.com/user-attachments/assets/99753798-c88b-4367-b138-05b2dd15ebf9" />

## Test plan

- [x] Launch on macOS — verify traffic lights sit in the new strip, search/nav buttons render to their right, dragging the strip moves the window
- [x] Launch on Linux (qbz mode) — verify no regression in the existing strip layout
- [x] macOS Settings → Appearance — verify search-in-titlebar and per-item nav toggles are present and work; window-controls customization stays hidden
- [x] macOS Settings → Appearance → Hide title bar — verify toggling on hides the strip, surfaces the traffic lights over the sidebar, gives the top band drag behavior, and pads the sidebar/main-content; toggling off returns to the unified strip