### PR TITLE
fix(ci): suffix macOS .app.tar.gz bundles with arch to fix auto-updater

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -18,8 +18,10 @@ jobs:
         include:
           - target: aarch64-apple-darwin
             artifact: qbz-macos-aarch64
+            arch: aarch64
           - target: x86_64-apple-darwin
             artifact: qbz-macos-x86_64
+            arch: x86_64
     runs-on: macos-latest
     permissions:
       contents: write
@@ -102,13 +104,20 @@ jobs:
         run: npm run tauri build -- --target ${{ matrix.target }}
 
       - name: Collect artifacts
+        env:
+          BUNDLE_DIR: src-tauri/target/${{ matrix.target }}/release/bundle
+          ARCH: ${{ matrix.arch }}
         run: |
+          set -euo pipefail
           mkdir -p dist
-          # DMG for manual distribution
-          cp -v src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg dist/ || true
-          # .app.tar.gz + .sig for auto-updater
-          cp -v src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz dist/ || true
-          cp -v src-tauri/target/${{ matrix.target }}/release/bundle/macos/*.tar.gz.sig dist/ || true
+          # DMG for manual distribution (filename already includes arch).
+          cp -v "$BUNDLE_DIR"/dmg/*.dmg dist/
+          # .app.tar.gz + .sig for auto-updater. Rename with arch suffix so the
+          # two matrix jobs don't overwrite each other on the GitHub Release,
+          # and so release-updater-manifest.yml's regex picks them up
+          # ("aarch64.app.tar.gz$" / "(x64|x86_64).app.tar.gz$").
+          cp -v "$BUNDLE_DIR/macos/QBZ.app.tar.gz"     "dist/QBZ_${ARCH}.app.tar.gz"
+          cp -v "$BUNDLE_DIR/macos/QBZ.app.tar.gz.sig" "dist/QBZ_${ARCH}.app.tar.gz.sig"
           ls -la dist
 
       - name: Upload artifacts


### PR DESCRIPTION
## Summary
The macOS in-app updater was failing with `None of the fallback platforms ["darwin-aarch64-app", "darwin-aarch64"] were found in the response 'platforms' object`. Root cause: both matrix jobs in `release-macos.yml` emit Tauri's default-named `QBZ.app.tar.gz`, so the second upload silently overwrites the first on the GitHub Release, and the manifest workflow's regex (`aarch64.app.tar.gz$` / `(x64|x86_64).app.tar.gz$`) then matches nothing, leaving `latest.json` with no `darwin-*` entries. This change tags each matrix job with an `arch` label and copies the bundle to `dist/QBZ_${ARCH}.app.tar.gz` (plus matching `.sig`) so both architectures publish as distinct assets and the existing manifest regex picks them up. Also dropped the `|| true` that was swallowing missing DMG/bundle output, so a broken build fails loud instead of uploading an incomplete release.

## Test plan
- [ ] Cut a tag and confirm both `QBZ_aarch64.app.tar.gz` and `QBZ_x86_64.app.tar.gz` appear on the release with matching `.sig` files
- [ ] Verify the generated `latest.json` contains `darwin-aarch64` and `darwin-x86_64` entries
- [ ] Trigger an in-app update on macOS and confirm it no longer errors out