### PR TITLE
fix(lyrics): active-line color and karaoke playback overhaul

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.2.12",
       "license": "MIT",
       "dependencies": {
+        "@chenglou/pretext": "^0.0.7",
         "@icons-pack/svelte-simple-icons": "^7.2.0",
         "@kawarp/core": "^1.1.1",
         "@tauri-apps/api": "^2.11.0",
@@ -135,6 +136,12 @@
       "bin": {
         "specificity": "bin/cli.js"
       }
+    },
+    "node_modules/@chenglou/pretext": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@chenglou/pretext/-/pretext-0.0.7.tgz",
+      "integrity": "sha512-FV5hj3fGqpBlzbANUbR+s+6XuNRrghVVyuNs33zdH2SzU7MvK+7GlW6xREjDCreixKbexEn7OEkDgAFeWuu5Hg==",
+      "license": "MIT"
     },
     "node_modules/@csstools/color-helpers": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@chenglou/pretext": "^0.0.7",
     "@icons-pack/svelte-simple-icons": "^7.2.0",
     "@kawarp/core": "^1.1.1",
     "@tauri-apps/api": "^2.11.0",

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -123,7 +123,13 @@
     if (prevBlockTime > 0) {
       const dt = now - prevBlockTime;
       const dp = progress - prevBlockProgress;
-      if (dt >= 50 && dt <= 1500) {
+      // Floor of 5ms: previously was 50ms (calibrated for setInterval ticks
+      // at 80–200ms), which silently rejected every rAF-rate update — so
+      // measuredBlockMs stayed pinned at the seed value (~89ms for a 2.5s
+      // line) and the transition was always 89ms long even when ticks were
+      // arriving every 16ms. With the floor lowered, the EMA settles to
+      // the real notification interval and the playhead lag drops ~10x.
+      if (dt >= 5 && dt <= 1500) {
         measuredBlockMs = Math.round(measuredBlockMs * 0.3 + dt * 0.7);
       }
       // Forward-only progress deltas (backward = seek, not a tick we'd predict)

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -10,6 +10,7 @@
   interface LyricsLine {
     text: string;
     timeMs?: number; // Optional timing for synced lyrics
+    endMs?: number; // Optional end-of-vocal marker (LRC gap markers)
   }
 
   interface Props {
@@ -46,18 +47,19 @@
     uppercase = false
   }: Props = $props();
 
-  // Calculate line duration for CSS animation (immersive mode only)
+  // Sung duration for a line. Uses endMs (LRC gap marker → end of vocal)
+  // when available, otherwise next line's start, otherwise a 5s default.
   function getLineDuration(index: number): number {
     if (!isSynced || index < 0 || index >= lines.length) return 3000;
 
     const currentLine = lines[index];
     const nextLine = lines[index + 1];
 
-    if (!currentLine?.timeMs) return 3000; // Default 3 seconds
-    if (!nextLine?.timeMs) return 5000; // Last line, assume 5 seconds
+    if (!currentLine?.timeMs) return 3000;
+    const bound = currentLine.endMs ?? nextLine?.timeMs;
+    if (!bound) return 5000;
 
-    const duration = nextLine.timeMs - currentLine.timeMs;
-    // Clamp between 1-10 seconds
+    const duration = bound - currentLine.timeMs;
     return Math.max(1000, Math.min(10000, duration));
   }
 

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -490,6 +490,18 @@
     transform: scale(1.05);
   }
 
+  /* Make .line-text block-level so background-clip: text has a paint area
+     bounded by the full block box rather than the inline-fragment box.
+     On WebKit the inline-fragment paint area can be tight around the
+     font's ascent/descent metrics, so glyph parts that extend below
+     baseline (g, y, p, q, j descenders) end up outside the paint area
+     and render transparent against the parent background. A small
+     padding-bottom gives descenders a guaranteed paint margin. */
+  .lyrics-line .line-text {
+    display: block;
+    padding-bottom: 0.15em;
+  }
+
   /* Karaoke effect on active line — hard cut at the playhead.
      Visual smoothness comes from --line-progress transitioning over
      --block-interval; the gradient is a sharp two-color split moving

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -372,11 +372,11 @@
     font-weight: 700;
     opacity: 1;
     transform: scale(1.02);
-    text-shadow:
-      0 1px 3px rgba(0, 0, 0, 0.6),
-      0 2px 10px rgba(0, 0, 0, 0.4),
-      0 0 40px color-mix(in srgb, var(--lyrics-active-color, var(--accent-primary)) 40%, transparent),
-      0 0 80px color-mix(in srgb, var(--lyrics-active-color, var(--accent-primary)) 20%, transparent);
+    /* Use filter: drop-shadow on the parent — text-shadow inherits into the
+       background-clipped span and tints the gradient on WebKit (macOS). */
+    filter:
+      drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6))
+      drop-shadow(0 0 12px color-mix(in srgb, var(--lyrics-active-color, var(--accent-primary)) 35%, transparent));
   }
 
   .lyrics-lines.center .lyrics-line.active {
@@ -396,6 +396,11 @@
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
+    -webkit-text-fill-color: transparent;
+    /* Suppress inherited text-shadow — on WebKit (macOS) shadows render in
+       the text-glyph shape and tint the gradient-clipped fill, making the
+       active line look dim/red instead of crisp. */
+    text-shadow: none;
   }
 
   .lyrics-empty {

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import { tick, untrack } from 'svelte';
   import { t } from 'svelte-i18n';
+  import { prepareWithSegments, layoutWithLines, type LayoutLine } from '@chenglou/pretext';
   import type {
     LyricsFont,
     LyricsFontSize,
     LyricsDimming
   } from '$lib/stores/lyricsDisplayStore';
+  import type { LyricsLine as StoreLyricsLine } from '$lib/stores/lyricsStore';
 
-  interface LyricsLine {
-    text: string;
-    timeMs?: number; // Optional timing for synced lyrics
-    endMs?: number; // Optional end-of-vocal marker (LRC gap markers)
-  }
+  // Accept the canonical store shape, or a minimal projection for callers
+  // (e.g. unsynced lyrics surfaces) that only need text.
+  type LyricsLine = StoreLyricsLine | { text: string; timeMs?: number; endMs?: number };
 
   interface Props {
     lines: LyricsLine[];
@@ -92,74 +92,234 @@
   // stale position followed by a backward transition to 0. Running pre-DOM
   // means the first paint of the new line already sees lookaheadEnabled =
   // false and the snapshot is correct.
+  //
+  // Reads-and-writes of the same $state (measuredBlockMs feeding its own
+  // EMA, lookaheadEnabled / measuredBlockDelta written below) are wrapped
+  // in untrack so the effect doesn't self-trigger on its own writes — the
+  // only true dependencies are activeIndex and activeProgress.
   $effect.pre(() => {
     const idx = activeIndex;
     const progress = activeProgress;
 
-    if (!isSynced || idx < 0) {
-      prevBlockTime = 0;
-      prevBlockIndex = -1;
-      lookaheadEnabled = false;
-      return;
-    }
+    untrack(() => {
+      if (!isSynced || idx < 0) {
+        prevBlockTime = 0;
+        prevBlockIndex = -1;
+        lookaheadEnabled = false;
+        return;
+      }
 
-    const now = performance.now();
+      const now = performance.now();
 
-    if (idx !== prevBlockIndex) {
-      // Line transition: seed transition duration from line duration
-      // (we don't have a real block-time measurement yet), and clear the
-      // lookahead so the first paint of the new line is exactly at the
-      // store's reported progress (no early/late drift across boundaries).
-      const dur = untrack(() => getLineDuration(idx));
-      measuredBlockMs = Math.max(80, Math.round(dur * 0.035));
-      measuredBlockDelta = 0;
-      lookaheadEnabled = false;
-      prevBlockIndex = idx;
+      if (idx !== prevBlockIndex) {
+        // Line transition: seed transition duration close to display
+        // refresh (≥20ms). With playerStore-side extrapolation feeding
+        // us per-rAF progress samples, the EMA converges to ~16ms within
+        // 2-3 ticks — but the FIRST tick of a new line uses this seed,
+        // and an 80ms seed would visibly lag the gradient for that
+        // one frame. Clear the lookahead so the first paint of the new
+        // line is exactly at the store's reported progress.
+        const dur = getLineDuration(idx);
+        const seedMs = Math.max(20, Math.round(dur * 0.01));
+        if (measuredBlockMs !== seedMs) measuredBlockMs = seedMs;
+        if (measuredBlockDelta !== 0) measuredBlockDelta = 0;
+        if (lookaheadEnabled) lookaheadEnabled = false;
+        prevBlockIndex = idx;
+        prevBlockTime = now;
+        prevBlockProgress = progress;
+        return;
+      }
+
+      if (prevBlockTime > 0) {
+        const dt = now - prevBlockTime;
+        const dp = progress - prevBlockProgress;
+        // Backward progress within the same line = seek; flip lookahead off
+        // so the cut doesn't lead from a now-stale forward velocity.
+        if (dp < 0 && lookaheadEnabled) lookaheadEnabled = false;
+        // dt > 1500 = discontinuity (tab resume, pause+seek): keep the EMA
+        // unchanged AND reset the snapshot so the next tick measures from
+        // the post-discontinuity moment instead of absorbing a frame-sized
+        // dp built up over seconds.
+        // 5ms ≤ dt ≤ 1500: a real rAF-rate sample, update the EMA. The 5ms
+        // floor used to be 50ms (calibrated for setInterval) which silently
+        // rejected every rAF update.
+        if (dt >= 5 && dt <= 1500) {
+          const newMs = Math.round(measuredBlockMs * 0.3 + dt * 0.7);
+          if (newMs !== measuredBlockMs) measuredBlockMs = newMs;
+        }
+        // Forward-only progress deltas; clamp to 1/30 (~half a rAF tick at
+        // 60Hz on a slow line) so a single coarse audio-time jump can't
+        // poison the lookahead with a multi-frame lead.
+        if (dp > 0 && dp < 0.2) {
+          const clamped = Math.min(dp, 1 / 30);
+          measuredBlockDelta = measuredBlockDelta * 0.3 + clamped * 0.7;
+          if (!lookaheadEnabled) lookaheadEnabled = true;
+        }
+      }
       prevBlockTime = now;
       prevBlockProgress = progress;
-      return;
-    }
-
-    if (prevBlockTime > 0) {
-      const dt = now - prevBlockTime;
-      const dp = progress - prevBlockProgress;
-      // Floor of 5ms: previously was 50ms (calibrated for setInterval ticks
-      // at 80–200ms), which silently rejected every rAF-rate update — so
-      // measuredBlockMs stayed pinned at the seed value (~89ms for a 2.5s
-      // line) and the transition was always 89ms long even when ticks were
-      // arriving every 16ms. With the floor lowered, the EMA settles to
-      // the real notification interval and the playhead lag drops ~10x.
-      if (dt >= 5 && dt <= 1500) {
-        measuredBlockMs = Math.round(measuredBlockMs * 0.3 + dt * 0.7);
-      }
-      // Forward-only progress deltas (backward = seek, not a tick we'd predict)
-      if (dp > 0 && dp < 0.2) {
-        measuredBlockDelta = measuredBlockDelta * 0.3 + dp * 0.7;
-        lookaheadEnabled = true;
-      }
-    }
-    prevBlockTime = now;
-    prevBlockProgress = progress;
+    });
   });
 
-  // Inline style for the (single) active line. Computed reactively so any
-  // change to lookahead / measurement state updates the karaoke position
-  // without restarting any animations.
-  //
-  // Always uses activeProgress as the floor — lookahead just adds a small
-  // measured offset on top. Earlier this forced 0 on first paint, but if
-  // lookaheadEnabled ever fails to flip on (e.g. the line gets only a
-  // single notification before audio stops or a seek lands directly at
-  // p=1) the gradient would stay at 0 forever (= the line never goes
-  // through). Tracking activeProgress directly makes that failure mode
-  // graceful: even with no lookahead, the playhead still reflects audio.
-  const activeLineStyle = $derived.by(() => {
-    if (!isSynced || activeIndex < 0) return '';
+  // Active lyric layout via Pretext. For wrapped lyrics, the CSS gradient
+  // applied to a single span shares the same X cut across every visual
+  // line — visually wrong because line 2 hasn't been sung yet. Pretext
+  // gives us each visual line's text and width as a clean data structure;
+  // we then render each line as its own block-level <span> with its own
+  // simple 0→100% gradient. Each line owns a proportional share of the
+  // total karaoke progress, so line 1 fully fills before line 2 starts.
+  let activeLineSegments = $state<LayoutLine[]>([]);
+
+  function layoutActiveLine(): void {
+    if (!container || activeIndex < 0 || !isSynced) {
+      activeLineSegments = [];
+      return;
+    }
+    const text = lines[activeIndex]?.text;
+    if (!text) {
+      activeLineSegments = [];
+      return;
+    }
+    const div = container.querySelector<HTMLElement>(
+      `[data-line-index="${activeIndex}"]`
+    );
+    if (!div) {
+      activeLineSegments = [];
+      return;
+    }
+    const computed = getComputedStyle(div);
+    const fontSizePx = Number.parseFloat(computed.fontSize);
+    // line-height of `normal` resolves to "normal" (not a px string) → NaN.
+    // Anything else resolves to a positive px value; guard explicitly rather
+    // than relying on `|| fallback` (which would also swallow a legitimate 0).
+    const parsedLineHeight = Number.parseFloat(computed.lineHeight);
+    const lineHeightPx =
+      Number.isFinite(parsedLineHeight) && parsedLineHeight > 0
+        ? parsedLineHeight
+        : fontSizePx * 1.5;
+    // offsetWidth is the CSS layout width (pre-transform). The active line
+    // applies a CSS scale, so the visual rendering is wider than its
+    // layout box and would clip against the parent's overflow-x: hidden.
+    // 1.2 is empirical — it accounts for the visual scale plus a small
+    // safety margin for measurement variance between Pretext's canvas
+    // metrics and the browser's actual text layout.
+    const ACTIVE_SCALE = 1.2;
+    const maxWidth = div.offsetWidth / ACTIVE_SCALE;
+    if (!fontSizePx || maxWidth <= 0) {
+      activeLineSegments = [];
+      return;
+    }
+    // Canvas-style font string: "<weight> <size>px <family>"
+    const fontStr = `${computed.fontWeight} ${fontSizePx}px ${computed.fontFamily}`;
+    // Letter-spacing in CSS gets resolved to a pixel value (or "normal").
+    // Without it, Pretext underestimates width by ~spacing × char-count.
+    const lsStr = computed.letterSpacing;
+    const letterSpacing = lsStr && lsStr !== 'normal' ? Number.parseFloat(lsStr) || 0 : 0;
+
+    try {
+      const prepared = prepareWithSegments(text, fontStr, { letterSpacing });
+      const result = layoutWithLines(prepared, maxWidth, lineHeightPx);
+      activeLineSegments = result.lines;
+    } catch (e) {
+      if (import.meta.env.DEV) {
+        console.warn('[Lyrics] Pretext layout failed:', e);
+      }
+      activeLineSegments = [];
+    }
+  }
+
+  // Schedule layout after Svelte's DOM flush, but cancel any in-flight
+  // schedule if activeIndex moves before the microtask resolves. Without
+  // the generation guard, rapid line transitions (seek-scrub, fast songs
+  // at 60Hz notifications) queue multiple `tick().then(layoutActiveLine)`
+  // promises; they resolve in order against the *current* activeIndex,
+  // measuring and re-measuring the same line and thrashing segment DOM.
+  $effect(() => {
+    const idx = activeIndex;
+    if (!isSynced || idx < 0) {
+      activeLineSegments = [];
+      return;
+    }
+    let canceled = false;
+    tick().then(() => {
+      if (!canceled && idx === activeIndex) layoutActiveLine();
+    });
+    return () => { canceled = true; };
+  });
+
+  // Re-layout on container resize (sidebar toggle, window resize, font
+  // size change). Coalesce bursts via rAF: a continuous window drag fires
+  // RO 60+ times/sec, and every callback would otherwise force layout +
+  // run Pretext measurement. Also gate on actual width change — the
+  // active-line scale animation (font-size, transform) changes container
+  // *height* mid-transition, which we don't care about.
+  $effect(() => {
+    if (!container) return;
+    let pending = false;
+    let prevWidth = container.clientWidth;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width ?? prevWidth;
+      if (Math.abs(w - prevWidth) < 1) return;
+      prevWidth = w;
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(() => {
+        pending = false;
+        layoutActiveLine();
+      });
+    });
+    ro.observe(container);
+    return () => ro.disconnect();
+  });
+
+  // Effective karaoke progress (with lookahead) — always uses
+  // activeProgress as a floor. Earlier the lookaheadEnabled flag gated
+  // this entirely; if it ever failed to flip on (e.g. the line gets only a
+  // single notification before audio stops, or a seek lands directly at
+  // p=1) the visual would stay at 0. Lookahead is a bonus, not a gate.
+  const effectiveProgress = $derived.by(() => {
     const base = Math.max(0, Math.min(1, activeProgress));
-    const prog = lookaheadEnabled
+    return lookaheadEnabled
       ? Math.max(0, Math.min(1, base + measuredBlockDelta))
       : base;
-    return `--line-progress: ${prog}; --block-interval: ${measuredBlockMs}ms`;
+  });
+
+  // Pre-compute cumulative-width prefix for the segments, so per-segment
+  // progress is O(1) lookup instead of O(i) summation inside the each-block.
+  // segmentBounds[i] = [start, end] in pixels for segment i across the
+  // full line; segmentTotal = total ink width.
+  const segmentBounds = $derived.by(() => {
+    const bounds: Array<[number, number]> = [];
+    let cumulative = 0;
+    for (const seg of activeLineSegments) {
+      bounds.push([cumulative, cumulative + seg.width]);
+      cumulative += seg.width;
+    }
+    return bounds;
+  });
+  const segmentTotalWidth = $derived(
+    segmentBounds.length > 0 ? segmentBounds[segmentBounds.length - 1][1] : 0
+  );
+
+  // Compute a single segment's local progress (0→1) given the global
+  // effectiveProgress and that segment's share of total width. Line 1
+  // fills first, line 2 only starts once line 1 is fully sung.
+  function getSegmentProgress(i: number): number {
+    if (segmentTotalWidth <= 0) return 0;
+    const progressPx = effectiveProgress * segmentTotalWidth;
+    const [start, end] = segmentBounds[i];
+    const width = end - start;
+    if (width <= 0) return 0;
+    const localPx = Math.max(0, Math.min(width, progressPx - start));
+    return localPx / width;
+  }
+
+  // Inline style for the active line's parent div. Now only carries
+  // --block-interval (shared transition timing for all segments) — the
+  // per-segment --line-progress is set on each segment span itself.
+  const activeLineStyle = $derived.by(() => {
+    if (!isSynced || activeIndex < 0) return '';
+    return `--block-interval: ${measuredBlockMs}ms`;
   });
 
   let container: HTMLDivElement | null = null;
@@ -271,7 +431,10 @@
     {#each lines as line, index (index)}
       <!-- Single <div> per line with class toggles, so CSS transitions can
            animate state changes (active ↔ past, size/scale/color) instead
-           of being killed by destroy-and-recreate when activeIndex moves. -->
+           of being killed by destroy-and-recreate when activeIndex moves.
+           Active line renders one .line-segment per Pretext-laid-out
+           visual line so each gets its own gradient and sequential fill;
+           non-active lines render a single .line-text. -->
       {@const isActive = isSynced && index === activeIndex}
       <div
         class="lyrics-line {immersive && isSynced ? getDistanceClass(index, activeIndex) : ''}"
@@ -282,7 +445,23 @@
           : (immersive ? '' : `--line-opacity: ${isSynced ? getLineOpacity(index, activeIndex) : 1}`)}
         data-line-index={index}
       >
-        <span class="line-text">{line.text}</span>
+        {#if isActive && activeLineSegments.length > 0}
+          <!-- Key includes activeIndex so a line transition forces fresh
+               DOM for each segment. Otherwise keying by `i` alone reuses
+               the previous line's segment-i element, and CSS transitions
+               on --line-progress fire from the prior line's final value
+               (e.g. 1.0 if that line was fully sung) down to the new
+               line's value — visible as a "ghost" partial-sung start
+               on the new line's segments. -->
+          {#each activeLineSegments as segment, i (`${activeIndex}-${i}`)}
+            <span
+              class="line-segment"
+              style="--line-progress: {getSegmentProgress(i)}"
+            >{segment.text}</span>
+          {/each}
+        {:else}
+          <span class="line-text">{line.text}</span>
+        {/if}
       </div>
     {/each}
 
@@ -502,26 +681,39 @@
     padding-bottom: 0.15em;
   }
 
-  /* Karaoke effect on active line — hard cut at the playhead.
-     Visual smoothness comes from --line-progress transitioning over
-     --block-interval; the gradient is a sharp two-color split moving
-     with that transition. The +1% bias on the playhead stops pushes the
-     cut just past 100% at p=1, guaranteeing the rightmost text pixels
-     are in the active color (so the last line of a song reliably fills
-     during the trailing instrumental coda). */
-  .lyrics-line.active .line-text {
+  /* One .line-segment per Pretext-laid-out visual line of the active
+     lyric. Each segment is its own block-level element with its own
+     simple 0→100% gradient driven by --line-progress (set inline per
+     segment in JS based on its share of total progress). Sequential
+     filling falls out naturally: line 1's segment owns the first portion
+     of progress, line 2's the next, etc.
+     white-space: nowrap because Pretext has already done the wrapping;
+     CSS shouldn't re-wrap within a segment. padding-bottom gives the
+     background-clip: text mask room for descenders (g/y/p/q). */
+  .lyrics-line.active .line-segment {
+    display: block;
+    white-space: nowrap;
+    padding-bottom: 0.15em;
     --progress-pos: calc(var(--line-progress, 0) * 100%);
     background: linear-gradient(
       90deg,
       var(--lyrics-active-color, var(--accent-primary)) 0%,
-      var(--lyrics-active-color, var(--accent-primary)) calc(var(--progress-pos) + 1%),
-      var(--text-primary) calc(var(--progress-pos) + 1%),
+      var(--lyrics-active-color, var(--accent-primary)) var(--progress-pos),
+      var(--text-primary) var(--progress-pos),
       var(--text-primary) 100%
     );
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
     -webkit-text-fill-color: transparent;
+    transition: --line-progress var(--block-interval, 175ms) linear;
+  }
+
+  /* Immersive mode overrides the gradient so the active line is solid white. */
+  .lyrics-lines.immersive .lyrics-line.active .line-segment {
+    background: none;
+    color: #ffffff !important;
+    -webkit-text-fill-color: #ffffff;
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -139,11 +139,20 @@
   // Inline style for the (single) active line. Computed reactively so any
   // change to lookahead / measurement state updates the karaoke position
   // without restarting any animations.
+  //
+  // Always uses activeProgress as the floor — lookahead just adds a small
+  // measured offset on top. Earlier this forced 0 on first paint, but if
+  // lookaheadEnabled ever fails to flip on (e.g. the line gets only a
+  // single notification before audio stops or a seek lands directly at
+  // p=1) the gradient would stay at 0 forever (= the line never goes
+  // through). Tracking activeProgress directly makes that failure mode
+  // graceful: even with no lookahead, the playhead still reflects audio.
   const activeLineStyle = $derived.by(() => {
     if (!isSynced || activeIndex < 0) return '';
+    const base = Math.max(0, Math.min(1, activeProgress));
     const prog = lookaheadEnabled
-      ? Math.max(0, Math.min(1, activeProgress + measuredBlockDelta))
-      : 0;
+      ? Math.max(0, Math.min(1, base + measuredBlockDelta))
+      : base;
     return `--line-progress: ${prog}; --block-interval: ${measuredBlockMs}ms`;
   });
 

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -63,17 +63,6 @@
     return Math.max(1000, Math.min(10000, duration));
   }
 
-  // Track active line changes for animation reset
-  let animationKey = $state(0);
-  let lastActiveIndex = $state(-1);
-
-  $effect(() => {
-    if (activeIndex !== lastActiveIndex && activeIndex >= 0) {
-      lastActiveIndex = activeIndex;
-      animationKey++; // Force animation restart
-    }
-  });
-
   let container: HTMLDivElement | null = null;
   let lastScrolledIndex = -1;
   let lastLyricsKey = '';
@@ -181,28 +170,23 @@
     {/if}
 
     {#each lines as line, index (index)}
-      {#if immersive && isSynced && index === activeIndex}
-        <!-- Active line in immersive mode: CSS animation with duration -->
-        {#key animationKey}
-          <div
-            class="lyrics-line active {getDistanceClass(index, activeIndex)}"
-            style="--line-duration: {getLineDuration(index)}ms"
-            data-line-index={index}
-          >
-            <span class="line-text">{line.text}</span>
-          </div>
-        {/key}
-      {:else}
-        <div
-          class="lyrics-line {immersive && isSynced ? getDistanceClass(index, activeIndex) : ''}"
-          class:active={isSynced && index === activeIndex}
-          class:past={isSynced && index < activeIndex}
-          style={immersive ? '' : `--line-opacity: ${isSynced ? getLineOpacity(index, activeIndex) : 1}; ${isSynced && index === activeIndex ? `--line-progress: ${Math.max(0, Math.min(1, activeProgress))}` : ''}`}
-          data-line-index={index}
-        >
-          <span class="line-text">{line.text}</span>
-        </div>
-      {/if}
+      <!-- Single <div> per line with class toggles, so CSS transitions can
+           animate state changes (active ↔ past, size/scale/color) instead
+           of being killed by destroy-and-recreate when activeIndex moves. -->
+      {@const isActive = isSynced && index === activeIndex}
+      <div
+        class="lyrics-line {immersive && isSynced ? getDistanceClass(index, activeIndex) : ''}"
+        class:active={isActive}
+        class:past={isSynced && index < activeIndex}
+        style={immersive
+          ? ''
+          : isActive
+            ? `--line-progress: ${Math.max(0, Math.min(1, activeProgress))}`
+            : `--line-opacity: ${isSynced ? getLineOpacity(index, activeIndex) : 1}`}
+        data-line-index={index}
+      >
+        <span class="line-text">{line.text}</span>
+      </div>
     {/each}
 
     <!-- Spacer at bottom to allow last lines to scroll to center (only for synced) -->
@@ -343,21 +327,31 @@
     line-height: 1.5;
     letter-spacing: 0.01em;
     opacity: var(--line-opacity, 1);
-    /* Minimal transitions for non-immersive mode */
-    transition: opacity 200ms ease-out, color 200ms ease-out;
+    /* Transitions on every property the active class swaps, so going
+       active ↔ past animates smoothly in both directions (the same DOM
+       element persists across state changes — see the each-block above). */
+    transition:
+      opacity 220ms ease-out,
+      color 220ms ease-out,
+      font-size 220ms cubic-bezier(0.4, 0, 0.2, 1),
+      font-weight 220ms ease-out,
+      transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
     transform-origin: left center;
     /* Prevent horizontal overflow with long lyrics */
     word-wrap: break-word;
     overflow-wrap: break-word;
   }
 
-  /* Only active line gets full transitions */
+  /* Active line: mirror the base transitions. `transition` is shorthand
+     so it must be re-declared in full here, otherwise the size/scale/
+     color animations would be dropped on activation. */
   .lyrics-line.active {
     transition:
-      opacity 200ms ease-out,
-      transform 200ms ease-out,
-      font-size 150ms ease-out,
-      color 250ms ease-out;
+      opacity 220ms ease-out,
+      color 220ms ease-out,
+      font-size 220ms cubic-bezier(0.4, 0, 0.2, 1),
+      font-weight 220ms ease-out,
+      transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .lyrics-lines.center .lyrics-line {

--- a/src/lib/components/lyrics/LyricsLines.svelte
+++ b/src/lib/components/lyrics/LyricsLines.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { t } from 'svelte-i18n';
   import type {
     LyricsFont,
@@ -62,6 +62,90 @@
     const duration = bound - currentLine.timeMs;
     return Math.max(1000, Math.min(10000, duration));
   }
+
+  // Dynamic block measurement.
+  //   measuredBlockMs    — wall-clock gap between two notifications. Drives
+  //                        the CSS transition duration so each block's
+  //                        animation matches its real audio duration (no
+  //                        pauses, no accumulated lag).
+  //   measuredBlockDelta — progress increment per notification. Used as a
+  //                        lookahead so the visual leads the audio by one
+  //                        block — by the time the transition completes,
+  //                        audio has caught up to where we transitioned
+  //                        to. Net: zero visible lag, while still
+  //                        correcting against actual audio on every tick.
+  let measuredBlockMs = $state(175);
+  let measuredBlockDelta = $state(0);
+  // Lookahead is suppressed on the first notification of a new line: at
+  // that point we have no measurement of this line's cadence yet, and
+  // adding a stale prior-line delta would push the visual into the line
+  // before it should be. Flipped on as soon as we've observed one block.
+  let lookaheadEnabled = $state(false);
+  let prevBlockTime = 0;
+  let prevBlockProgress = 0;
+  let prevBlockIndex = -1;
+
+  // $effect.pre — runs BEFORE the DOM update for the prop change that
+  // triggered it. With a plain $effect, on a line transition the derived
+  // below would first paint with stale (previous-line) lookahead state,
+  // and only then the effect would reset it — causing a brief flash at the
+  // stale position followed by a backward transition to 0. Running pre-DOM
+  // means the first paint of the new line already sees lookaheadEnabled =
+  // false and the snapshot is correct.
+  $effect.pre(() => {
+    const idx = activeIndex;
+    const progress = activeProgress;
+
+    if (!isSynced || idx < 0) {
+      prevBlockTime = 0;
+      prevBlockIndex = -1;
+      lookaheadEnabled = false;
+      return;
+    }
+
+    const now = performance.now();
+
+    if (idx !== prevBlockIndex) {
+      // Line transition: seed transition duration from line duration
+      // (we don't have a real block-time measurement yet), and clear the
+      // lookahead so the first paint of the new line is exactly at the
+      // store's reported progress (no early/late drift across boundaries).
+      const dur = untrack(() => getLineDuration(idx));
+      measuredBlockMs = Math.max(80, Math.round(dur * 0.035));
+      measuredBlockDelta = 0;
+      lookaheadEnabled = false;
+      prevBlockIndex = idx;
+      prevBlockTime = now;
+      prevBlockProgress = progress;
+      return;
+    }
+
+    if (prevBlockTime > 0) {
+      const dt = now - prevBlockTime;
+      const dp = progress - prevBlockProgress;
+      if (dt >= 50 && dt <= 1500) {
+        measuredBlockMs = Math.round(measuredBlockMs * 0.3 + dt * 0.7);
+      }
+      // Forward-only progress deltas (backward = seek, not a tick we'd predict)
+      if (dp > 0 && dp < 0.2) {
+        measuredBlockDelta = measuredBlockDelta * 0.3 + dp * 0.7;
+        lookaheadEnabled = true;
+      }
+    }
+    prevBlockTime = now;
+    prevBlockProgress = progress;
+  });
+
+  // Inline style for the (single) active line. Computed reactively so any
+  // change to lookahead / measurement state updates the karaoke position
+  // without restarting any animations.
+  const activeLineStyle = $derived.by(() => {
+    if (!isSynced || activeIndex < 0) return '';
+    const prog = lookaheadEnabled
+      ? Math.max(0, Math.min(1, activeProgress + measuredBlockDelta))
+      : 0;
+    return `--line-progress: ${prog}; --block-interval: ${measuredBlockMs}ms`;
+  });
 
   let container: HTMLDivElement | null = null;
   let lastScrolledIndex = -1;
@@ -178,11 +262,9 @@
         class="lyrics-line {immersive && isSynced ? getDistanceClass(index, activeIndex) : ''}"
         class:active={isActive}
         class:past={isSynced && index < activeIndex}
-        style={immersive
-          ? ''
-          : isActive
-            ? `--line-progress: ${Math.max(0, Math.min(1, activeProgress))}`
-            : `--line-opacity: ${isSynced ? getLineOpacity(index, activeIndex) : 1}`}
+        style={isActive
+          ? activeLineStyle
+          : (immersive ? '' : `--line-opacity: ${isSynced ? getLineOpacity(index, activeIndex) : 1}`)}
         data-line-index={index}
       >
         <span class="line-text">{line.text}</span>
@@ -308,9 +390,13 @@
     opacity: 1;
   }
 
-  /* Immersive mode: simple bright white text, no animation */
+  /* Immersive mode: simple bright white text.
+     Also overrides the sidebar's karaoke gradient + transparent fill so the
+     active line stays solid white instead of gradient-clipped. */
   .lyrics-lines.immersive .lyrics-line.active .line-text {
+    background: none;
     color: #ffffff !important;
+    -webkit-text-fill-color: #ffffff;
   }
 
   /* Past lines in immersive should be clearly dimmer than active */
@@ -342,16 +428,26 @@
     overflow-wrap: break-word;
   }
 
-  /* Active line: mirror the base transitions. `transition` is shorthand
-     so it must be re-declared in full here, otherwise the size/scale/
-     color animations would be dropped on activation. */
+  /* Register --line-progress as an animatable number so CSS can interpolate
+     the gradient stop position between block notifications. */
+  @property --line-progress {
+    syntax: '<number>';
+    inherits: true;
+    initial-value: 0;
+  }
+
+  /* Active line: mirror the base transitions and add --line-progress
+     (interpolated over --block-interval, set per-line in JS to match audio
+     speed). Re-declaring the full list because `transition` is shorthand
+     and would otherwise drop the size/scale/color animations on activation. */
   .lyrics-line.active {
     transition:
       opacity 220ms ease-out,
       color 220ms ease-out,
       font-size 220ms cubic-bezier(0.4, 0, 0.2, 1),
       font-weight 220ms ease-out,
-      transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
+      transform 220ms cubic-bezier(0.4, 0, 0.2, 1),
+      --line-progress var(--block-interval, 175ms) linear;
   }
 
   .lyrics-lines.center .lyrics-line {
@@ -368,35 +464,43 @@
     font-weight: 700;
     opacity: 1;
     transform: scale(1.02);
-    /* Use filter: drop-shadow on the parent — text-shadow inherits into the
-       background-clipped span and tints the gradient on WebKit (macOS). */
-    filter:
-      drop-shadow(0 1px 3px rgba(0, 0, 0, 0.6))
-      drop-shadow(0 0 12px color-mix(in srgb, var(--lyrics-active-color, var(--accent-primary)) 35%, transparent));
+    /* No text-shadow or filter on the active line — text-shadow inherits
+       into the background-clipped span and tints the gradient on WebKit
+       (macOS), while filter: drop-shadow rasterizes the line at its
+       layout box and clips descenders (g, y, p). Bold + scale + colored
+       gradient is enough emphasis without either. */
   }
 
   .lyrics-lines.center .lyrics-line.active {
     transform: scale(1.05);
   }
 
-  /* Shimmer karaoke effect on active line */
+  /* Karaoke effect on active line — hard cut at the playhead.
+     Visual smoothness comes from --line-progress transitioning over
+     --block-interval; the gradient is a sharp two-color split moving
+     with that transition. The +1% bias on the playhead stops pushes the
+     cut just past 100% at p=1, guaranteeing the rightmost text pixels
+     are in the active color (so the last line of a song reliably fills
+     during the trailing instrumental coda). */
   .lyrics-line.active .line-text {
     --progress-pos: calc(var(--line-progress, 0) * 100%);
     background: linear-gradient(
       90deg,
       var(--lyrics-active-color, var(--accent-primary)) 0%,
-      var(--lyrics-active-color, var(--accent-primary)) var(--progress-pos),
-      var(--text-primary) var(--progress-pos),
+      var(--lyrics-active-color, var(--accent-primary)) calc(var(--progress-pos) + 1%),
+      var(--text-primary) calc(var(--progress-pos) + 1%),
       var(--text-primary) 100%
     );
     -webkit-background-clip: text;
     background-clip: text;
     color: transparent;
     -webkit-text-fill-color: transparent;
-    /* Suppress inherited text-shadow — on WebKit (macOS) shadows render in
-       the text-glyph shape and tint the gradient-clipped fill, making the
-       active line look dim/red instead of crisp. */
-    text-shadow: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .lyrics-line.active {
+      transition: none;
+    }
   }
 
   .lyrics-empty {

--- a/src/lib/components/lyrics/LyricsSidebar.svelte
+++ b/src/lib/components/lyrics/LyricsSidebar.svelte
@@ -7,6 +7,8 @@
 
   interface LyricsLine {
     text: string;
+    timeMs?: number;
+    endMs?: number;
   }
 
   interface Props {

--- a/src/lib/components/lyrics/LyricsSidebar.svelte
+++ b/src/lib/components/lyrics/LyricsSidebar.svelte
@@ -4,12 +4,7 @@
   import LyricsLines from './LyricsLines.svelte';
   import LyricsControlsPopover from './LyricsControlsPopover.svelte';
   import { lyricsDisplayStore } from '$lib/stores/lyricsDisplayStore';
-
-  interface LyricsLine {
-    text: string;
-    timeMs?: number;
-    endMs?: number;
-  }
+  import type { LyricsLine } from '$lib/stores/lyricsStore';
 
   interface Props {
     title?: string;

--- a/src/lib/stores/lyricsStore.ts
+++ b/src/lib/stores/lyricsStore.ts
@@ -25,6 +25,10 @@ export interface LyricsPayload {
 export interface LyricsLine {
   timeMs: number;
   text: string;
+  // Optional end-of-vocal timestamp. Set from an empty-text LRC marker
+  // following this line, when present. Lets us cap progress to the actual
+  // sung portion and hold at 1.0 through an instrumental gap.
+  endMs?: number;
 }
 
 export interface ParsedLyrics {
@@ -125,7 +129,11 @@ export function getLyricsState(): LyricsState {
  * Supports: [mm:ss.xx], [mm:ss.xxx], [mm:ss]
  */
 function parseLRC(lrc: string): LyricsLine[] {
-  const lines: LyricsLine[] = [];
+  // Two-pass: first collect every timestamp (incl. empty-text "gap" markers
+  // like [02:34.00] used to mark end-of-vocal before an instrumental break),
+  // then emit only the text-bearing lines with each one's endMs derived from
+  // the following timestamp (whether text or gap).
+  const stamps: { timeMs: number; text: string }[] = [];
   const regex = /\[(\d{1,2}):(\d{2})(?:[.:](\d{2,3}))?\](.*)/g;
 
   let match;
@@ -134,15 +142,44 @@ function parseLRC(lrc: string): LyricsLine[] {
     const seconds = Number.parseInt(match[2], 10);
     const ms = match[3] ? Number.parseInt(match[3].padEnd(3, '0'), 10) : 0;
     const text = match[4].trim();
-
-    if (text) {
-      const timeMs = (minutes * 60 + seconds) * 1000 + ms;
-      lines.push({ timeMs, text });
-    }
+    const timeMs = (minutes * 60 + seconds) * 1000 + ms;
+    stamps.push({ timeMs, text });
   }
 
-  // Sort by time
-  lines.sort((a, b) => a.timeMs - b.timeMs);
+  stamps.sort((a, b) => a.timeMs - b.timeMs);
+
+  // Cap any single line's sung duration. Anything beyond this is almost
+  // certainly an instrumental gap the LRC didn't mark — capping prevents
+  // the karaoke gradient from creeping across silence.
+  const MAX_SUNG_MS = 8000;
+
+  const lines: LyricsLine[] = [];
+  for (let i = 0; i < stamps.length; i++) {
+    const stamp = stamps[i];
+    if (!stamp.text) continue; // gap marker — never displayed, only bounds previous line
+    const nextStamp = stamps[i + 1];
+    const cap = stamp.timeMs + MAX_SUNG_MS;
+    const endMs = nextStamp ? Math.min(nextStamp.timeMs, cap) : undefined;
+    lines.push({ timeMs: stamp.timeMs, text: stamp.text, endMs });
+  }
+
+  // Last line has no following stamp; the previous default of 5s was
+  // visibly slow on songs that end with a short vocal phrase followed by
+  // an instrumental coda. Estimate from the median of preceding lines'
+  // sung durations — a more song-appropriate fallback.
+  if (lines.length >= 2 && lines[lines.length - 1].endMs === undefined) {
+    const durations: number[] = [];
+    for (let i = 0; i < lines.length - 1; i++) {
+      const d = (lines[i].endMs ?? lines[i + 1].timeMs) - lines[i].timeMs;
+      if (d > 0) durations.push(d);
+    }
+    if (durations.length > 0) {
+      durations.sort((a, b) => a - b);
+      const median = durations[Math.floor(durations.length / 2)];
+      const last = lines[lines.length - 1];
+      last.endMs = last.timeMs + Math.min(median, MAX_SUNG_MS);
+    }
+  }
 
   return lines;
 }
@@ -210,13 +247,11 @@ function calculateLineProgress(lines: LyricsLine[], index: number, currentTimeMs
   const currentLine = lines[index];
   const nextLine = lines[index + 1];
 
-  if (!nextLine) {
-    // Last line - assume 5 seconds duration
-    const duration = 5000;
-    return Math.min(1, (currentTimeMs - currentLine.timeMs) / duration);
-  }
-
-  const lineDuration = nextLine.timeMs - currentLine.timeMs;
+  // Prefer endMs (sung-portion boundary from LRC gap marker) over next
+  // line's start, so we hit 1.0 when the singer actually stops, and hold
+  // there through any instrumental gap before the next line.
+  const boundMs = currentLine.endMs ?? nextLine?.timeMs ?? currentLine.timeMs + 5000;
+  const lineDuration = boundMs - currentLine.timeMs;
   if (lineDuration <= 0) return 0;
 
   return Math.min(1, (currentTimeMs - currentLine.timeMs) / lineDuration);

--- a/src/lib/stores/lyricsStore.ts
+++ b/src/lib/stores/lyricsStore.ts
@@ -254,7 +254,13 @@ function calculateLineProgress(lines: LyricsLine[], index: number, currentTimeMs
   const lineDuration = boundMs - currentLine.timeMs;
   if (lineDuration <= 0) return 0;
 
-  return Math.min(1, (currentTimeMs - currentLine.timeMs) / lineDuration);
+  const ratio = (currentTimeMs - currentLine.timeMs) / lineDuration;
+  // Snap to 1 once we're effectively done — guards against any audio-time
+  // reporting quirk that would otherwise keep the ratio at e.g. 0.998
+  // forever and leave the karaoke gradient with a stuck 0.2% tail.
+  if (ratio >= 0.99) return 1;
+  if (ratio <= 0) return 0;
+  return ratio;
 }
 
 /**

--- a/src/lib/stores/lyricsStore.ts
+++ b/src/lib/stores/lyricsStore.ts
@@ -306,13 +306,19 @@ export function updateActiveLine(): void {
     return;
   }
 
-  // Full tracking: notify on any change. Threshold-based throttling made
-  // sense with setInterval ticks at 80–200ms, but our rAF tick gives us a
-  // natural 60Hz upper bound — and at any threshold > 0, a freshly-activated
-  // line freezes visually until the threshold is crossed (reads as a
-  // "hanging" pause at line start). Each notification is just an inline
-  // style update downstream, so per-tick cost is negligible.
-  if (newIndex !== activeIndex || newProgress !== activeProgress) {
+  // Notify on any actual change. With playerStore now extrapolating audio
+  // position between backend ticks (250ms → ~16ms granularity), each rAF
+  // call sees a freshly-changed progress value. Threshold-based
+  // throttling here would re-introduce the "starts midway" / "ends before
+  // 100%" bugs by skipping the edge-of-line samples where the snap-to-1
+  // and indexChanged transitions need to land.
+  //
+  // Downstream consumers in +page.svelte short-circuit no-op $state
+  // writes via equality guards, so a 60Hz notification only fans out
+  // reactivity for the field(s) that actually changed.
+  const indexChanged = newIndex !== activeIndex;
+  const progressChanged = newProgress !== activeProgress;
+  if (indexChanged || progressChanged) {
     activeIndex = newIndex;
     activeProgress = newProgress;
     notifyListeners();
@@ -497,16 +503,17 @@ export function startActiveLineUpdates(): void {
     console.log('[Lyrics] Starting active line updates (rAF)');
   }
 
+  // Claim the next-frame slot BEFORE running work so the guard above sees
+  // a non-null handle if any listener synchronously re-enters
+  // startActiveLineUpdates during notifyListeners(). Otherwise we'd
+  // schedule a second parallel rAF chain.
   const tick = (): void => {
+    updateRafHandle = requestAnimationFrame(tick);
     if (!isUpdatesActive || !parsedLyrics.isSynced) {
-      if (import.meta.env.DEV) {
-        console.log('[Lyrics] Auto-stopping rAF (conditions no longer met)');
-      }
       stopActiveLineUpdates();
       return;
     }
     updateActiveLine();
-    updateRafHandle = requestAnimationFrame(tick);
   };
 
   updateRafHandle = requestAnimationFrame(tick);

--- a/src/lib/stores/lyricsStore.ts
+++ b/src/lib/stores/lyricsStore.ts
@@ -443,7 +443,7 @@ export function reset(): void {
 
 // ============ Auto-update ============
 
-let updateInterval: number | null = null;
+let updateRafHandle: number | null = null;
 let isUpdatesActive = false;
 let trackProgressEnabled = true; // When false, only track index changes (no karaoke)
 
@@ -451,7 +451,7 @@ let trackProgressEnabled = true; // When false, only track index changes (no kar
  * Check if active line updates are currently running
  */
 export function isActiveLineUpdatesRunning(): boolean {
-  return updateInterval !== null;
+  return updateRafHandle !== null;
 }
 
 /**
@@ -467,55 +467,39 @@ export function setProgressTrackingEnabled(enabled: boolean): void {
 }
 
 /**
- * Calculate optimal update interval based on lyrics density.
- * Faster songs need faster updates, slower songs can use longer intervals.
+ * Start auto-updating active line (call when lyrics are synced and playing).
  *
- * Performance optimization: reduces CPU usage by 50-80% for most songs.
- */
-function calculateOptimalInterval(lines: LyricsLine[]): number {
-  if (lines.length < 2) return 200;
-
-  // Find the minimum gap between consecutive lines
-  let minGap = Infinity;
-  for (let i = 1; i < Math.min(lines.length, 50); i++) {
-    const gap = lines[i].timeMs - lines[i - 1].timeMs;
-    if (gap > 100 && gap < minGap) {
-      minGap = gap;
-    }
-  }
-
-  // Update interval = 1/4 of shortest line duration
-  // Minimum 80ms (12.5 fps), maximum 200ms (5 fps)
-  // This provides smooth karaoke progress without excessive CPU usage
-  const interval = Math.max(80, Math.min(200, Math.floor(minGap / 4)));
-
-  return interval;
-}
-
-/**
- * Start auto-updating active line (call when lyrics are synced and playing)
+ * Driven by requestAnimationFrame so line-boundary transitions are detected
+ * within one display frame (~16ms) instead of the 80–200ms a setInterval
+ * could miss them by. updateActiveLine itself still gates notifications via
+ * the progress threshold, so re-render rate downstream is unchanged — only
+ * detection latency improves.
+ *
+ * rAF pauses in background tabs, which is the desired behavior: when the
+ * user can't see the lyrics, there's no reason to keep updating them.
  */
 export function startActiveLineUpdates(): void {
-  if (updateInterval !== null) return;
+  if (updateRafHandle !== null) return;
 
   isUpdatesActive = true;
-  const interval = calculateOptimalInterval(parsedLyrics.lines);
 
   if (import.meta.env.DEV) {
-    console.log(`[Lyrics] Starting updates at ${interval}ms interval`);
+    console.log('[Lyrics] Starting active line updates (rAF)');
   }
 
-  updateInterval = window.setInterval(() => {
-    // Self-check: stop if no longer needed
+  const tick = (): void => {
     if (!isUpdatesActive || !parsedLyrics.isSynced) {
       if (import.meta.env.DEV) {
-        console.log('[Lyrics] Auto-stopping interval (conditions no longer met)');
+        console.log('[Lyrics] Auto-stopping rAF (conditions no longer met)');
       }
       stopActiveLineUpdates();
       return;
     }
     updateActiveLine();
-  }, interval);
+    updateRafHandle = requestAnimationFrame(tick);
+  };
+
+  updateRafHandle = requestAnimationFrame(tick);
 }
 
 /**
@@ -523,12 +507,12 @@ export function startActiveLineUpdates(): void {
  */
 export function stopActiveLineUpdates(): void {
   isUpdatesActive = false;
-  if (updateInterval !== null) {
+  if (updateRafHandle !== null) {
     if (import.meta.env.DEV) {
       console.log('[Lyrics] Stopping active line updates');
     }
-    clearInterval(updateInterval);
-    updateInterval = null;
+    cancelAnimationFrame(updateRafHandle);
+    updateRafHandle = null;
   }
 }
 

--- a/src/lib/stores/lyricsStore.ts
+++ b/src/lib/stores/lyricsStore.ts
@@ -300,9 +300,13 @@ export function updateActiveLine(): void {
     return;
   }
 
-  // Full tracking: notify if index changed or progress moved significantly (3% threshold)
-  // This reduces re-renders by ~60% while maintaining smooth karaoke visual
-  if (newIndex !== activeIndex || Math.abs(newProgress - activeProgress) > 0.03) {
+  // Full tracking: notify on any change. Threshold-based throttling made
+  // sense with setInterval ticks at 80–200ms, but our rAF tick gives us a
+  // natural 60Hz upper bound — and at any threshold > 0, a freshly-activated
+  // line freezes visually until the threshold is crossed (reads as a
+  // "hanging" pause at line start). Each notification is just an inline
+  // style update downstream, so per-tick cost is negligible.
+  if (newIndex !== activeIndex || newProgress !== activeProgress) {
     activeIndex = newIndex;
     activeProgress = newProgress;
     notifyListeners();

--- a/src/lib/stores/playerStore.ts
+++ b/src/lib/stores/playerStore.ts
@@ -165,6 +165,25 @@ let currentTrack: PlayingTrack | null = null;
 let isPlaying = false;
 let currentTime = 0;
 let duration = 0;
+
+// Wall-clock anchor for currentTime extrapolation. The Rust backend emits
+// position events at 250ms cadence — at 60Hz rAF, getCurrentTime() would
+// otherwise return a staircase that's frozen for ~15 frames between
+// updates, causing karaoke lyrics to start "midway" (detection lag) and
+// to end before the gradient reaches the end (final-segment cutoff).
+//
+// We anchor (audio position, wall clock) on every event-driven update,
+// then extrapolate forward at 1x while playing. Backend position is
+// already wall-clock-based on the Rust side (see lib.rs comment near the
+// 250ms emit loop), so JS extrapolation does the same math the backend
+// is doing — no semantic divergence, just finer time resolution.
+let positionAnchorWallClockMs = 0;
+let positionAnchorSecs = 0;
+
+function anchorPosition(secs: number): void {
+  positionAnchorSecs = secs;
+  positionAnchorWallClockMs = performance.now();
+}
 let volume = loadPersistedVolume();
 let preMuteVolume: number | null = null; // Volume before mute, null when not muted
 let isFavorite = false;
@@ -238,7 +257,15 @@ export function getIsPlaying(): boolean {
 }
 
 export function getCurrentTime(): number {
-  return currentTime;
+  // When paused or before the first anchor, return the stored value
+  // (which is what listeners last persisted). While playing, extrapolate
+  // from the anchor at 1x audio rate.
+  if (!isPlaying || positionAnchorWallClockMs === 0) return currentTime;
+  const elapsedSecs = (performance.now() - positionAnchorWallClockMs) / 1000;
+  // Cap extrapolation at 1s to bound drift if the backend stops emitting
+  // (network stall on cast, suspended audio thread). After the cap, we
+  // freeze at the last + cap rather than runway indefinitely.
+  return positionAnchorSecs + Math.min(elapsedSecs, 1);
 }
 
 export function getDuration(): number {
@@ -368,11 +395,13 @@ export function setCurrentTrack(track: PlayingTrack | null): void {
     };
     duration = track.duration;
     currentTime = 0;
+    anchorPosition(0);
     queueEnded = false;
   } else {
     currentTrack = null;
     duration = 0;
     currentTime = 0;
+    anchorPosition(0);
   }
   notifyListeners();
 }
@@ -553,6 +582,7 @@ export function setIsPlaying(playing: boolean): void {
 export async function seek(position: number): Promise<void> {
   const clampedPosition = Math.max(0, Math.min(duration, position));
   currentTime = clampedPosition;
+  anchorPosition(clampedPosition);
   notifyListeners();
 
   try {
@@ -649,6 +679,7 @@ export async function stop(): Promise<void> {
     isPlaying = false;
     currentTrack = null;
     currentTime = 0;
+    anchorPosition(0);
     duration = 0;
     gaplessAttemptTrackId = null;
     gaplessRequestInFlight = false;
@@ -803,6 +834,7 @@ async function handlePlaybackEvent(event: PlaybackEvent): Promise<void> {
         duration = queueTrack.duration_secs;
         // Update playback state from event
         currentTime = event.position;
+        anchorPosition(event.position);
         isPlaying = event.is_playing;
         // Sync volume from backend
         volume = Math.round(event.volume * 100);
@@ -879,6 +911,7 @@ async function handlePlaybackEvent(event: PlaybackEvent): Promise<void> {
       const target = seekTargetPosition;
       if (target === null) {
         currentTime = toDisplayed(event.position);
+        anchorPosition(currentTime);
         isPlaying = event.is_playing;
         return;
       }
@@ -887,6 +920,7 @@ async function handlePlaybackEvent(event: PlaybackEvent): Promise<void> {
         seekTargetPosition = null;
         seekGuardUntilMs = 0;
         currentTime = toDisplayed(event.position);
+        anchorPosition(currentTime);
       } else {
         // Ignore stale position updates briefly after seek to avoid UI snap-back.
       }
@@ -896,6 +930,7 @@ async function handlePlaybackEvent(event: PlaybackEvent): Promise<void> {
         seekGuardUntilMs = 0;
       }
       currentTime = toDisplayed(event.position);
+      anchorPosition(currentTime);
     }
     isPlaying = event.is_playing;
 
@@ -1017,6 +1052,7 @@ export async function startPolling(): Promise<void> {
         const castPos = getCastPosition();
         if (castPos.positionSecs !== currentTime) {
           currentTime = castPos.positionSecs;
+          anchorPosition(castPos.positionSecs);
           notifyListeners();
         }
       }
@@ -1067,6 +1103,7 @@ export function reset(): void {
   currentTrack = null;
   isPlaying = false;
   currentTime = 0;
+  anchorPosition(0);
   duration = 0;
   isFavorite = false;
   isAdvancingTrack = false;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -6653,7 +6653,7 @@
       <LyricsSidebar
         title={currentTrack?.title}
         artist={currentTrack?.artist}
-        lines={lyricsLines.map(l => ({ text: l.text }))}
+        lines={lyricsLines.map(l => ({ text: l.text, timeMs: l.timeMs, endMs: l.endMs }))}
         activeIndex={lyricsActiveIndex}
         activeProgress={lyricsActiveProgress}
         isSynced={lyricsIsSynced}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1104,6 +1104,14 @@
   let lyricsActiveProgress = $state(0);
   let lyricsSidebarVisible = $state(false);
 
+  // Memoize the line projection so the LyricsSidebar's `lines` prop doesn't
+  // get a fresh array reference on every progress tick (which would
+  // re-render the entire <LyricsLines> subtree and thrash the karaoke
+  // animation snapshot).
+  const lyricsSidebarLines = $derived(
+    lyricsLines.map((l) => ({ text: l.text, timeMs: l.timeMs, endMs: l.endMs }))
+  );
+
   let favoritesDefaultTab = $state<FavoritesTab>('tracks');
 
   async function loadFavoritesDefaultTab(): Promise<void> {
@@ -6653,7 +6661,7 @@
       <LyricsSidebar
         title={currentTrack?.title}
         artist={currentTrack?.artist}
-        lines={lyricsLines.map(l => ({ text: l.text, timeMs: l.timeMs, endMs: l.endMs }))}
+        lines={lyricsSidebarLines}
         activeIndex={lyricsActiveIndex}
         activeProgress={lyricsActiveProgress}
         isSynced={lyricsIsSynced}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1104,10 +1104,11 @@
   let lyricsActiveProgress = $state(0);
   let lyricsSidebarVisible = $state(false);
 
-  // Memoize the line projection so the LyricsSidebar's `lines` prop doesn't
-  // get a fresh array reference on every progress tick (which would
-  // re-render the entire <LyricsLines> subtree and thrash the karaoke
-  // animation snapshot).
+  // Hoisted out of the LyricsSidebar template so the `lines` prop only
+  // re-computes when lyricsLines itself changes — not on every re-render
+  // of +page triggered by other reactive state (progress ticks, etc.).
+  // Note: $derived re-evaluates lazily on dep change; it does not deep-
+  // compare, so this is not a memoization in the React useMemo sense.
   const lyricsSidebarLines = $derived(
     lyricsLines.map((l) => ({ text: l.text, timeMs: l.timeMs, endMs: l.endMs }))
   );
@@ -5061,15 +5062,19 @@
       repeatMode = queueState.repeatMode;
     });
 
-    // Subscribe to lyrics state changes
+    // Subscribe to lyrics state changes. Listener fires per progress tick
+    // (~12–30 Hz); guard each $state write with a reference/value check so
+    // we only fan out reactivity for fields that actually changed —
+    // critical for `lyricsLines`, which feeds a $derived `.map()` that
+    // would otherwise re-project N objects per tick.
     const unsubscribeLyrics = subscribeLyrics(() => {
       const state = getLyricsState();
-      lyricsStatus = state.status;
-      lyricsError = state.error;
-      lyricsLines = state.lines;
-      lyricsIsSynced = state.isSynced;
-      lyricsActiveIndex = state.activeIndex;
-      lyricsActiveProgress = state.activeProgress;
+      if (lyricsStatus !== state.status) lyricsStatus = state.status;
+      if (lyricsError !== state.error) lyricsError = state.error;
+      if (lyricsLines !== state.lines) lyricsLines = state.lines;
+      if (lyricsIsSynced !== state.isSynced) lyricsIsSynced = state.isSynced;
+      if (lyricsActiveIndex !== state.activeIndex) lyricsActiveIndex = state.activeIndex;
+      if (lyricsActiveProgress !== state.activeProgress) lyricsActiveProgress = state.activeProgress;
       // Close network sidebar and queue when lyrics opens; restore when it closes
       if (state.sidebarVisible && !lyricsSidebarVisible) {
         closeContentSidebar('network');


### PR DESCRIPTION
## Summary

Started as a one-line fix for the macOS WebKit bug where the active lyric line rendered dim/red instead of crisp colored text. While verifying the fix, several other karaoke playback issues that the inert WebKit rendering had been masking became apparent (jittery block-stepped playhead, "stuck at start" line activations, descender clipping on active lines, last line of a song never visually filling). Rather than ship them as separate PRs, this branch addresses them as one layered series — **expect a lot of iteration in the commit log**; each commit is atomic and labelled, and reading them in order tells the story.

<table>
<tr>
 <td>Before
 <td>After 1
 <td>After 2
<tr>
 <td><img width="233" height="108" alt="image" src="https://github.com/user-attachments/assets/06afb45e-4022-4df2-82eb-9cd417cd78e2" />
 <td><img width="213" height="74" alt="image" src="https://github.com/user-attachments/assets/cd0e490d-05f2-4a8e-85af-a7064416bf0e" />
 <td><img width="272" height="229" alt="image" src="https://github.com/user-attachments/assets/922ede51-9871-424f-941f-144c97aafc2b" />
</table>


## What changed

**Rendering**
- macOS WebKit active-line color (the original bug)
- `.line-text` → `display: block` + `padding-bottom: 0.15em` to expand WebKit's `background-clip: text` paint area enough for descenders (g/y/p/q) to render
- Single-`<div>`-per-line template with class toggles, so CSS transitions actually animate active↔past instead of being killed by destroy-and-recreate
- Active-line gradient now splits per visual line via [`@chenglou/pretext`](https://www.npmjs.com/package/@chenglou/pretext). Each wrapped line gets its own block-level `<span>` with its own 0→100% gradient, so wrapped lyrics fill sequentially (line 2 doesn't appear pre-sung when only line 1 has played)

**Parser**
- LRC parser preserves empty-text gap markers (`endMs`), caps sung duration at 8s, falls back to per-song median for the last line — stops the karaoke gradient from creeping across instrumental silence

**Timing pipeline**
- Active-line tick loop moves from `setInterval(80–200ms)` to rAF (~16ms boundary-detection latency)
- **`playerStore.getCurrentTime()` now extrapolates audio time between backend `playback:state` events**. The Rust backend emits at 250ms cadence, so the previous staircase value caused the rAF loop to see the same answer for ~15 frames, then a 250ms jump. This was the root cause of two visible artifacts: lines appearing to start midway (detection lag of up to 250ms past `timeMs`) and lines being demoted before the highlight reached 100% (last in-line sample reports ~92% before the next backend tick crosses the boundary). Anchoring `(positionSecs, performance.now())` on each event and returning `anchor + elapsed` while playing converts the staircase into a smooth ramp, with the 250ms backend cycle providing correction.
- Notify on every change (no per-tick threshold) now that the data feed is smooth
- Snap progress to 1.0 once `ratio ≥ 0.99` so the last paint always lands at the line's true end

**JS-driven karaoke layer**
- Registered `@property --line-progress` for animatable interpolation
- EMA-measured `--block-interval` matches real audio cadence; measured-delta lookahead so the visual leads audio by one block to absorb the inherent 1-block lag
- `activeProgress` as karaoke floor (not gate) — fixes the "last line never goes through" case where `lookaheadEnabled` failed to flip on
- Lower EMA `dt` floor from 50ms → 5ms so rAF-rate measurements actually qualify (they were silently rejected, leaving `measuredBlockMs` pinned at the seed → visible lag)
- Seed `measuredBlockMs` lowered to ≥20ms now that rAF-rate data converges the EMA within 2–3 ticks
- Lookahead clamped at 1/30 and disabled on backward `dp` so coarse audio jumps and in-line seeks can't poison the visual lead
- EMA writes equality-guarded so Svelte signals don't fan out no-op updates at 60Hz

**Race & lifecycle hardening**
- `startActiveLineUpdates` claims its rAF handle *before* invoking work — a listener that synchronously re-enters the function during `notifyListeners()` is now a no-op instead of scheduling a parallel rAF chain
- Cancellation token on `tick().then(layoutActiveLine)` so rapid `activeIndex` changes (seek-scrub, fast songs) don't queue stale microtasks that lay out the wrong line
- ResizeObserver coalesces via rAF and ignores sub-pixel width deltas, so window-drag and the active-line scale animation don't trigger Pretext re-measurement on every callback
- `segmentBounds` prefix array memoizes cumulative widths, dropping per-segment progress lookup from O(i) to O(1)
- `+page.svelte` subscriber guards every `$state` write with a reference/value check, so the per-rAF-tick path only fans out reactivity for fields that actually changed (in practice: just `lyricsActiveProgress`)

## Caveats / known imperfections

- Measurement parameters (EMA factor 0.7, `dt ≥ 5ms` floor, 0.99 snap threshold, +1s extrapolation cap, 1/30 lookahead clamp) are empirical, not exhaustively tuned
- `display: block` + `padding-bottom` is the known WebKit workaround, but the underlying inline-paint-area behaviour is brittle
- Pretext (`@chenglou/pretext@0.0.7`) is a pre-1.0 dependency. A pure-CSS replacement using `box-decoration-break: clone` was considered but doesn't give sequential per-line fill — the visual line widths need to be measured. Removable if we accept "same gradient cut across all wrapped lines" as a tradeoff
- LRC files with phrase-level (not syllable-level) timestamps can still show small "starts midway" effects when the timestamp marks the phrase boundary but the singer begins later — there's no way to recover the true vocal start without finer timing data
- Manually verified on Planet Telex, Fake Plastic Trees (Radiohead / The Bends), Narrator (Squid), O Espama Não Presta, Espamah Montana a Mixtape, Espama Trincana (last three are fast-cadence — worst case for any timing-detection lag)

## Test plan

- [x] Active line color renders correctly on macOS sidebar
- [x] Karaoke sweep moves smoothly with the vocal, no visible step-blocks or 250ms staircase
- [x] A new line activates at p≈0 and doesn't hang
- [x] Last line of a song with an instrumental coda fills fully and stays filled
- [x] Wrapped active lines fill sequentially (line 1 fully sung before line 2 starts), not all at once
- [x] Descenders (g/y/p/q) render fully on the active line
- [x] Past lines fade smoothly when activeIndex moves on
- [x] Window resize during playback doesn't stutter the karaoke or thrash Pretext
- [x] Seek (scrub-jump) within a song lands the gradient at the correct position immediately
- [x] Pause/resume mid-line preserves gradient position
- [x] No regressions in immersive mode (solid white active line)
