### PR TITLE
fix(views): close other dropdown filters when opening one

### DIFF
--- a/src/lib/components/GenreFilterButton.svelte
+++ b/src/lib/components/GenreFilterButton.svelte
@@ -22,11 +22,11 @@
     context?: GenreFilterContext;
     variant?: ButtonVariant;
     align?: DropdownAlign;
+    isOpen?: boolean;
   }
 
-  let { onFilterChange, context = 'home', variant = 'default', align = 'left' }: Props = $props();
+  let { onFilterChange, context = 'home', variant = 'default', align = 'left', isOpen = $bindable(false) }: Props = $props();
 
-  let isOpen = $state(false);
   let buttonEl = $state<HTMLButtonElement | null>(null);
   let hasFilter = $state(false);
   let selectedGenreName = $state<string | null>(null);

--- a/src/lib/components/views/ArtistDetailView.svelte
+++ b/src/lib/components/views/ArtistDetailView.svelte
@@ -425,23 +425,48 @@
   } as const;
 
   let albumSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.ALBUMS));
-  let showAlbumSortMenu = $state(false);
   let epsSinglesSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.EPS_SINGLES));
-  let showEpsSinglesSortMenu = $state(false);
   let liveAlbumsSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.LIVE_ALBUMS));
-  let showLiveAlbumsSortMenu = $state(false);
   let compilationsSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.COMPILATIONS));
-  let showCompilationsSortMenu = $state(false);
   let tributesSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.TRIBUTES));
-  let showTributesSortMenu = $state(false);
   let tributesExpanded = $state(false); // Collapsed by default
   let tributesVisibleCount = $state(20); // Load 20 at a time
   let othersSortMode = $state<AlbumSortMode>(loadAlbumSortMode(STORAGE_SORT_KEYS.OTHERS));
-  let showOthersSortMenu = $state(false);
+
+  // Mutually-exclusive section sort menus. Only one menu is open at a time.
+  type OpenSortMenu =
+    | 'albums'
+    | 'epsSingles'
+    | 'liveAlbums'
+    | 'compilations'
+    | 'tributes'
+    | 'others'
+    | null;
+  let openSortMenu = $state<OpenSortMenu>(null);
 
   // Popular tracks display state
   let visibleTracksCount = $state(5);
   let showTracksContextMenu = $state(false);
+
+  // Close the popular-tracks context menu on clicks outside its trigger or panel.
+  $effect(() => {
+    if (!showTracksContextMenu) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.action-btn-circle') || target.closest('.context-menu')) return;
+      showTracksContextMenu = false;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   function loadAlbumSortMode(key: string, fallback: AlbumSortMode = 'default'): AlbumSortMode {
     try {
@@ -713,12 +738,17 @@
     }
   });
 
-  // Close sort menu when clicking outside
+  // Close any open sort menu when clicking outside it. Clicks on any
+  // sort button or sort menu are handled by the button's own onclick so
+  // switching between sections doesn't immediately collapse the new menu.
   $effect(() => {
-    if (!showAlbumSortMenu) return;
+    if (openSortMenu === null) return;
 
-    function handleClick() {
-      showAlbumSortMenu = false;
+    function handleClick(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.sort-btn') || target.closest('.sort-menu')) return;
+      openSortMenu = null;
     }
 
     // Delay to avoid closing immediately
@@ -2141,7 +2171,6 @@
                 <Ellipsis size={18} />
               </button>
               {#if showTracksContextMenu}
-                <div class="context-menu-backdrop" onclick={() => showTracksContextMenu = false} role="presentation"></div>
                 <div class="context-menu">
                   <button class="context-menu-item" onclick={() => { handlePlayAllTracksNext(); showTracksContextMenu = false; }}>
                     {$t('actions.playNext')}
@@ -2371,7 +2400,7 @@
       </div>
       <!-- Album Sort Dropdown -->
       <div class="sort-dropdown">
-        <button class="sort-btn" onclick={() => (showAlbumSortMenu = !showAlbumSortMenu)}>
+        <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'albums' ? null : 'albums')}>
           <span>
             {#if albumSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
             {:else if albumSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2382,40 +2411,40 @@
           </span>
           <ChevronDown size={14} />
         </button>
-        {#if showAlbumSortMenu}
+        {#if openSortMenu === 'albums'}
           <div class="sort-menu">
             <button
               class="sort-item"
               class:selected={albumSortMode === 'default'}
-              onclick={() => { albumSortMode = 'default'; showAlbumSortMenu = false; }}
+              onclick={() => { albumSortMode = 'default'; openSortMenu = null; }}
             >
               {$t('sort.default')}
             </button>
             <button
               class="sort-item"
               class:selected={albumSortMode === 'newest'}
-              onclick={() => { albumSortMode = 'newest'; showAlbumSortMenu = false; }}
+              onclick={() => { albumSortMode = 'newest'; openSortMenu = null; }}
             >
               {$t('sort.newest')}
             </button>
             <button
               class="sort-item"
               class:selected={albumSortMode === 'oldest'}
-              onclick={() => { albumSortMode = 'oldest'; showAlbumSortMenu = false; }}
+              onclick={() => { albumSortMode = 'oldest'; openSortMenu = null; }}
             >
               {$t('sort.oldest')}
             </button>
             <button
               class="sort-item"
               class:selected={albumSortMode === 'title-asc'}
-              onclick={() => { albumSortMode = 'title-asc'; showAlbumSortMenu = false; }}
+              onclick={() => { albumSortMode = 'title-asc'; openSortMenu = null; }}
             >
               {$t('sort.titleAZ')}
             </button>
             <button
               class="sort-item"
               class:selected={albumSortMode === 'title-desc'}
-              onclick={() => { albumSortMode = 'title-desc'; showAlbumSortMenu = false; }}
+              onclick={() => { albumSortMode = 'title-desc'; openSortMenu = null; }}
             >
               {$t('sort.titleZA')}
             </button>
@@ -2470,7 +2499,7 @@
           <span class="section-count">{artist.epsSingles.length}</span>
         </div>
         <div class="sort-dropdown">
-          <button class="sort-btn" onclick={() => (showEpsSinglesSortMenu = !showEpsSinglesSortMenu)}>
+          <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'epsSingles' ? null : 'epsSingles')}>
             <span>
               {#if epsSinglesSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
               {:else if epsSinglesSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2481,13 +2510,13 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showEpsSinglesSortMenu}
+          {#if openSortMenu === 'epsSingles'}
             <div class="sort-menu">
-              <button class="sort-item" class:selected={epsSinglesSortMode === 'default'} onclick={() => { epsSinglesSortMode = 'default'; showEpsSinglesSortMenu = false; }}>{$t('sort.default')}</button>
-              <button class="sort-item" class:selected={epsSinglesSortMode === 'newest'} onclick={() => { epsSinglesSortMode = 'newest'; showEpsSinglesSortMenu = false; }}>{$t('sort.newest')}</button>
-              <button class="sort-item" class:selected={epsSinglesSortMode === 'oldest'} onclick={() => { epsSinglesSortMode = 'oldest'; showEpsSinglesSortMenu = false; }}>{$t('sort.oldest')}</button>
-              <button class="sort-item" class:selected={epsSinglesSortMode === 'title-asc'} onclick={() => { epsSinglesSortMode = 'title-asc'; showEpsSinglesSortMenu = false; }}>{$t('sort.titleAZ')}</button>
-              <button class="sort-item" class:selected={epsSinglesSortMode === 'title-desc'} onclick={() => { epsSinglesSortMode = 'title-desc'; showEpsSinglesSortMenu = false; }}>{$t('sort.titleZA')}</button>
+              <button class="sort-item" class:selected={epsSinglesSortMode === 'default'} onclick={() => { epsSinglesSortMode = 'default'; openSortMenu = null; }}>{$t('sort.default')}</button>
+              <button class="sort-item" class:selected={epsSinglesSortMode === 'newest'} onclick={() => { epsSinglesSortMode = 'newest'; openSortMenu = null; }}>{$t('sort.newest')}</button>
+              <button class="sort-item" class:selected={epsSinglesSortMode === 'oldest'} onclick={() => { epsSinglesSortMode = 'oldest'; openSortMenu = null; }}>{$t('sort.oldest')}</button>
+              <button class="sort-item" class:selected={epsSinglesSortMode === 'title-asc'} onclick={() => { epsSinglesSortMode = 'title-asc'; openSortMenu = null; }}>{$t('sort.titleAZ')}</button>
+              <button class="sort-item" class:selected={epsSinglesSortMode === 'title-desc'} onclick={() => { epsSinglesSortMode = 'title-desc'; openSortMenu = null; }}>{$t('sort.titleZA')}</button>
             </div>
           {/if}
         </div>
@@ -2534,7 +2563,7 @@
           <span class="section-count">{artist.liveAlbums.length}</span>
         </div>
         <div class="sort-dropdown">
-          <button class="sort-btn" onclick={() => (showLiveAlbumsSortMenu = !showLiveAlbumsSortMenu)}>
+          <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'liveAlbums' ? null : 'liveAlbums')}>
             <span>
               {#if liveAlbumsSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
               {:else if liveAlbumsSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2545,13 +2574,13 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showLiveAlbumsSortMenu}
+          {#if openSortMenu === 'liveAlbums'}
             <div class="sort-menu">
-              <button class="sort-item" class:selected={liveAlbumsSortMode === 'default'} onclick={() => { liveAlbumsSortMode = 'default'; showLiveAlbumsSortMenu = false; }}>{$t('sort.default')}</button>
-              <button class="sort-item" class:selected={liveAlbumsSortMode === 'newest'} onclick={() => { liveAlbumsSortMode = 'newest'; showLiveAlbumsSortMenu = false; }}>{$t('sort.newest')}</button>
-              <button class="sort-item" class:selected={liveAlbumsSortMode === 'oldest'} onclick={() => { liveAlbumsSortMode = 'oldest'; showLiveAlbumsSortMenu = false; }}>{$t('sort.oldest')}</button>
-              <button class="sort-item" class:selected={liveAlbumsSortMode === 'title-asc'} onclick={() => { liveAlbumsSortMode = 'title-asc'; showLiveAlbumsSortMenu = false; }}>{$t('sort.titleAZ')}</button>
-              <button class="sort-item" class:selected={liveAlbumsSortMode === 'title-desc'} onclick={() => { liveAlbumsSortMode = 'title-desc'; showLiveAlbumsSortMenu = false; }}>{$t('sort.titleZA')}</button>
+              <button class="sort-item" class:selected={liveAlbumsSortMode === 'default'} onclick={() => { liveAlbumsSortMode = 'default'; openSortMenu = null; }}>{$t('sort.default')}</button>
+              <button class="sort-item" class:selected={liveAlbumsSortMode === 'newest'} onclick={() => { liveAlbumsSortMode = 'newest'; openSortMenu = null; }}>{$t('sort.newest')}</button>
+              <button class="sort-item" class:selected={liveAlbumsSortMode === 'oldest'} onclick={() => { liveAlbumsSortMode = 'oldest'; openSortMenu = null; }}>{$t('sort.oldest')}</button>
+              <button class="sort-item" class:selected={liveAlbumsSortMode === 'title-asc'} onclick={() => { liveAlbumsSortMode = 'title-asc'; openSortMenu = null; }}>{$t('sort.titleAZ')}</button>
+              <button class="sort-item" class:selected={liveAlbumsSortMode === 'title-desc'} onclick={() => { liveAlbumsSortMode = 'title-desc'; openSortMenu = null; }}>{$t('sort.titleZA')}</button>
             </div>
           {/if}
         </div>
@@ -2598,7 +2627,7 @@
           <span class="section-count">{artist.compilations.length}</span>
         </div>
         <div class="sort-dropdown">
-          <button class="sort-btn" onclick={() => (showCompilationsSortMenu = !showCompilationsSortMenu)}>
+          <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'compilations' ? null : 'compilations')}>
             <span>
               {#if compilationsSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
               {:else if compilationsSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2609,13 +2638,13 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showCompilationsSortMenu}
+          {#if openSortMenu === 'compilations'}
             <div class="sort-menu">
-              <button class="sort-item" class:selected={compilationsSortMode === 'default'} onclick={() => { compilationsSortMode = 'default'; showCompilationsSortMenu = false; }}>{$t('sort.default')}</button>
-              <button class="sort-item" class:selected={compilationsSortMode === 'newest'} onclick={() => { compilationsSortMode = 'newest'; showCompilationsSortMenu = false; }}>{$t('sort.newest')}</button>
-              <button class="sort-item" class:selected={compilationsSortMode === 'oldest'} onclick={() => { compilationsSortMode = 'oldest'; showCompilationsSortMenu = false; }}>{$t('sort.oldest')}</button>
-              <button class="sort-item" class:selected={compilationsSortMode === 'title-asc'} onclick={() => { compilationsSortMode = 'title-asc'; showCompilationsSortMenu = false; }}>{$t('sort.titleAZ')}</button>
-              <button class="sort-item" class:selected={compilationsSortMode === 'title-desc'} onclick={() => { compilationsSortMode = 'title-desc'; showCompilationsSortMenu = false; }}>{$t('sort.titleZA')}</button>
+              <button class="sort-item" class:selected={compilationsSortMode === 'default'} onclick={() => { compilationsSortMode = 'default'; openSortMenu = null; }}>{$t('sort.default')}</button>
+              <button class="sort-item" class:selected={compilationsSortMode === 'newest'} onclick={() => { compilationsSortMode = 'newest'; openSortMenu = null; }}>{$t('sort.newest')}</button>
+              <button class="sort-item" class:selected={compilationsSortMode === 'oldest'} onclick={() => { compilationsSortMode = 'oldest'; openSortMenu = null; }}>{$t('sort.oldest')}</button>
+              <button class="sort-item" class:selected={compilationsSortMode === 'title-asc'} onclick={() => { compilationsSortMode = 'title-asc'; openSortMenu = null; }}>{$t('sort.titleAZ')}</button>
+              <button class="sort-item" class:selected={compilationsSortMode === 'title-desc'} onclick={() => { compilationsSortMode = 'title-desc'; openSortMenu = null; }}>{$t('sort.titleZA')}</button>
             </div>
           {/if}
         </div>
@@ -2655,7 +2684,7 @@
           <span class="section-count">{artist.others.length}</span>
         </div>
         <div class="sort-dropdown">
-          <button class="sort-btn" onclick={() => (showOthersSortMenu = !showOthersSortMenu)}>
+          <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'others' ? null : 'others')}>
             <span>
               {#if othersSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
               {:else if othersSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2666,13 +2695,13 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showOthersSortMenu}
+          {#if openSortMenu === 'others'}
             <div class="sort-menu">
-              <button class="sort-item" class:selected={othersSortMode === 'default'} onclick={() => { othersSortMode = 'default'; showOthersSortMenu = false; }}>{$t('sort.default')}</button>
-              <button class="sort-item" class:selected={othersSortMode === 'newest'} onclick={() => { othersSortMode = 'newest'; showOthersSortMenu = false; }}>{$t('sort.newest')}</button>
-              <button class="sort-item" class:selected={othersSortMode === 'oldest'} onclick={() => { othersSortMode = 'oldest'; showOthersSortMenu = false; }}>{$t('sort.oldest')}</button>
-              <button class="sort-item" class:selected={othersSortMode === 'title-asc'} onclick={() => { othersSortMode = 'title-asc'; showOthersSortMenu = false; }}>{$t('sort.titleAZ')}</button>
-              <button class="sort-item" class:selected={othersSortMode === 'title-desc'} onclick={() => { othersSortMode = 'title-desc'; showOthersSortMenu = false; }}>{$t('sort.titleZA')}</button>
+              <button class="sort-item" class:selected={othersSortMode === 'default'} onclick={() => { othersSortMode = 'default'; openSortMenu = null; }}>{$t('sort.default')}</button>
+              <button class="sort-item" class:selected={othersSortMode === 'newest'} onclick={() => { othersSortMode = 'newest'; openSortMenu = null; }}>{$t('sort.newest')}</button>
+              <button class="sort-item" class:selected={othersSortMode === 'oldest'} onclick={() => { othersSortMode = 'oldest'; openSortMenu = null; }}>{$t('sort.oldest')}</button>
+              <button class="sort-item" class:selected={othersSortMode === 'title-asc'} onclick={() => { othersSortMode = 'title-asc'; openSortMenu = null; }}>{$t('sort.titleAZ')}</button>
+              <button class="sort-item" class:selected={othersSortMode === 'title-desc'} onclick={() => { othersSortMode = 'title-desc'; openSortMenu = null; }}>{$t('sort.titleZA')}</button>
             </div>
           {/if}
         </div>
@@ -2780,7 +2809,7 @@
         </div>
         {#if tributesExpanded}
           <div class="sort-dropdown">
-            <button class="sort-btn" onclick={() => (showTributesSortMenu = !showTributesSortMenu)}>
+            <button class="sort-btn" onclick={() => (openSortMenu = openSortMenu === 'tributes' ? null : 'tributes')}>
               <span>
                 {#if tributesSortMode === 'default'}{$t('sort.sort')}: {$t('sort.default')}
                 {:else if tributesSortMode === 'newest'}{$t('sort.sort')}: {$t('sort.newest')}
@@ -2791,13 +2820,13 @@
               </span>
               <ChevronDown size={14} />
             </button>
-            {#if showTributesSortMenu}
+            {#if openSortMenu === 'tributes'}
               <div class="sort-menu">
-                <button class="sort-item" class:selected={tributesSortMode === 'default'} onclick={() => { tributesSortMode = 'default'; showTributesSortMenu = false; }}>{$t('sort.default')}</button>
-                <button class="sort-item" class:selected={tributesSortMode === 'newest'} onclick={() => { tributesSortMode = 'newest'; showTributesSortMenu = false; }}>{$t('sort.newest')}</button>
-                <button class="sort-item" class:selected={tributesSortMode === 'oldest'} onclick={() => { tributesSortMode = 'oldest'; showTributesSortMenu = false; }}>{$t('sort.oldest')}</button>
-                <button class="sort-item" class:selected={tributesSortMode === 'title-asc'} onclick={() => { tributesSortMode = 'title-asc'; showTributesSortMenu = false; }}>{$t('sort.titleAZ')}</button>
-                <button class="sort-item" class:selected={tributesSortMode === 'title-desc'} onclick={() => { tributesSortMode = 'title-desc'; showTributesSortMenu = false; }}>{$t('sort.titleZA')}</button>
+                <button class="sort-item" class:selected={tributesSortMode === 'default'} onclick={() => { tributesSortMode = 'default'; openSortMenu = null; }}>{$t('sort.default')}</button>
+                <button class="sort-item" class:selected={tributesSortMode === 'newest'} onclick={() => { tributesSortMode = 'newest'; openSortMenu = null; }}>{$t('sort.newest')}</button>
+                <button class="sort-item" class:selected={tributesSortMode === 'oldest'} onclick={() => { tributesSortMode = 'oldest'; openSortMenu = null; }}>{$t('sort.oldest')}</button>
+                <button class="sort-item" class:selected={tributesSortMode === 'title-asc'} onclick={() => { tributesSortMode = 'title-asc'; openSortMenu = null; }}>{$t('sort.titleAZ')}</button>
+                <button class="sort-item" class:selected={tributesSortMode === 'title-desc'} onclick={() => { tributesSortMode = 'title-desc'; openSortMenu = null; }}>{$t('sort.titleZA')}</button>
               </div>
             {/if}
           </div>
@@ -4510,11 +4539,6 @@
     position: relative;
   }
 
-  .context-menu-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 99;
-  }
 
   .context-menu {
     position: absolute;

--- a/src/lib/components/views/CollectionsView.svelte
+++ b/src/lib/components/views/CollectionsView.svelte
@@ -61,8 +61,33 @@
   let sortDir = $state<SortDir>(initial.sortDir ?? 'asc');
   let kindFilter = $state<KindFilter>(initial.kindFilter ?? 'all');
   let searchQuery = $state('');
-  let showSortMenu = $state(false);
-  let showFilterMenu = $state(false);
+  // Mutually-exclusive toolbar dropdown state. Only one menu is open at a time.
+  type OpenMenu = 'sort' | 'filter' | null;
+  let openMenu = $state<OpenMenu>(null);
+
+  // Close the open menu on clicks outside any control button or menu.
+  // Clicks on `.control-btn` / `.control-menu` are handled by their own
+  // onclick handlers, which correctly swap `openMenu` between siblings.
+  $effect(() => {
+    if (openMenu === null) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.control-btn') || target.closest('.control-menu')) return;
+      openMenu = null;
+    }
+
+    // Defer registration so the click that opened the menu doesn't
+    // immediately close it.
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   const normalizedSearch = $derived(searchQuery.trim().toLowerCase());
 
@@ -122,7 +147,7 @@
       sortBy = value;
       sortDir = 'asc';
     }
-    showSortMenu = false;
+    openMenu = null;
   }
 
   function resetFilters() {
@@ -215,15 +240,14 @@
         <button
           type="button"
           class="control-btn"
-          onclick={() => { showSortMenu = !showSortMenu; showFilterMenu = false; }}
+          onclick={() => (openMenu = openMenu === 'sort' ? null : 'sort')}
           title={$t('collectionDetail.sort')}
         >
           <ArrowUpDown size={14} />
           <span>{sortOptions.find((o) => o.value === sortBy)?.label}</span>
           <span class="sort-indicator">{sortDir === 'asc' ? '↑' : '↓'}</span>
         </button>
-        {#if showSortMenu}
-          <div class="control-backdrop" onclick={() => (showSortMenu = false)} role="presentation"></div>
+        {#if openMenu === 'sort'}
           <div class="control-menu">
             {#each sortOptions as option}
               <button
@@ -247,7 +271,7 @@
           type="button"
           class="control-btn"
           class:active={kindFilter !== 'all'}
-          onclick={() => { showFilterMenu = !showFilterMenu; showSortMenu = false; }}
+          onclick={() => (openMenu = openMenu === 'filter' ? null : 'filter')}
           title={$t('collectionDetail.filter')}
         >
           <Filter size={14} />
@@ -256,14 +280,13 @@
             <span class="filter-count">1</span>
           {/if}
         </button>
-        {#if showFilterMenu}
-          <div class="control-backdrop" onclick={() => (showFilterMenu = false)} role="presentation"></div>
+        {#if openMenu === 'filter'}
           <div class="control-menu">
             <button
               type="button"
               class="control-menu-item"
               class:selected={kindFilter === 'all'}
-              onclick={() => { kindFilter = 'all'; showFilterMenu = false; }}
+              onclick={() => { kindFilter = 'all'; openMenu = null; }}
             >
               <span>{$t('collections.kindFilterAll')}</span>
               {#if kindFilter === 'all'}<Check size={12} />{/if}
@@ -272,7 +295,7 @@
               type="button"
               class="control-menu-item"
               class:selected={kindFilter === 'collection'}
-              onclick={() => { kindFilter = 'collection'; showFilterMenu = false; }}
+              onclick={() => { kindFilter = 'collection'; openMenu = null; }}
             >
               <span>{$t('collections.kindFilterCollection')}</span>
               {#if kindFilter === 'collection'}<Check size={12} />{/if}
@@ -281,7 +304,7 @@
               type="button"
               class="control-menu-item"
               class:selected={kindFilter === 'artist_collection'}
-              onclick={() => { kindFilter = 'artist_collection'; showFilterMenu = false; }}
+              onclick={() => { kindFilter = 'artist_collection'; openMenu = null; }}
             >
               <span>{$t('collections.kindFilterArtistCollection')}</span>
               {#if kindFilter === 'artist_collection'}<Check size={12} />{/if}
@@ -556,11 +579,6 @@
     font-weight: 600;
   }
 
-  .control-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 200;
-  }
   .control-menu {
     position: absolute;
     top: calc(100% + 4px);

--- a/src/lib/components/views/FavoritesView.svelte
+++ b/src/lib/components/views/FavoritesView.svelte
@@ -369,15 +369,58 @@
   let albumViewMode = $state<'grid' | 'list'>('grid');
   type AlbumGroupMode = 'alpha' | 'artist';
   let albumGroupMode = $state<AlbumGroupMode>('alpha');
-  let showAlbumGroupMenu = $state(false);
   let albumGroupingEnabled = $state(false);
+
+  // Mutually-exclusive toolbar/section dropdown state. Only one menu is open at a time.
+  type OpenMenu =
+    | 'genre'
+    | 'genreTracks'
+    | 'albumGroup'
+    | 'albumSort'
+    | 'trackGroup'
+    | 'artistGroup'
+    | 'tracksContext'
+    | 'discographySort'
+    | 'epsSinglesSort'
+    | 'liveAlbumsSort'
+    | null;
+  let openMenu = $state<OpenMenu>(null);
+
+  // Close the open menu on clicks outside any toolbar control, dropdown, or
+  // section sort. Without this, the only way to dismiss a menu is to make a
+  // selection or click another peer dropdown.
+  $effect(() => {
+    if (openMenu === null) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (
+        target.closest('.control-btn') ||
+        target.closest('.dropdown-menu') ||
+        target.closest('.section-sort-btn') ||
+        target.closest('.section-sort-menu') ||
+        target.closest('.action-btn-circle') ||
+        target.closest('.context-menu') ||
+        target.closest('.genre-filter-wrapper')
+      ) return;
+      openMenu = null;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   // Album sorting
   type AlbumSortBy = 'default' | 'date' | 'title' | 'artist';
   type SortDirection = 'asc' | 'desc';
   let albumSortBy = $state<AlbumSortBy>('default');
   let albumSortDirection = $state<SortDirection>('desc'); // desc = newest first for date
-  let showAlbumSortMenu = $state(false);
 
   const albumSortOptions: { value: AlbumSortBy; label: string }[] = [
     { value: 'default', label: $t('sort.default') },
@@ -394,15 +437,13 @@
       // Default directions
       albumSortDirection = value === 'date' ? 'desc' : 'asc';
     }
-    showAlbumSortMenu = false;
+    openMenu = null;
   }
 
   type TrackGroupMode = 'album' | 'artist' | 'name';
   let trackGroupMode = $state<TrackGroupMode>('album');
-  let showTrackGroupMenu = $state(false);
   let trackGroupingEnabled = $state(false);
 
-  let showArtistGroupMenu = $state(false);
   let artistGroupingEnabled = $state(false);
 
   // Artist view mode: grid (cards) or sidepanel (two-column with albums)
@@ -454,9 +495,6 @@
   let discographySortMode = $state<AlbumSortMode>('default');
   let epsSinglesSortMode = $state<AlbumSortMode>('default');
   let liveAlbumsSortMode = $state<AlbumSortMode>('default');
-  let showDiscographySortMenu = $state(false);
-  let showEpsSinglesSortMenu = $state(false);
-  let showLiveAlbumsSortMenu = $state(false);
 
   function sortQobuzAlbums(albums: QobuzAlbum[], mode: AlbumSortMode): QobuzAlbum[] {
     if (mode === 'default') return albums;
@@ -495,8 +533,6 @@
       case 'title-desc': return $t('sort.titleZA');
     }
   }
-
-  let showTracksContextMenu = $state(false);
 
   async function scrollToTrack(trackId: number) {
     await tick();
@@ -1000,9 +1036,7 @@
 
   function handleTabChange(tab: TabType) {
     activeTab = tab;
-    showAlbumGroupMenu = false;
-    showTrackGroupMenu = false;
-    showArtistGroupMenu = false;
+    openMenu = null;
     onTabNavigate?.(tab);
     loadTabIfNeeded(tab);
   }
@@ -1430,18 +1464,17 @@
         <div class="context-menu-wrapper">
           <button
             class="action-btn-circle"
-            onclick={() => showTracksContextMenu = !showTracksContextMenu}
+            onclick={() => (openMenu = openMenu === 'tracksContext' ? null : 'tracksContext')}
             title={$t('actions.more')}
           >
             <Ellipsis size={18} />
           </button>
-          {#if showTracksContextMenu}
-            <div class="context-menu-backdrop" onclick={() => showTracksContextMenu = false} role="presentation"></div>
+          {#if openMenu === 'tracksContext'}
             <div class="context-menu">
-              <button class="context-menu-item" onclick={() => { handlePlayAllTracksNext(); showTracksContextMenu = false; }}>
+              <button class="context-menu-item" onclick={() => { handlePlayAllTracksNext(); openMenu = null; }}>
                 {$t('actions.playNext')}
               </button>
-              <button class="context-menu-item" onclick={() => { handlePlayAllTracksLater(); showTracksContextMenu = false; }}>
+              <button class="context-menu-item" onclick={() => { handlePlayAllTracksLater(); openMenu = null; }}>
                 {$t('actions.addToQueue')}
               </button>
             </div>
@@ -1518,9 +1551,18 @@
         {/if}
       </span>
       {#if activeTab === 'albums'}
-        <GenreFilterButton context={GENRE_CONTEXT} variant="control" align="right" onFilterChange={handleGenreFilterChange} />
+        <GenreFilterButton
+          context={GENRE_CONTEXT}
+          variant="control"
+          align="right"
+          onFilterChange={handleGenreFilterChange}
+          bind:isOpen={
+            () => openMenu === 'genre',
+            (v: boolean) => openMenu = v ? 'genre' : (openMenu === 'genre' ? null : openMenu)
+          }
+        />
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => (showAlbumGroupMenu = !showAlbumGroupMenu)}>
+          <button class="control-btn" onclick={() => (openMenu = openMenu === 'albumGroup' ? null : 'albumGroup')}>
             <span>
               {albumGroupingEnabled
                 ? albumGroupMode === 'alpha'
@@ -1530,26 +1572,26 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showAlbumGroupMenu}
+          {#if openMenu === 'albumGroup'}
             <div class="dropdown-menu">
               <button
                 class="dropdown-item"
                 class:selected={!albumGroupingEnabled}
-                onclick={() => { albumGroupingEnabled = false; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupingEnabled = false; openMenu = null; }}
               >
                 {$t('purchases.group.optionOff')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={albumGroupingEnabled && albumGroupMode === 'alpha'}
-                onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionAlpha')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={albumGroupingEnabled && albumGroupMode === 'artist'}
-                onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionArtist')}
               </button>
@@ -1557,11 +1599,11 @@
           {/if}
         </div>
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => (showAlbumSortMenu = !showAlbumSortMenu)}>
+          <button class="control-btn" onclick={() => (openMenu = openMenu === 'albumSort' ? null : 'albumSort')}>
             <span>{$t('sort.sort')}: {albumSortOptions.find(o => o.value === albumSortBy)?.label}</span>
             <ChevronDown size={14} />
           </button>
-          {#if showAlbumSortMenu}
+          {#if openMenu === 'albumSort'}
             <div class="dropdown-menu">
               {#each albumSortOptions as option}
                 <button
@@ -1609,9 +1651,18 @@
             <span>{$t('actions.selectAll')}</span>
           </label>
         {/if}
-        <GenreFilterButton context={GENRE_CONTEXT_TRACKS} variant="control" align="right" onFilterChange={handleGenreFilterChange} />
+        <GenreFilterButton
+          context={GENRE_CONTEXT_TRACKS}
+          variant="control"
+          align="right"
+          onFilterChange={handleGenreFilterChange}
+          bind:isOpen={
+            () => openMenu === 'genreTracks',
+            (v: boolean) => openMenu = v ? 'genreTracks' : (openMenu === 'genreTracks' ? null : openMenu)
+          }
+        />
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => (showTrackGroupMenu = !showTrackGroupMenu)}>
+          <button class="control-btn" onclick={() => (openMenu = openMenu === 'trackGroup' ? null : 'trackGroup')}>
             <span>
               {trackGroupingEnabled
                 ? trackGroupMode === 'album'
@@ -1623,33 +1674,33 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showTrackGroupMenu}
+          {#if openMenu === 'trackGroup'}
             <div class="dropdown-menu">
               <button
                 class="dropdown-item"
                 class:selected={!trackGroupingEnabled}
-                onclick={() => { trackGroupingEnabled = false; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupingEnabled = false; openMenu = null; }}
               >
                 {$t('purchases.group.optionOff')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'album'}
-                onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; openMenu = null; }}
               >
               {$t('purchases.group.optionAlbum')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'artist'}
-                onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionArtist')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'name'}
-                onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionAlpha')}
               </button>
@@ -1677,23 +1728,23 @@
         </button>
         {#if artistViewMode === 'grid'}
           <div class="dropdown-container">
-            <button class="control-btn" onclick={() => (showArtistGroupMenu = !showArtistGroupMenu)}>
+            <button class="control-btn" onclick={() => (openMenu = openMenu === 'artistGroup' ? null : 'artistGroup')}>
               <span>{artistGroupingEnabled ? $t('purchases.group.alpha') : $t('purchases.group.off')}</span>
               <ChevronDown size={14} />
             </button>
-            {#if showArtistGroupMenu}
+            {#if openMenu === 'artistGroup'}
               <div class="dropdown-menu">
                 <button
                   class="dropdown-item"
                   class:selected={!artistGroupingEnabled}
-                  onclick={() => { artistGroupingEnabled = false; showArtistGroupMenu = false; }}
+                  onclick={() => { artistGroupingEnabled = false; openMenu = null; }}
                 >
                   {$t('purchases.group.optionOff')}
                 </button>
                 <button
                   class="dropdown-item"
                   class:selected={artistGroupingEnabled}
-                  onclick={() => { artistGroupingEnabled = true; showArtistGroupMenu = false; }}
+                  onclick={() => { artistGroupingEnabled = true; openMenu = null; }}
                 >
                   {$t('purchases.group.optionAlpha')}
                 </button>
@@ -1976,18 +2027,18 @@
                       <div class="section-sort-wrapper">
                         <button
                           class="section-sort-btn"
-                          onclick={() => { showDiscographySortMenu = !showDiscographySortMenu; }}
+                          onclick={() => (openMenu = openMenu === 'discographySort' ? null : 'discographySort')}
                         >
                           {getSortLabel(discographySortMode)}
                           <ChevronDown size={14} />
                         </button>
-                        {#if showDiscographySortMenu}
+                        {#if openMenu === 'discographySort'}
                           <div class="section-sort-menu" role="menu">
                             {#each (['default', 'newest', 'oldest', 'title-asc', 'title-desc'] as const) as mode}
                               <button
                                 class="section-sort-option"
                                 class:selected={discographySortMode === mode}
-                                onclick={() => { discographySortMode = mode; showDiscographySortMenu = false; }}
+                                onclick={() => { discographySortMode = mode; openMenu = null; }}
                               >
                                 {getSortLabel(mode)}
                               </button>
@@ -2029,18 +2080,18 @@
                       <div class="section-sort-wrapper">
                         <button
                           class="section-sort-btn"
-                          onclick={() => { showEpsSinglesSortMenu = !showEpsSinglesSortMenu; }}
+                          onclick={() => (openMenu = openMenu === 'epsSinglesSort' ? null : 'epsSinglesSort')}
                         >
                           {getSortLabel(epsSinglesSortMode)}
                           <ChevronDown size={14} />
                         </button>
-                        {#if showEpsSinglesSortMenu}
+                        {#if openMenu === 'epsSinglesSort'}
                           <div class="section-sort-menu" role="menu">
                             {#each (['default', 'newest', 'oldest', 'title-asc', 'title-desc'] as const) as mode}
                               <button
                                 class="section-sort-option"
                                 class:selected={epsSinglesSortMode === mode}
-                                onclick={() => { epsSinglesSortMode = mode; showEpsSinglesSortMenu = false; }}
+                                onclick={() => { epsSinglesSortMode = mode; openMenu = null; }}
                               >
                                 {getSortLabel(mode)}
                               </button>
@@ -2082,18 +2133,18 @@
                       <div class="section-sort-wrapper">
                         <button
                           class="section-sort-btn"
-                          onclick={() => { showLiveAlbumsSortMenu = !showLiveAlbumsSortMenu; }}
+                          onclick={() => (openMenu = openMenu === 'liveAlbumsSort' ? null : 'liveAlbumsSort')}
                         >
                           {getSortLabel(liveAlbumsSortMode)}
                           <ChevronDown size={14} />
                         </button>
-                        {#if showLiveAlbumsSortMenu}
+                        {#if openMenu === 'liveAlbumsSort'}
                           <div class="section-sort-menu" role="menu">
                             {#each (['default', 'newest', 'oldest', 'title-asc', 'title-desc'] as const) as mode}
                               <button
                                 class="section-sort-option"
                                 class:selected={liveAlbumsSortMode === mode}
-                                onclick={() => { liveAlbumsSortMode = mode; showLiveAlbumsSortMenu = false; }}
+                                onclick={() => { liveAlbumsSortMode = mode; openMenu = null; }}
                               >
                                 {getSortLabel(mode)}
                               </button>
@@ -2708,12 +2759,6 @@
 
   .context-menu-wrapper {
     position: relative;
-  }
-
-  .context-menu-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 99;
   }
 
   .context-menu {

--- a/src/lib/components/views/LabelView.svelte
+++ b/src/lib/components/views/LabelView.svelte
@@ -142,6 +142,26 @@
   let visibleTracksCount = $state(5);
   let showTracksContextMenu = $state(false);
 
+  // Close the popular-tracks context menu on clicks outside its trigger or panel.
+  $effect(() => {
+    if (!showTracksContextMenu) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.action-btn-circle') || target.closest('.context-menu')) return;
+      showTracksContextMenu = false;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
+
   // Description expand
   let descriptionExpanded = $state(false);
   let labelDescription = $state<string | null>(null);
@@ -955,7 +975,6 @@
                 <Ellipsis size={18} />
               </button>
               {#if showTracksContextMenu}
-                <div class="context-menu-backdrop" onclick={() => showTracksContextMenu = false} role="presentation"></div>
                 <div class="context-menu">
                   <button class="context-menu-item" onclick={() => { handlePlayAllTracksNext(); showTracksContextMenu = false; }}>
                     {$t('player.playNext')}
@@ -1529,7 +1548,6 @@
 
   /* Context menu */
   .context-menu-wrapper { position: relative; }
-  .context-menu-backdrop { position: fixed; inset: 0; z-index: 99; }
   .context-menu {
     position: absolute; top: 100%; right: 0; margin-top: 8px;
     min-width: 160px; background-color: var(--bg-tertiary);

--- a/src/lib/components/views/LocalLibraryView.svelte
+++ b/src/lib/components/views/LocalLibraryView.svelte
@@ -1005,17 +1005,19 @@
   type AlbumGroupMode = 'alpha' | 'artist';
   let albumGroupMode = $state<AlbumGroupMode>('alpha');
   let albumGroupingEnabled = $state(false);
-  let showGroupMenu = $state(false);
+
+  // Mutually-exclusive toolbar dropdown state. Only one menu is open at a time.
+  type OpenMenu = 'group' | 'filter' | 'sort' | 'trackGroup' | null;
+  let openMenu = $state<OpenMenu>(null);
 
   // Quality/Format filter with checkboxes (AND between sections, OR within section)
-  let showFilterPanel = $state(false);
   let filterPanelRef: HTMLDivElement | null = $state(null);
   let filterPanelTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function startFilterPanelTimer() {
     clearFilterPanelTimer();
     filterPanelTimeout = setTimeout(() => {
-      showFilterPanel = false;
+      if (openMenu === 'filter') openMenu = null;
     }, 3000);
   }
 
@@ -1027,21 +1029,21 @@
   }
 
   function handleFilterPanelActivity() {
-    if (showFilterPanel) {
+    if (openMenu === 'filter') {
       startFilterPanelTimer();
     }
   }
 
   function handleClickOutsideFilterPanel(event: MouseEvent) {
-    if (showFilterPanel && filterPanelRef && !filterPanelRef.contains(event.target as Node)) {
-      showFilterPanel = false;
+    if (openMenu === 'filter' && filterPanelRef && !filterPanelRef.contains(event.target as Node)) {
+      openMenu = null;
       clearFilterPanelTimer();
     }
   }
 
   // Effect to manage filter panel auto-close
   $effect(() => {
-    if (showFilterPanel) {
+    if (openMenu === 'filter') {
       startFilterPanelTimer();
       document.addEventListener('click', handleClickOutsideFilterPanel, true);
     } else {
@@ -1056,11 +1058,11 @@
 
   // Effect to close sort menu on click outside
   $effect(() => {
-    if (showSortMenu) {
+    if (openMenu === 'sort') {
       const handleClickOutside = (event: MouseEvent) => {
         const target = event.target as HTMLElement;
         if (!target.closest('.sort-btn') && !target.closest('.sort-menu')) {
-          showSortMenu = false;
+          if (openMenu === 'sort') openMenu = null;
         }
       };
       document.addEventListener('click', handleClickOutside, true);
@@ -1174,7 +1176,6 @@
   type SortDirection = 'asc' | 'desc';
   let sortBy = $state<SortBy>('title');
   let sortDirection = $state<SortDirection>('asc');
-  let showSortMenu = $state(false);
 
   const sortOptions: { value: SortBy; label: string }[] = [
     { value: 'title', label: 'Album Name' },
@@ -1198,7 +1199,7 @@
       sortBy = value;
       sortDirection = 'asc';
     }
-    showSortMenu = false;
+    openMenu = null;
   }
 
   function sortAlbums(items: LocalAlbum[]): LocalAlbum[] {
@@ -1242,7 +1243,6 @@
   let artistSearch = $state('');
   let artistViewMode = $state<'grid' | 'list'>('grid');
   let artistGroupingEnabled = $state(true); // Enable alpha grouping by default
-  let showArtistGroupMenu = $state(false);
   // Selected artist for the two-column layout
   let selectedArtistName = $state<string | null>(null);
   // Reference to the artist list scroll container
@@ -1269,7 +1269,6 @@
   type TrackGroupMode = 'album' | 'artist' | 'name';
   let trackGroupMode = $state<TrackGroupMode>('album');
   let trackGroupingEnabled = $state(false);
-  let showTrackGroupMenu = $state(false);
   let trackSearchTimer: ReturnType<typeof setTimeout> | null = null;
   // Reference to virtualized track list for programmatic scrolling
   let virtualizedTrackListRef = $state<{ scrollToGroup: (groupId: string) => void } | undefined>(undefined);
@@ -5304,7 +5303,7 @@
       <div class="dropdown-container">
         <button
           class="control-btn"
-          onclick={() => (showGroupMenu = !showGroupMenu)}
+          onclick={() => (openMenu = openMenu === 'group' ? null : 'group')}
           title="Group albums"
         >
           <span>{!albumGroupingEnabled
@@ -5313,26 +5312,26 @@
               ? $t('purchases.group.alpha')
               : $t('purchases.group.artist')}</span>
         </button>
-        {#if showGroupMenu}
+        {#if openMenu === 'group'}
           <div class="dropdown-menu">
             <button
               class="dropdown-item"
               class:selected={!albumGroupingEnabled}
-              onclick={() => { albumGroupingEnabled = false; showGroupMenu = false; }}
+              onclick={() => { albumGroupingEnabled = false; openMenu = null; }}
             >
               {$t('purchases.group.optionOff')}
             </button>
             <button
               class="dropdown-item"
               class:selected={albumGroupingEnabled && albumGroupMode === 'alpha'}
-              onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; showGroupMenu = false; }}
+              onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; openMenu = null; }}
             >
               {$t('purchases.group.optionAlpha')}
             </button>
             <button
               class="dropdown-item"
               class:selected={albumGroupingEnabled && albumGroupMode === 'artist'}
-              onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; showGroupMenu = false; }}
+              onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; openMenu = null; }}
             >
               {$t('purchases.group.optionArtist')}
             </button>
@@ -5345,7 +5344,7 @@
         <button
           class="control-btn icon-only"
           class:active={hasActiveFilters}
-          onclick={() => (showFilterPanel = !showFilterPanel)}
+          onclick={() => (openMenu = openMenu === 'filter' ? null : 'filter')}
           title="Filter by quality/format"
         >
           <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -5355,7 +5354,7 @@
             <span class="filter-badge">{activeFilterCount}</span>
           {/if}
         </button>
-        {#if showFilterPanel}
+        {#if openMenu === 'filter'}
           <!-- svelte-ignore a11y_no_static_element_interactions, a11y_click_events_have_key_events, a11y_no_noninteractive_element_interactions -->
           <div
             class="filter-panel"
@@ -5466,12 +5465,12 @@
       <div class="dropdown-container">
         <button
           class="control-btn icon-only"
-          onclick={() => (showSortMenu = !showSortMenu)}
+          onclick={() => (openMenu = openMenu === 'sort' ? null : 'sort')}
           title="Sort albums"
         >
           <ArrowUpDown size={14} />
         </button>
-        {#if showSortMenu}
+        {#if openMenu === 'sort'}
           <div class="sort-menu">
             {#each sortOptions as option}
               <button
@@ -6744,7 +6743,7 @@
             <div class="dropdown-container">
               <button
                 class="control-btn"
-                onclick={() => (showTrackGroupMenu = !showTrackGroupMenu)}
+                onclick={() => (openMenu = openMenu === 'trackGroup' ? null : 'trackGroup')}
                 title="Group tracks"
               >
                 <span>
@@ -6757,33 +6756,33 @@
                         : $t('purchases.group.name')}
                 </span>
               </button>
-              {#if showTrackGroupMenu}
+              {#if openMenu === 'trackGroup'}
                 <div class="dropdown-menu">
                   <button
                     class="dropdown-item"
                     class:selected={!trackGroupingEnabled}
-                    onclick={() => { trackGroupingEnabled = false; showTrackGroupMenu = false; }}
+                    onclick={() => { trackGroupingEnabled = false; openMenu = null; }}
                   >
                     {$t('purchases.group.optionOff')}
                   </button>
                   <button
                     class="dropdown-item"
                     class:selected={trackGroupingEnabled && trackGroupMode === 'album'}
-                    onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                    onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; openMenu = null; }}
                   >
                     {$t('purchases.group.optionAlbum')}
                   </button>
                   <button
                     class="dropdown-item"
                     class:selected={trackGroupingEnabled && trackGroupMode === 'artist'}
-                    onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                    onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; openMenu = null; }}
                   >
                     {$t('purchases.group.optionArtist')}
                   </button>
                   <button
                     class="dropdown-item"
                     class:selected={trackGroupingEnabled && trackGroupMode === 'name'}
-                    onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                    onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; openMenu = null; }}
                   >
                     {$t('purchases.group.optionAlpha')}
                   </button>

--- a/src/lib/components/views/MixtapeCollectionDetailView.svelte
+++ b/src/lib/components/views/MixtapeCollectionDetailView.svelte
@@ -395,9 +395,30 @@
 
   let sortBy = $state<SortBy>('position');
   let sortDir = $state<SortDir>('asc');
-  let showSortMenu = $state(false);
   let typeFilter = $state<TypeFilter>('all');
-  let showFilterMenu = $state(false);
+
+  // Mutually-exclusive toolbar dropdown state. Only one menu is open at a time.
+  type OpenMenu = 'sort' | 'filter' | null;
+  let openMenu = $state<OpenMenu>(null);
+
+  $effect(() => {
+    if (openMenu === null) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.control-btn') || target.closest('.control-menu')) return;
+      openMenu = null;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   // Source filter — multi-select, maps to the resolved item kind (qobuz /
   // plex / local, see resolveItems). Empty set means "all pass" (no filter).
@@ -467,7 +488,7 @@
       sortBy = value;
       sortDir = 'asc';
     }
-    showSortMenu = false;
+    openMenu = null;
   }
 
   const sortOptions: { value: SortBy; label: string }[] = $derived([
@@ -1552,15 +1573,14 @@
           <button
             type="button"
             class="control-btn"
-            onclick={() => { showSortMenu = !showSortMenu; showFilterMenu = false; }}
+            onclick={() => (openMenu = openMenu === 'sort' ? null : 'sort')}
             title={$t('collectionDetail.sort') || 'Sort'}
           >
             <ArrowUpDown size={14} />
             <span>{sortOptions.find((o) => o.value === sortBy)?.label}</span>
             <span class="sort-indicator">{sortDir === 'asc' ? '↑' : '↓'}</span>
           </button>
-          {#if showSortMenu}
-            <div class="control-backdrop" onclick={() => (showSortMenu = false)} role="presentation"></div>
+          {#if openMenu === 'sort'}
             <div class="control-menu">
               {#each sortOptions as option}
                 <button
@@ -1584,7 +1604,7 @@
             type="button"
             class="control-btn"
             class:active={typeFilter !== 'all' || sourceFilter.size > 0}
-            onclick={() => { showFilterMenu = !showFilterMenu; showSortMenu = false; }}
+            onclick={() => (openMenu = openMenu === 'filter' ? null : 'filter')}
             title={$t('collectionDetail.filter') || 'Filter'}
           >
             <Filter size={14} />
@@ -1593,8 +1613,7 @@
               <span class="filter-count">{(sourceFilter.size) + (typeFilter !== 'all' ? 1 : 0)}</span>
             {/if}
           </button>
-          {#if showFilterMenu}
-            <div class="control-backdrop" onclick={() => (showFilterMenu = false)} role="presentation"></div>
+          {#if openMenu === 'filter'}
             <div class="control-menu wide">
               <div class="filter-section-label">{$t('collectionDetail.colType') || $t('discographyBuilder.colType')}</div>
               {#each typeFilterOptions as option}
@@ -2451,11 +2470,6 @@
   .sort-indicator {
     color: var(--text-muted);
     font-size: 11px;
-  }
-  .control-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 100;
   }
   .control-menu {
     position: absolute;

--- a/src/lib/components/views/MixtapesView.svelte
+++ b/src/lib/components/views/MixtapesView.svelte
@@ -56,7 +56,28 @@
   let sortBy = $state<SortBy>(initial.sortBy ?? 'position');
   let sortDir = $state<SortDir>(initial.sortDir ?? 'asc');
   let searchQuery = $state('');
-  let showSortMenu = $state(false);
+  // Mutually-exclusive toolbar dropdown state.
+  type OpenMenu = 'sort' | null;
+  let openMenu = $state<OpenMenu>(null);
+
+  $effect(() => {
+    if (openMenu === null) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (target.closest('.control-btn') || target.closest('.control-menu')) return;
+      openMenu = null;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   const normalizedSearch = $derived(searchQuery.trim().toLowerCase());
 
@@ -100,7 +121,7 @@
       sortBy = value;
       sortDir = 'asc';
     }
-    showSortMenu = false;
+    openMenu = null;
   }
 
   function resetFilters() {
@@ -186,15 +207,14 @@
         <button
           type="button"
           class="control-btn"
-          onclick={() => (showSortMenu = !showSortMenu)}
+          onclick={() => (openMenu = openMenu === 'sort' ? null : 'sort')}
           title={$t('collectionDetail.sort')}
         >
           <ArrowUpDown size={14} />
           <span>{sortOptions.find((o) => o.value === sortBy)?.label}</span>
           <span class="sort-indicator">{sortDir === 'asc' ? '↑' : '↓'}</span>
         </button>
-        {#if showSortMenu}
-          <div class="control-backdrop" onclick={() => (showSortMenu = false)} role="presentation"></div>
+        {#if openMenu === 'sort'}
           <div class="control-menu">
             {#each sortOptions as option}
               <button
@@ -453,11 +473,6 @@
     font-size: 11px;
   }
 
-  .control-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 200;
-  }
   .control-menu {
     position: absolute;
     top: calc(100% + 4px);

--- a/src/lib/components/views/PurchasesView.svelte
+++ b/src/lib/components/views/PurchasesView.svelte
@@ -78,13 +78,10 @@
   let albumViewMode = $state<'grid' | 'list'>('grid');
   let albumGroupingEnabled = $state(false);
   let albumGroupMode = $state<AlbumGroupMode>('alpha');
-  let showAlbumGroupMenu = $state(false);
   let albumSortBy = $state<SortBy>('date');
   let albumSortDirection = $state<SortDirection>('desc');
-  let showAlbumSortMenu = $state(false);
 
   // Albums: filter panel (LocalLibraryView pattern)
-  let showFilterPanel = $state(false);
   let filterPanelRef = $state<HTMLDivElement | null>(null);
   type QualityFilter = 'all' | 'hires' | 'cd' | 'lossy';
   let filterHideUnavailable = $state(getHideUnavailable());
@@ -94,7 +91,37 @@
   // Tracks: grouping
   let trackGroupingEnabled = $state(false);
   let trackGroupMode = $state<TrackGroupMode>('artist');
-  let showTrackGroupMenu = $state(false);
+
+  // Mutually-exclusive toolbar dropdown state. Only one menu is open at a time.
+  type OpenMenu = 'albumGroup' | 'albumSort' | 'filter' | 'trackGroup' | null;
+  let openMenu = $state<OpenMenu>(null);
+
+  // Close the open menu on clicks outside any toolbar control or menu.
+  // Clicks on `.control-btn` / `.dropdown-menu` / `.filter-panel` are
+  // handled by their own onclick handlers, which swap `openMenu` between
+  // siblings without ever closing the new one prematurely.
+  $effect(() => {
+    if (openMenu === null) return;
+
+    function handleClickOutside(event: MouseEvent) {
+      const target = event.target as HTMLElement | null;
+      if (!target) return;
+      if (
+        target.closest('.control-btn') ||
+        target.closest('.dropdown-menu') ||
+        target.closest('.filter-panel')
+      ) return;
+      openMenu = null;
+    }
+
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutside);
+    }, 0);
+
+    return () => {
+      document.removeEventListener('click', handleClickOutside);
+    };
+  });
 
   // Track format picker popup
   let formatPickerTrack = $state<PurchasedTrack | null>(null);
@@ -106,15 +133,6 @@
   $effect(() => { setHideUnavailable(filterHideUnavailable); });
   $effect(() => { setUserItem('qbz-purchases-quality-filter', filterQuality); });
   $effect(() => { setHideDownloaded(filterHideDownloaded); });
-
-  /** Close all dropdown menus (mutual exclusion) */
-  function closeAllMenus() {
-    showAlbumGroupMenu = false;
-    showAlbumSortMenu = false;
-    showFilterPanel = false;
-    showTrackGroupMenu = false;
-    closeFormatPicker();
-  }
 
   const albumSortOptions = [
     { value: 'date' as SortBy, labelKey: 'purchases.sort.date' },
@@ -144,7 +162,7 @@
       albumSortBy = value;
       albumSortDirection = value === 'date' ? 'desc' : 'asc';
     }
-    showAlbumSortMenu = false;
+    openMenu = null;
   }
 
   function formatPurchaseDate(ts?: number): string {
@@ -559,7 +577,7 @@
       <div class="toolbar-controls">
         <!-- Group dropdown -->
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => { const wasOpen = showAlbumGroupMenu; closeAllMenus(); showAlbumGroupMenu = !wasOpen; }}>
+          <button class="control-btn" onclick={() => { closeFormatPicker(); openMenu = openMenu === 'albumGroup' ? null : 'albumGroup'; }}>
             <span>{!albumGroupingEnabled
               ? $t('purchases.group.off')
               : albumGroupMode === 'alpha'
@@ -567,26 +585,26 @@
                 : $t('purchases.group.artist')}</span>
             <ChevronDown size={14} />
           </button>
-          {#if showAlbumGroupMenu}
+          {#if openMenu === 'albumGroup'}
             <div class="dropdown-menu">
               <button
                 class="dropdown-item"
                 class:selected={!albumGroupingEnabled}
-                onclick={() => { albumGroupingEnabled = false; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupingEnabled = false; openMenu = null; }}
               >
                 {$t('purchases.group.optionOff')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={albumGroupingEnabled && albumGroupMode === 'alpha'}
-                onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupMode = 'alpha'; albumGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionAlpha')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={albumGroupingEnabled && albumGroupMode === 'artist'}
-                onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; showAlbumGroupMenu = false; }}
+                onclick={() => { albumGroupMode = 'artist'; albumGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionArtist')}
               </button>
@@ -596,11 +614,11 @@
 
         <!-- Sort dropdown -->
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => { const wasOpen = showAlbumSortMenu; closeAllMenus(); showAlbumSortMenu = !wasOpen; }}>
+          <button class="control-btn" onclick={() => { closeFormatPicker(); openMenu = openMenu === 'albumSort' ? null : 'albumSort'; }}>
             <span>{$t('purchases.sortLabel')}: {$t(albumSortOptions.find(option => option.value === albumSortBy)?.labelKey ?? 'purchases.sort.date')}</span>
             <ChevronDown size={14} />
           </button>
-          {#if showAlbumSortMenu}
+          {#if openMenu === 'albumSort'}
             <div class="dropdown-menu sort-menu">
               {#each albumSortOptions as option}
                 <button
@@ -623,7 +641,7 @@
           <button
             class="control-btn icon-only"
             class:active={hasActiveFilters}
-            onclick={() => { const wasOpen = showFilterPanel; closeAllMenus(); showFilterPanel = !wasOpen; }}
+            onclick={() => { closeFormatPicker(); openMenu = openMenu === 'filter' ? null : 'filter'; }}
             title={$t('library.filters')}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -633,8 +651,7 @@
               <span class="filter-badge">{activeFilterCount}</span>
             {/if}
           </button>
-          {#if showFilterPanel}
-            <div class="filter-backdrop" onclick={() => showFilterPanel = false} role="presentation"></div>
+          {#if openMenu === 'filter'}
             <div class="filter-panel">
               <div class="filter-panel-header">
                 <span>{$t('library.filters')}</span>
@@ -711,7 +728,7 @@
       <div class="toolbar-controls">
         <!-- Track group dropdown -->
         <div class="dropdown-container">
-          <button class="control-btn" onclick={() => { const wasOpen = showTrackGroupMenu; closeAllMenus(); showTrackGroupMenu = !wasOpen; }}>
+          <button class="control-btn" onclick={() => { closeFormatPicker(); openMenu = openMenu === 'trackGroup' ? null : 'trackGroup'; }}>
             <span>
               {trackGroupingEnabled
                 ? trackGroupMode === 'album'
@@ -723,33 +740,33 @@
             </span>
             <ChevronDown size={14} />
           </button>
-          {#if showTrackGroupMenu}
+          {#if openMenu === 'trackGroup'}
             <div class="dropdown-menu">
               <button
                 class="dropdown-item"
                 class:selected={!trackGroupingEnabled}
-                onclick={() => { trackGroupingEnabled = false; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupingEnabled = false; openMenu = null; }}
               >
                 {$t('purchases.group.optionOff')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'album'}
-                onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'album'; trackGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionAlbum')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'artist'}
-                onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'artist'; trackGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionArtist')}
               </button>
               <button
                 class="dropdown-item"
                 class:selected={trackGroupingEnabled && trackGroupMode === 'name'}
-                onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; showTrackGroupMenu = false; }}
+                onclick={() => { trackGroupMode = 'name'; trackGroupingEnabled = true; openMenu = null; }}
               >
                 {$t('purchases.group.optionName')}
               </button>
@@ -762,7 +779,7 @@
           <button
             class="control-btn icon-only"
             class:active={hasActiveFilters}
-            onclick={() => { const wasOpen = showFilterPanel; closeAllMenus(); showFilterPanel = !wasOpen; }}
+            onclick={() => { closeFormatPicker(); openMenu = openMenu === 'filter' ? null : 'filter'; }}
             title={$t('library.filters')}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
@@ -772,8 +789,7 @@
               <span class="filter-badge">{activeFilterCount}</span>
             {/if}
           </button>
-          {#if showFilterPanel}
-            <div class="filter-backdrop" onclick={() => showFilterPanel = false} role="presentation"></div>
+          {#if openMenu === 'filter'}
             <div class="filter-panel">
               <div class="filter-panel-header">
                 <span>{$t('library.filters')}</span>
@@ -1354,12 +1370,6 @@
   }
 
   /* ── Filter Panel (LocalLibraryView pattern) ── */
-  .filter-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 19;
-  }
-
   .filter-badge {
     display: inline-flex;
     align-items: center;


### PR DESCRIPTION
Multiple filter/sort/group dropdowns could be open at the same time across the library views, and several views rendered a full-screen click-swallowing backdrop that forced two clicks to switch between sibling dropdowns.

This PR unifies each affected view's dropdown state into a single typed `openMenu` union so toggling one menu auto-closes the rest, and replaces every `*-backdrop` overlay with a `document` click listener that ignores peer controls — so clicking from one dropdown straight to another now works in a single click. Touched views: Favorites, LocalLibrary, ArtistDetail, Label, Collections, MixtapeCollectionDetail, Mixtapes, and Purchases. `GenreFilterButton.isOpen` is now `$bindable` so its open state can be coordinated by the parent.

Minor UX shift: clicking somewhere unrelated while a context menu is open now activates that target in the same click (previously the backdrop dismissed the menu and ate the click).