### PR TITLE
Changed apt format in README.md to deb822

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ sudo snap connect qbz-player:pipewire
 
 ```bash
 curl -fsSL https://vicrodh.github.io/qbz-apt/qbz-archive-keyring.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/qbz-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/qbz-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://vicrodh.github.io/qbz-apt stable main" | sudo tee /etc/apt/sources.list.d/qbz.list
+cat <<EOF | sudo tee /etc/apt/sources.list.d/qbz.sources
+Types: deb
+URIs: https://vicrodh.github.io/qbz-apt
+Suites: stable
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /usr/share/keyrings/qbz-archive-keyring.gpg
+EOF
 sudo apt update && sudo apt install qbz
 ```
 


### PR DESCRIPTION
While upgrading to Ubuntu 26.04 it disabled the old `.list` format and forced me to switch to `.sources` (new deb822 format)

As this is only a small change in the README, no UI is included, or new Release built, I did not rename the branch, include screenshots or a list of breaking changes.