### PR TITLE
fix(cast): make DLNA casting work with strict renderers (specifically, HQPlayer6)

### DIFF
--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -1,7 +1,6 @@
 //! DLNA device connection and playback via AVTransport SOAP
 
 use rupnp::http::Uri;
-use rupnp::ssdp::URN;
 use rupnp::{Device, Service};
 use serde::{Deserialize, Serialize};
 
@@ -63,10 +62,9 @@ impl DlnaConnection {
             DlnaError::Connection(format!("Failed to load device description: {}", e))
         })?;
 
-        let av_transport_service = parsed_device.find_service(&av_transport_urn()).cloned();
-        let rendering_control_service = parsed_device
-            .find_service(&rendering_control_urn())
-            .cloned();
+        let av_transport_service = find_service_any_version(&parsed_device, "AVTransport");
+        let rendering_control_service =
+            find_service_any_version(&parsed_device, "RenderingControl");
 
         log::info!(
             "DLNA: Connected to {} (AVT: {:?}, RC: {:?})",
@@ -477,8 +475,15 @@ fn build_didl_metadata(uri: &str, metadata: &DlnaMetadata, content_type: &str) -
         .unwrap_or_default();
 
     // Use actual content type for protocolInfo - critical for DLNA compatibility
-    // Many devices reject content if protocolInfo doesn't match actual MIME type
-    let protocol_info = format!("http-get:*:{}:*", content_type);
+    // Many devices reject content if protocolInfo doesn't match actual MIME type.
+    // The 4th field advertises the same DLNA content features the media server
+    // sends on GET/HEAD (see `media_server::DLNA_CONTENT_FEATURES`); strict
+    // renderers cross-check these against the response headers.
+    let protocol_info = format!(
+        "http-get:*:{}:{}",
+        content_type,
+        crate::media_server::DLNA_CONTENT_FEATURES
+    );
 
     format!(
         r#"<DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
@@ -512,10 +517,45 @@ fn xml_escape(s: &str) -> String {
         .replace('\'', "&apos;")
 }
 
-fn av_transport_urn() -> URN {
-    URN::Service("schemas-upnp-org".into(), "AVTransport".into(), 1)
+/// Version-agnostic service-type match: `true` when `service_type` names
+/// `service` at any UPnP version. Shared by [`find_service_any_version`] so the
+/// rule can be unit-tested without constructing a real rupnp `Device`.
+fn service_type_matches(service_type: &str, service: &str) -> bool {
+    service_type.contains(&format!(":service:{}:", service))
 }
 
-fn rendering_control_urn() -> URN {
-    URN::Service("schemas-upnp-org".into(), "RenderingControl".into(), 1)
+/// Find a service by name regardless of its UPnP version (`:1`/`:2`/`:3`),
+/// matching discovery's substring logic so a `:2`/`:3`-only renderer connects.
+fn find_service_any_version(device: &Device, service: &str) -> Option<Service> {
+    device
+        .services_iter()
+        .find(|s| service_type_matches(&s.service_type().to_string(), service))
+        .cloned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::service_type_matches;
+
+    #[test]
+    fn matches_any_upnp_version() {
+        for st in [
+            "urn:schemas-upnp-org:service:AVTransport:1",
+            "urn:schemas-upnp-org:service:AVTransport:2",
+            "urn:schemas-upnp-org:service:AVTransport:3",
+        ] {
+            assert!(
+                service_type_matches(st, "AVTransport"),
+                "expected {st} to match AVTransport"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_unrelated_service() {
+        assert!(!service_type_matches(
+            "urn:schemas-upnp-org:service:ConnectionManager:1",
+            "AVTransport"
+        ));
+    }
 }

--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -44,6 +44,16 @@ pub struct DlnaConnection {
     rendering_control_service: Option<Service>,
     // Current media URI
     current_uri: Option<String>,
+    // Last SetAVTransportURI payload (URI + DIDL). Kept so `play()` can
+    // re-assert the content on a 702 "no contents" fault — HQPlayer6 clears
+    // CurrentURI when a track ends, which would otherwise make a bare Play
+    // (the manual play button, or a late auto-advance) fail permanently.
+    last_set_uri_payload: Option<String>,
+    // Set by `load_media`, cleared by `play`. When true the URI was just set, so
+    // `play` skips its idle pre-check (the content is already current) and avoids
+    // a redundant SetAVTransportURI. A bare play (manual button / resume) leaves
+    // it false so the pre-check runs.
+    uri_freshly_set: bool,
     is_playing: bool,
 }
 
@@ -80,6 +90,8 @@ impl DlnaConnection {
             av_transport_service,
             rendering_control_service,
             current_uri: None,
+            last_set_uri_payload: None,
+            uri_freshly_set: false,
             is_playing: false,
         })
     }
@@ -153,6 +165,10 @@ impl DlnaConnection {
 
         log::info!("DLNA: SetAVTransportURI response: {:?}", response);
         self.current_uri = Some(uri.to_string());
+        // Remember the exact payload so play() can re-assert it if the renderer
+        // later reports 702 "no contents" (see the retry loop in `play`).
+        self.last_set_uri_payload = Some(payload);
+        self.uri_freshly_set = true;
         log::info!("DLNA: Set URI to {}", uri);
 
         Ok(())
@@ -189,33 +205,141 @@ impl DlnaConnection {
             return Err(DlnaError::NotConnected);
         }
 
+        // Clone the service handle so the retry loop below doesn't hold an
+        // immutable `&self` borrow across the `&mut self` write of
+        // `self.is_playing` on success. `rupnp::Service` is `Clone`.
         let av_service = self
             .av_transport_service
             .as_ref()
-            .ok_or_else(|| DlnaError::Playback("Device has no AVTransport service".to_string()))?;
+            .ok_or_else(|| DlnaError::Playback("Device has no AVTransport service".to_string()))?
+            .clone();
 
-        let response = tokio::time::timeout(
-            std::time::Duration::from_secs(10),
-            av_service.action(
-                &self.device_url,
-                "Play",
-                "<InstanceID>0</InstanceID><Speed>1</Speed>",
-            ),
+        // Snapshot the last SetAVTransportURI payload up front so we can (re-)assert
+        // it without holding a `&self` borrow across the loop below.
+        let set_uri_payload = self.last_set_uri_payload.clone();
+
+        // PRE-CHECK — the core of the strict-renderer fix. When a track reaches its
+        // natural end HQPlayer6 finalises/clears the transport, so a *bare* Play at
+        // that point (the manual play button, or a resume after a stop) either
+        // faults 702 "No contents" or 200-OKs into a silent no-op (the "it just
+        // stops, no error, won't play" symptom). Both are cured the way the manual
+        // recovery works: re-assert the current URI so Play acts on fresh content
+        // (SetAVTransportURI + Play — the sequence that reliably starts a track).
+        // Only do this when the URI was NOT just set (skip the redundant SetURI on
+        // the auto-advance path, whose settle-race 702 the retry net below still
+        // covers) and the transport is idle (STOPPED / NO_MEDIA_PRESENT); a PAUSED
+        // transport is left untouched so pause→resume keeps its position.
+        let uri_freshly_set = std::mem::replace(&mut self.uri_freshly_set, false);
+        if !uri_freshly_set {
+            if let Some(payload) = set_uri_payload.as_deref() {
+                if Self::transport_is_idle(&av_service, &self.device_url).await {
+                    log::info!("DLNA: transport idle before Play; re-asserting SetAVTransportURI");
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        av_service.action(&self.device_url, "SetAVTransportURI", payload),
+                    )
+                    .await;
+                }
+            }
+        }
+
+        // Retry net for the residual settle race. AVTransport faults at a boundary:
+        //   701 "Transition not available" — pure settle race; wait and retry Play.
+        //   702 "No contents" — empty transport; re-assert the URI, then retry.
+        // HQPlayer6 returns these as a raw HTTP status line (e.g. "702"), which
+        // rupnp surfaces as `HttpErrorCode` before it parses a SOAP body;
+        // spec-compliant renderers return a SOAP Fault parsed into `UPnPError`.
+        // Match both. A renderer that accepts Play immediately sees a single attempt.
+        const PLAY_SETTLE_CODE: u16 = 701;
+        const PLAY_NO_CONTENT_CODE: u16 = 702;
+        const PLAY_MAX_ATTEMPTS: u32 = 6;
+
+        for attempt in 1..=PLAY_MAX_ATTEMPTS {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                av_service.action(
+                    &self.device_url,
+                    "Play",
+                    "<InstanceID>0</InstanceID><Speed>1</Speed>",
+                ),
+            )
+            .await
+            .map_err(|_| {
+                log::error!("DLNA: Play action timed out after 10s");
+                DlnaError::Playback("Play action timed out".to_string())
+            })?;
+
+            let e = match result {
+                Ok(response) => {
+                    log::info!("DLNA: Play response: {:?}", response);
+                    self.is_playing = true;
+                    log::info!("DLNA: Play started successfully");
+                    return Ok(());
+                }
+                Err(e) => e,
+            };
+
+            let code = match &e {
+                rupnp::Error::UPnPError(u) => Some(u.err_code()),
+                rupnp::Error::HttpErrorCode(c) => Some(c.as_u16()),
+                _ => None,
+            };
+            let reassert_uri = match code {
+                Some(PLAY_NO_CONTENT_CODE) => true,
+                Some(PLAY_SETTLE_CODE) => false,
+                _ => {
+                    log::error!("DLNA: Play action failed: {}", e);
+                    return Err(DlnaError::Playback(e.to_string()));
+                }
+            };
+
+            if attempt == PLAY_MAX_ATTEMPTS {
+                log::error!("DLNA: Play still faulting after {PLAY_MAX_ATTEMPTS} attempts: {e}");
+                return Err(DlnaError::Playback(e.to_string()));
+            }
+
+            if reassert_uri {
+                if let Some(payload) = set_uri_payload.as_deref() {
+                    let _ = tokio::time::timeout(
+                        std::time::Duration::from_secs(10),
+                        av_service.action(&self.device_url, "SetAVTransportURI", payload),
+                    )
+                    .await;
+                }
+            }
+
+            // Linear backoff: ~300 ms * attempt, so playback typically recovers
+            // within ~1–2 s and gives up after ~4.5 s worst case.
+            let backoff = std::time::Duration::from_millis(300 * attempt as u64);
+            log::warn!(
+                "DLNA: Play returned transient UPnP fault ({e}); \
+                 retry {attempt}/{PLAY_MAX_ATTEMPTS} after {backoff:?}"
+            );
+            tokio::time::sleep(backoff).await;
+        }
+
+        // Unreachable: the loop returns on success or on the final attempt.
+        unreachable!("play retry loop exited without returning")
+    }
+
+    /// True only if the renderer's transport is idle (STOPPED / NO_MEDIA_PRESENT).
+    /// On any query error/timeout returns `false` — "not known to be idle" — so we
+    /// never re-assert the URI under uncertainty and disturb a paused resume.
+    async fn transport_is_idle(av_service: &Service, device_url: &Uri) -> bool {
+        match tokio::time::timeout(
+            std::time::Duration::from_secs(3),
+            av_service.action(device_url, "GetTransportInfo", "<InstanceID>0</InstanceID>"),
         )
         .await
-        .map_err(|_| {
-            log::error!("DLNA: Play action timed out after 10s");
-            DlnaError::Playback("Play action timed out".to_string())
-        })?
-        .map_err(|e| {
-            log::error!("DLNA: Play action failed: {}", e);
-            DlnaError::Playback(e.to_string())
-        })?;
-
-        log::info!("DLNA: Play response: {:?}", response);
-        self.is_playing = true;
-        log::info!("DLNA: Play started successfully");
-        Ok(())
+        {
+            Ok(Ok(resp)) => matches!(
+                resp.get("CurrentTransportState")
+                    .map(|s| s.trim().to_ascii_uppercase())
+                    .as_deref(),
+                Some("STOPPED") | Some("NO_MEDIA_PRESENT")
+            ),
+            _ => false,
+        }
     }
 
     /// Pause playback

--- a/crates/qbz-cast/src/media_server.rs
+++ b/crates/qbz-cast/src/media_server.rs
@@ -17,6 +17,28 @@ use tiny_http::{Header, Method, Response, Server, StatusCode};
 
 use crate::CastError;
 
+/// DLNA `contentFeatures.dlna.org` value advertised on GET/HEAD responses.
+///
+/// `DLNA.ORG_OP=01` = byte-range seek supported, no time-seek.
+/// `DLNA.ORG_FLAGS=01700000...` = streaming/interactive-transfer flags.
+/// No `DLNA.ORG_PN` — FLAC has no standard DLNA profile name.
+///
+/// Strict renderers (e.g. HQPlayer) HEAD-probe the URL and treat the stream as
+/// invalid/finished without these headers. Kept in sync with the DIDL
+/// `protocolInfo` in `dlna::device::build_didl_metadata`.
+pub const DLNA_CONTENT_FEATURES: &str =
+    "DLNA.ORG_OP=01;DLNA.ORG_FLAGS=01700000000000000000000000000000";
+
+/// Chunked-encoding threshold for media responses.
+///
+/// tiny_http 0.12.0 auto-selects `Transfer-Encoding: chunked` (dropping
+/// `Content-Length`) once a body reaches its default 32 KiB threshold. Strict
+/// DLNA renderers (e.g. HQPlayer) reject a chunked media body: they play the
+/// few seconds they buffer, then go STOPPED without range-continuing. Raising
+/// the threshold above any real file size forces Identity encoding with an
+/// explicit `Content-Length` on every media response (200, 206, and HEAD).
+const NO_CHUNK_THRESHOLD: usize = usize::MAX;
+
 #[derive(Clone)]
 struct MediaEntry {
     content_type: String,
@@ -242,8 +264,12 @@ fn handle_request(
         url
     );
 
-    if method != &Method::Get {
-        log::warn!("MediaServer: Rejected non-GET request: {}", method);
+    // Allow GET and HEAD. Strict DLNA renderers HEAD-probe the URL to validate
+    // the resource before playing; 405-rejecting HEAD makes them treat the
+    // stream as invalid and stop shortly after buffering.
+    let is_head = method == &Method::Head;
+    if method != &Method::Get && !is_head {
+        log::warn!("MediaServer: Rejected unsupported method: {}", method);
         return Response::from_data(Vec::new()).with_status_code(StatusCode(405));
     }
 
@@ -280,6 +306,26 @@ fn handle_request(
         }
     };
 
+    // HEAD: advertise the resource (type/size/DLNA features) without reading
+    // any bytes. tiny_http suppresses the body for HEAD while still emitting the
+    // advertised Content-Length.
+    if is_head {
+        let headers = vec![
+            header("Content-Type", &entry.content_type),
+            header("Accept-Ranges", "bytes"),
+            header("transferMode.dlna.org", "Streaming"),
+            header("contentFeatures.dlna.org", DLNA_CONTENT_FEATURES),
+        ];
+        return Response::new(
+            StatusCode(200),
+            headers,
+            std::io::Cursor::new(Vec::new()),
+            Some(entry.size as usize),
+            None,
+        )
+        .with_chunked_threshold(NO_CHUNK_THRESHOLD);
+    }
+
     let range_header = request
         .headers()
         .iter()
@@ -294,9 +340,12 @@ fn handle_request(
     };
 
     let mut response = Response::from_data(data)
+        .with_chunked_threshold(NO_CHUNK_THRESHOLD)
         .with_status_code(status_code)
         .with_header(header("Content-Type", &entry.content_type))
-        .with_header(header("Accept-Ranges", "bytes"));
+        .with_header(header("Accept-Ranges", "bytes"))
+        .with_header(header("transferMode.dlna.org", "Streaming"))
+        .with_header(header("contentFeatures.dlna.org", DLNA_CONTENT_FEATURES));
 
     if let Some(content_range) = content_range {
         response = response.with_header(header("Content-Range", &content_range));

--- a/crates/qbz/src/cast_service.rs
+++ b/crates/qbz/src/cast_service.rs
@@ -33,6 +33,12 @@ type Runtime = Arc<AppRuntime<SlintAdapter>>;
 /// Cast position poll cadence (mirrors Tauri's `POSITION_POLL_INTERVAL_MS`).
 const POSITION_POLL_INTERVAL_MS: u64 = 1000;
 
+/// How close (in seconds) the renderer must get to a track's end before a DLNA
+/// `STOPPED`/`NO_MEDIA_PRESENT` counts as genuine end-of-track. A stop while the
+/// max observed position is further than this from the end is treated as a
+/// renderer hiccup (logged, no auto-advance) rather than a track end.
+const CAST_END_GUARD_SECS: f64 = 5.0;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum CastProtocol {
     Chromecast,
@@ -92,6 +98,12 @@ struct CastInner {
     is_playing: bool,
     // Track-end one-shot latch (reset on PLAYING).
     track_end_detected: bool,
+    // DLNA track-end guard: whether we've seen PLAYING for the current track,
+    // and the max position observed while playing. Many renderers reset RelTime
+    // to 0 on STOP, so the instantaneous position at the STOPPED poll is
+    // unreliable — track the max instead. Both reset per new track.
+    cast_saw_playing: bool,
+    cast_max_position: f64,
     // QConnect coexistence: remember whether QConnect was on before casting.
     qconnect_was_on_before_cast: bool,
     // Position-poll task; aborted on disconnect.
@@ -243,6 +255,8 @@ impl SlintCastService {
             inner.protocol = Some(proto);
             inner.connected_device_ip = Some(device_ip);
             inner.track_end_detected = false;
+            inner.cast_saw_playing = false;
+            inner.cast_max_position = 0.0;
         }
         self.push_connection_state().await;
         self.start_position_poll();
@@ -422,6 +436,8 @@ impl SlintCastService {
             inner.current_track_id = Some(track.id);
             inner.is_playing = true;
             inner.track_end_detected = false;
+            inner.cast_saw_playing = false;
+            inner.cast_max_position = 0.0;
         }
         // Quality label comes from the track's catalog metadata (always present,
         // no network call) so it's the same whether bytes came from cache,
@@ -743,14 +759,39 @@ impl SlintCastService {
         // Track-end detection (mirrors castStore): Chromecast {PLAYING,BUFFERING}
         // -> IDLE; DLNA PLAYING -> {STOPPED, NO_MEDIA_PRESENT}. One-shot latch,
         // reset on PLAYING.
+        //
+        // For DLNA a bare STOPPED is ambiguous: a strict renderer that hiccups
+        // mid-track also reports STOPPED. We only treat it as end-of-track when
+        // the track actually reached (near) its end — guarded by the max
+        // position observed while PLAYING. A premature STOPPED is logged and
+        // NOT advanced, and is not latched so a resume to PLAYING recovers.
+        let max_position;
         let ended = {
             let mut inner = self.inner.lock().await;
             inner.is_playing = playing;
+            if state == "PLAYING" {
+                inner.cast_saw_playing = true;
+                inner.cast_max_position = inner.cast_max_position.max(position);
+            }
+            max_position = inner.cast_max_position;
             let ended = match proto {
                 CastProtocol::Chromecast => state == "IDLE" && !inner.track_end_detected,
                 CastProtocol::Dlna => {
-                    matches!(state.as_str(), "STOPPED" | "NO_MEDIA_PRESENT")
-                        && !inner.track_end_detected
+                    let stopped =
+                        matches!(state.as_str(), "STOPPED" | "NO_MEDIA_PRESENT");
+                    // When duration is unknown (<= 0) keep the old behavior and
+                    // honor STOPPED, so we never get stuck. Otherwise require the
+                    // track to have played to within CAST_END_GUARD_SECS of the end.
+                    let near_end = duration <= 0.0
+                        || (inner.cast_saw_playing
+                            && max_position >= duration - CAST_END_GUARD_SECS);
+                    if stopped && !near_end && inner.cast_saw_playing {
+                        log::warn!(
+                            "[Cast] premature STOPPED, not advancing (state={state}, \
+                             max_position={max_position:.1}, duration={duration:.1})"
+                        );
+                    }
+                    stopped && near_end && !inner.track_end_detected
                 }
             };
             if state == "PLAYING" {
@@ -760,6 +801,11 @@ impl SlintCastService {
             }
             ended
         };
+
+        log::debug!(
+            "[Cast] poll: state={state} position={position:.1} duration={duration:.1} \
+             max_position={max_position:.1}"
+        );
 
         // Feed the lyrics engine our position so it auto-follows while casting
         // (the local poll is skipped, so it can't drive lyrics). The 30Hz sync
@@ -794,7 +840,10 @@ impl SlintCastService {
         });
 
         if ended {
-            log::info!("[Cast] track ended (state={state}); auto-advancing");
+            log::info!(
+                "[Cast] track ended (state={state}, position={position:.1}, \
+                 duration={duration:.1}, max_position={max_position:.1}); auto-advancing"
+            );
             // Run the SAME local advance the next button uses: it moves the
             // core cursor, refreshes the card + queue, and play_audible casts
             // the new current track. Keeps the UI and renderer in sync.


### PR DESCRIPTION
## Summary

Fixes DLNA casting to strict renderers, reproduced end-to-end with **HQPlayer6**. Three problems, in the order they surfaced:

1. **Couldn't connect.** Services were matched by the hard-coded URN version `:1`, so a `:2`/`:3`-only renderer's `AVTransport`/`RenderingControl` were never found. Now matched by service name at **any** UPnP version.

2. **Each track played ~2–4s, then STOPPED and never re-requested the stream.** The FLAC itself is fine (`ffmpeg -f null -` decodes it clean) — the cause is **transfer encoding**. The media server let `tiny_http` auto-select it, and `choose_transfer_encoding` switches to `Transfer-Encoding: chunked` (dropping `Content-Length`) once a body passes its 32 KiB default. Whole tracks are 100+ MB, so GET **and** HEAD went out chunked with no length, which strict renderers reject. Fixed by pinning `with_chunked_threshold(usize::MAX)` on every media response to force Identity encoding with an explicit `Content-Length` on 200, 206, and HEAD.

3. **Hardening for strict renderers** (each helped or was needed alongside the above):
   - Answer `HEAD` (200 + `Content-Type`/`Accept-Ranges`/`Content-Length`/DLNA headers) instead of 405 — renderers HEAD-probe before playing.
   - Advertise `transferMode.dlna.org` and `contentFeatures.dlna.org` on GET/HEAD, and set the DIDL `protocolInfo` 4th field to the same features (was `*`).
   - Guard DLNA track-end detection: a bare `STOPPED` is ambiguous, so track the max position seen while `PLAYING` and only auto-advance within 5s of the end; a premature `STOPPED` is logged and ignored (not latched) so a resume recovers. Falls back to honoring `STOPPED` when duration is unknown.

## Testing

- `qbz-cast` and `qbz` type-check clean.
- On the wire while casting: `HEAD` returns `Content-Length` with **no** `Transfer-Encoding: chunked`; ranged `GET` returns `206` with the correct `Content-Range`.
- HQPlayer6 now plays each track to its natural end and auto-advances; pause/play/next work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)