### PR TITLE
fix(nix): add libjack2 to buildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -70,6 +70,7 @@
             alsa-lib
             fontconfig
             freetype
+            libjack2
           ];
 
           # The qbz_ui rustc alone peaks ~30 GB; running the test profile on


### PR DESCRIPTION
## Problem

Building QBZ v2.0.0 from `flake.nix` fails while compiling the `jack-sys`
crate (pulled in through `rodio -> cpal`). pkg-config cannot locate the JACK
library because `libjack2` is missing from the derivation `buildInputs`:

```
The system library `jack` required by crate `jack-sys` was not found.
The file `jack.pc` needs to be installed and the PKG_CONFIG_PATH environment
variable must contain its parent directory.
```

## Fix

Add `libjack2` to `buildInputs` so `jack.pc` is on `PKG_CONFIG_PATH` and
`jack-sys` links at build time.

## Testing

`nix build` completes and produces the `qbz` binary with the change applied;
it fails as shown above without it.

## Notes

- No breaking changes; one-line change scoped to `flake.nix`.
- Does not touch audio-backend routing or any protected area.

Closes #562
