### PR TITLE
fix(favorites): sync album favorite state on artist page and related albums

### DIFF
--- a/src/lib/components/views/AlbumDetailView.svelte
+++ b/src/lib/components/views/AlbumDetailView.svelte
@@ -209,6 +209,12 @@
 
   let isFavorite = $state(false);
   let isFavoriteLoading = $state(false);
+  // Bumped on albumFavoritesStore changes so the "By the same artist" grid's
+  // per-card `isFavorite` reads stay reactive.
+  let relatedFavoritesVersion = $state(0);
+  function isRelatedFav(albumId: string): boolean {
+    return relatedFavoritesVersion >= 0 && isAlbumFavorite(albumId);
+  }
   // Counter incremented when the unavailable-tracks store mutates so reactive
   // reads in {@const} blocks re-evaluate.
   let unavailableVersion = $state(0);
@@ -560,6 +566,7 @@
         loadCustomCoverStatus();
         unsubscribe = subscribeAlbumFavorites(() => {
           isFavorite = isAlbumFavorite(album.id);
+          relatedFavoritesVersion++;
         });
       } catch (err) {
         console.error('Failed to check album favorite status:', err);
@@ -1030,6 +1037,8 @@
                 genre={relatedAlbum.genre}
                 releaseYear={Number(relatedAlbum.releaseDate?.slice(0, 4)) || undefined}
                 quality={relatedAlbum.quality}
+                isFavorite={isRelatedFav(relatedAlbum.id)}
+                onFavorite={() => toggleAlbumFavorite(relatedAlbum.id)}
                 isAlbumFullyDownloaded={isRelatedAlbumDownloaded(relatedAlbum.id)}
                 onArtistClick={album.artistId && onTrackGoToArtist ? () => onTrackGoToArtist(album.artistId!) : undefined}
                 onClick={() => onRelatedAlbumClick?.(relatedAlbum.id)}

--- a/src/lib/components/views/ArtistDetailView.svelte
+++ b/src/lib/components/views/ArtistDetailView.svelte
@@ -41,6 +41,11 @@
     isTrackToggling,
     toggleTrackFavorite
   } from '$lib/stores/favoritesStore';
+  import {
+    subscribe as subscribeAlbumFavorites,
+    isAlbumFavorite,
+    toggleAlbumFavorite
+  } from '$lib/stores/albumFavoritesStore';
   import { tick, onMount, onDestroy } from 'svelte';
   import { getUserItem, setUserItem } from '$lib/utils/userStorage';
   import ImageLightbox from '../ImageLightbox.svelte';
@@ -246,6 +251,7 @@
   let isFavorite = $state(false);
   let isFavoriteLoading = $state(false);
   let trackFavoritesVersion = $state(0); // Bumped on favoritesStore changes to trigger reactivity
+  let albumFavoritesVersion = $state(0); // Bumped on albumFavoritesStore changes to trigger reactivity
 
   // Helpers that read trackFavoritesVersion to establish reactive dependency for the {#each} block
   function checkTrackFav(trackId: number): boolean {
@@ -253,6 +259,11 @@
   }
   function checkTrackToggling(trackId: number): boolean {
     return trackFavoritesVersion >= 0 && isTrackToggling(trackId);
+  }
+  // Reads albumFavoritesVersion so discography {#each} blocks re-evaluate when
+  // an album's favorite state changes (here or from the album detail view).
+  function checkAlbumFav(albumId: string): boolean {
+    return albumFavoritesVersion >= 0 && isAlbumFavorite(albumId);
   }
 
   let isRadioLoading = $state(false);
@@ -268,6 +279,7 @@
   let unsubscribeSidebar: (() => void) | null = null;
   let unsubscribeBlacklist: (() => void) | null = null;
   let unsubscribeTrackFavorites: (() => void) | null = null;
+  let unsubscribeAlbumFavorites: (() => void) | null = null;
 
   function updateBlacklistState() {
     artistIsBlacklisted = isBlacklisted(artist.id);
@@ -300,6 +312,11 @@
     // Subscribe to track favorites changes
     unsubscribeTrackFavorites = subscribeFavorites(() => {
       trackFavoritesVersion++;
+    });
+
+    // Subscribe to album favorites changes so discography hearts stay in sync
+    unsubscribeAlbumFavorites = subscribeAlbumFavorites(() => {
+      albumFavoritesVersion++;
     });
 
     // Load custom image status
@@ -337,6 +354,7 @@
     unsubscribeSidebar?.();
     unsubscribeBlacklist?.();
     unsubscribeTrackFavorites?.();
+    unsubscribeAlbumFavorites?.();
     unsubscribeAppearance?.();
     jumpNavObserver?.disconnect();
     // Close the network sidebar when leaving artist view
@@ -2460,6 +2478,8 @@
           {#each filteredAlbums as album}
             <AlbumCard
               albumId={album.id}
+              isFavorite={checkAlbumFav(album.id)}
+              onFavorite={() => toggleAlbumFavorite(album.id)}
               artwork={album.artwork}
               title={album.title}
               artist={album.year ? String(album.year) : ''}
@@ -2525,6 +2545,8 @@
         {#each filteredEpsSingles as album}
           <AlbumCard
             albumId={album.id}
+            isFavorite={checkAlbumFav(album.id)}
+            onFavorite={() => toggleAlbumFavorite(album.id)}
             artwork={album.artwork}
             title={album.title}
             artist={album.year ? String(album.year) : ''}
@@ -2589,6 +2611,8 @@
         {#each filteredLiveAlbums as album}
           <AlbumCard
             albumId={album.id}
+            isFavorite={checkAlbumFav(album.id)}
+            onFavorite={() => toggleAlbumFavorite(album.id)}
             artwork={album.artwork}
             title={album.title}
             artist={album.year ? String(album.year) : ''}
@@ -2653,6 +2677,8 @@
         {#each filteredCompilations as album}
           <AlbumCard
             albumId={album.id}
+            isFavorite={checkAlbumFav(album.id)}
+            onFavorite={() => toggleAlbumFavorite(album.id)}
             artwork={album.artwork}
             title={album.title}
             artist={album.year ? String(album.year) : ''}
@@ -2710,6 +2736,8 @@
         {#each filteredOthers as album}
           <AlbumCard
             albumId={album.id}
+            isFavorite={checkAlbumFav(album.id)}
+            onFavorite={() => toggleAlbumFavorite(album.id)}
             artwork={album.artwork}
             title={album.title}
             artist={album.year ? String(album.year) : ''}
@@ -2837,6 +2865,8 @@
           {#each visibleTributes as album}
             <AlbumCard
               albumId={album.id}
+              isFavorite={checkAlbumFav(album.id)}
+              onFavorite={() => toggleAlbumFavorite(album.id)}
               artwork={album.artwork}
               title={album.title}
               artist={album.year ? String(album.year) : ''}


### PR DESCRIPTION
Album cards on the artist page never received the favorite state from `albumFavoritesStore`, so their hearts always rendered empty even when the album was already favorited (which the album detail page showed correctly), leaving the two views out of sync.

This wires each artist-page discography card (albums, EPs & singles, live, compilations, others, tributes) and the album detail page's "By the same artist" grid to read `isAlbumFavorite` reactively via a store subscription, and to toggle via `toggleAlbumFavorite`, matching the existing pattern in DiscoveryView. Favorite state now stays in sync across the artist page, album detail page, and related-albums grid, and the heart is clickable in all of them.

Verified with `npm run check` (0 errors; only pre-existing unrelated warnings).