### PR TITLE
ci: add test-crates workflow for workspace unit tests

### DIFF
--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -1,0 +1,68 @@
+name: Test crates
+
+# Unit/doc tests for the shipping Rust workspace (no Slint UI graph).
+# Intentionally excludes qbz / qbz-ui / qbz-dac-wizard / qbz-slint-common so
+# CI never hits the 20–30 GB UI compile wall. Warm runs are a few seconds;
+# cold first run is dominated by dependency compile + rust-cache restore.
+
+on:
+  pull_request:
+    branches: [pre-release, main]
+    paths:
+      - "crates/**"
+      - "scripts/cargo-test.sh"
+      - ".github/workflows/test-crates.yml"
+  push:
+    branches: [pre-release]
+    paths:
+      - "crates/**"
+      - "scripts/cargo-test.sh"
+      - ".github/workflows/test-crates.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: test-crates-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: cargo test (workspace, no UI)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: System dependencies
+        run: |
+          # Non-UI crates still link Linux audio / D-Bus stubs (qbz-audio).
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential pkg-config \
+            libasound2-dev libjack-jackd2-dev \
+            libdbus-1-dev libssl-dev
+
+      - name: Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: test-crates-linux
+          cache-on-failure: true
+
+      - name: cargo test
+        env:
+          CARGO_TERM_COLOR: always
+          CARGO_BUILD_JOBS: "2"
+          # Keyring / credentials tests skip themselves when CI=true.
+          CI: "true"
+        run: |
+          echo "::group::rustc / cargo"
+          rustc -V
+          cargo -V
+          echo "::endgroup::"
+          START=$(date +%s)
+          ./scripts/cargo-test.sh
+          END=$(date +%s)
+          echo "cargo test wall time: $((END - START))s"

--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -1,18 +1,30 @@
-name: Test crates
+# Workspace unit/doc tests for the shipping crates/ tree (Slint-era).
+#
+# Companion to the release/build workflows, not a substitute:
+#   - release-linux / build-slint / release-snap compile -p qbz (full UI, ~30 GB peak)
+#   - this job runs `cargo test` on every non-UI crate only (~5 min cold, ~1–2 min warm)
+#
+# Excludes qbz, qbz-ui, qbz-dac-wizard, qbz-slint-common so the UI compile unit
+# never enters the graph. Cache key is intentionally separate from
+# `slint-linux` (stable + test profile vs nightly + release).
+#
+# Repo policy note: release builds stay tag/dispatch-only. This is the one
+# workflow that runs on pre-release integration so regressions land before a
+# release cut. Path-filtered so packaging/docs PRs skip it.
 
-# Unit/doc tests for the shipping Rust workspace (no Slint UI graph).
-# Intentionally excludes qbz / qbz-ui / qbz-dac-wizard / qbz-slint-common so
-# CI never hits the 20–30 GB UI compile wall. Warm runs are a few seconds;
-# cold first run is dominated by dependency compile + rust-cache restore.
+name: test-crates
 
 on:
   pull_request:
+    # pre-release is the real base; main is listed so a PR opened against main
+    # still runs once before redirect-pr-to-prerelease retargets it.
     branches: [pre-release, main]
     paths:
       - "crates/**"
       - "scripts/cargo-test.sh"
       - ".github/workflows/test-crates.yml"
   push:
+    # Integration branch only — never main (a push to main is a release merge).
     branches: [pre-release]
     paths:
       - "crates/**"
@@ -21,44 +33,60 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: test-crates-${{ github.workflow }}-${{ github.ref }}
+  group: test-crates-${{ github.ref }}
   cancel-in-progress: true
+
+permissions:
+  contents: read
 
 jobs:
   test:
     name: cargo test (workspace, no UI)
     runs-on: ubuntu-24.04
-    timeout-minutes: 45
+    # Cold first run ~5 min (compile + test); warm ~1–2 min. Headroom for
+    # registry lag / cache restore, not for a Slint UI compile.
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-      - name: System dependencies
+      - name: Install system dependencies
         run: |
-          # Non-UI crates still link Linux audio / D-Bus stubs (qbz-audio).
+          # Minimal subset of release-linux.yml deps: non-UI crates still link
+          # ALSA / JACK / D-Bus (qbz-audio) and OpenSSL (reqwest). mold matches
+          # the release linker for faster test-binary link.
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config \
+            build-essential pkg-config mold \
             libasound2-dev libjack-jackd2-dev \
             libdbus-1-dev libssl-dev
 
-      - name: Rust toolchain
+      # Floating stable is fine here: rust-cache keys on rustc -V, so a stable
+      # bump just rebuilds the test cache once. Nightly is reserved for the
+      # release/UI builds that need -Z threads.
+      - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Cargo cache
+      - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
+          # Manifest is crates/Cargo.toml → artifacts in crates/target (same
+          # workspaces mapping as release-linux / build-slint).
           workspaces: crates -> target
           shared-key: test-crates-linux
           cache-on-failure: true
+          # PRs restore only. pre-release pushes write so the integration
+          # branch keeps the cache warm (mirrors release-linux save-if policy).
+          save-if: ${{ github.ref == 'refs/heads/pre-release' }}
 
       - name: cargo test
         env:
           CARGO_TERM_COLOR: always
           CARGO_BUILD_JOBS: "2"
-          # Keyring / credentials tests skip themselves when CI=true.
-          CI: "true"
+          # Faster link; no -Z flags (stable toolchain).
+          RUSTFLAGS: "-C link-arg=-fuse-ld=mold"
         run: |
-          echo "::group::rustc / cargo"
+          echo "::group::toolchain"
           rustc -V
           cargo -V
           echo "::endgroup::"

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ AGENTS.md
 # /crates/Cargo.lock  # tracked for reproducible CI builds
 test-results/
 
+
+# Isolated cargo test target dir (scripts / agents)
+/crates/target-test/

--- a/crates/qbz-integrations/src/listenbrainz/mod.rs
+++ b/crates/qbz-integrations/src/listenbrainz/mod.rs
@@ -12,7 +12,7 @@
 //! ## Usage
 //!
 //! ```no_run
-//! use qbz_integrations::{ListenBrainzClient, ListenBrainzConfig, ListenType};
+//! use qbz_integrations::{ListenBrainzClient, ListenBrainzConfig};
 //!
 //! async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //!     let config = ListenBrainzConfig {
@@ -23,15 +23,15 @@
 //!
 //!     let client = ListenBrainzClient::with_config(config);
 //!
-//!     // Submit now playing
-//!     client.submit_listen(
-//!         ListenType::PlayingNow,
-//!         "Artist",
-//!         "Track",
-//!         Some("Album"),
-//!         None, // No timestamp for now playing
-//!         None, // No MBIDs
-//!     ).await?;
+//!     // Now playing (no timestamp)
+//!     client
+//!         .submit_playing_now("Artist", "Track", Some("Album"), None)
+//!         .await?;
+//!
+//!     // Scrobble after the track finishes
+//!     client
+//!         .submit_listen("Artist", "Track", Some("Album"), 1_700_000_000, None)
+//!         .await?;
 //!
 //!     Ok(())
 //! }

--- a/crates/qbz-library/src/local_playlists.rs
+++ b/crates/qbz-library/src/local_playlists.rs
@@ -105,8 +105,25 @@ fn now_ms() -> i64 {
 /// Create the local-playlist tables. Idempotent (`IF NOT EXISTS`), run by
 /// `LibraryDatabase::open` next to the rest of the schema.
 pub fn init_schema(conn: &Connection) -> Result<()> {
+    // `local_playlists.folder_id` references the shared sidebar folders table
+    // owned by `LibraryDatabase`. Create it here too so this module's schema
+    // is self-contained (unit tests open an in-memory DB and only call
+    // `init_schema`; production already creates `playlist_folders` first).
     conn.execute_batch(
         r#"
+        CREATE TABLE IF NOT EXISTS playlist_folders (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            icon_type TEXT DEFAULT 'preset',
+            icon_preset TEXT DEFAULT 'folder',
+            icon_color TEXT DEFAULT '#6366f1',
+            custom_image_path TEXT,
+            is_hidden INTEGER DEFAULT 0,
+            position INTEGER DEFAULT 0,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        );
+
         CREATE TABLE IF NOT EXISTS local_playlists (
             id TEXT PRIMARY KEY,
             name TEXT NOT NULL,

--- a/crates/qbz-playlist-import/src/match_qobuz.rs
+++ b/crates/qbz-playlist-import/src/match_qobuz.rs
@@ -327,6 +327,7 @@ mod tests {
             id,
             title: title.to_string(),
             version: None,
+            work: None,
             isrc: None,
             duration: 0,
             track_number: 0,

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Run the shipping-stack unit/doc tests (crates workspace).
+#
+# Excludes the Slint UI compile graph (qbz-ui + dependents). Building those for
+# tests re-triggers the UI "memory wall" and is unnecessary: qbz-ui has no
+# #[test]s, and the binary crate's tests need a full Slint link.
+#
+# Usage:
+#   ./scripts/cargo-test.sh              # default: workspace minus UI graph
+#   ./scripts/cargo-test.sh -- --lib     # extra args after -- go to cargo test
+#   CARGO_BUILD_JOBS=1 ./scripts/cargo-test.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+
+exec cargo test \
+  --manifest-path crates/Cargo.toml \
+  --workspace \
+  --exclude qbz \
+  --exclude qbz-ui \
+  --exclude qbz-dac-wizard \
+  --exclude qbz-slint-common \
+  --no-fail-fast \
+  "$@"

--- a/scripts/cargo-test.sh
+++ b/scripts/cargo-test.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Run the shipping-stack unit/doc tests (crates workspace).
 #
-# Excludes the Slint UI compile graph (qbz-ui + dependents). Building those for
-# tests re-triggers the UI "memory wall" and is unnecessary: qbz-ui has no
-# #[test]s, and the binary crate's tests need a full Slint link.
+# Same command CI uses (.github/workflows/test-crates.yml). Excludes the Slint
+# UI compile graph (qbz-ui + dependents) so a laptop / Actions runner never hits
+# the 20–30 GB UI memory wall. qbz-ui has no #[test]s; the binary crate's tests
+# need a full Slint link and stay out of the default suite.
 #
 # Usage:
-#   ./scripts/cargo-test.sh              # default: workspace minus UI graph
-#   ./scripts/cargo-test.sh -- --lib     # extra args after -- go to cargo test
+#   ./scripts/cargo-test.sh
+#   ./scripts/cargo-test.sh -- --lib          # skip doctests
 #   CARGO_BUILD_JOBS=1 ./scripts/cargo-test.sh
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

Adds a path-filtered `test-crates` GitHub Actions workflow that runs `./scripts/cargo-test.sh` on the shipping `crates/` workspace **without** compiling the Slint UI (so CI never hits the 20–30 GB memory wall).

Aligned with existing release CI conventions (`release-linux` / `build-slint`):

- kebab name `test-crates`, `ubuntu-24.04`, `contents: read`
- cache map `workspaces: crates -> target`, key `test-crates-linux` (separate from `slint-linux`)
- cache **writes only from `pre-release`** (`save-if`); PRs restore only
- `mold` linker via `RUSTFLAGS` (same as release)
- triggers: PR → `pre-release`/`main`; push → `pre-release` only (never main)
- timeout 20 min

Also fixes three suite green-blockers:

- `local_playlists::init_schema` creates shared `playlist_folders` (14 unit tests)
- `Track.work` field in playlist-import test fixture
- stale ListenBrainz doctest API

## Measured wall time (fork Actions)

| Run | Cache | `cargo test` wall | Full job |
|-----|-------|-------------------|----------|
| Cold | miss | ~229s | ~4m45s |
| Warm | hit | ~70–176s | ~1.5–4 min |

Local warm: ~2–6.5s. Worth running on CI for any PR that touches `crates/**`.

## Test plan

- [x] Green on fork PR: https://github.com/afonsojramos/qbz/pull/59
- [x] Upstream Actions run green on this PR
- [x] Confirm log shows no `qbz-ui` compile and `save-if: false` on the PR path