### PR TITLE
fix(log): redact secrets on stderr and stop Last.fm body dumps

### DIFF
--- a/crates/qbz-integrations/src/lastfm/client.rs
+++ b/crates/qbz-integrations/src/lastfm/client.rs
@@ -115,8 +115,7 @@ impl LastFmClient {
             .await?;
 
         let response_text = response.text().await?;
-        log::debug!("Last.fm auth.getSession response: {}", response_text);
-
+        // Do not log the raw body: it includes the session key.
         let data: LastFmResponse<AuthGetSessionResponse> = serde_json::from_str(&response_text)?;
 
         match data {

--- a/crates/qbz-log/src/lib.rs
+++ b/crates/qbz-log/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! It owns a composite [`log::Log`] implementation ([`tee::TeeLogger`]) that wraps
 //! `env_logger`'s built `Logger` and fans every record out to three sinks:
-//!   1. **stderr** (delegated to the inner `env_logger` logger, format unchanged),
+//!   1. **stderr** (redacted text, same line format as the file sink),
 //!   2. a bounded **in-memory ring** ([`ring`], cap [`ring::RING_CAP`]), and
 //!   3. an **on-disk file** (`~/.local/share/qbz/logs/qbz.log`, prev-rotated at startup).
 //!
 //! Secret **redaction** ([`redact`]) is applied once at the single write choke point,
-//! so every downstream consumer (ring, file, clipboard, paste upload) gets clean text.
+//! so every downstream consumer (stderr, ring, file, clipboard, paste upload) gets clean text.
 //!
 //! This crate is network-free and UI-free: no `reqwest`, no `tokio`, no `slint`.
 

--- a/crates/qbz-log/src/tee.rs
+++ b/crates/qbz-log/src/tee.rs
@@ -11,8 +11,7 @@ use crate::{redact, ring};
 
 /// Wraps `env_logger`'s built `Logger` and tees every record to the in-memory ring and
 /// (optionally) the on-disk log file, with secret redaction applied once at this single
-/// write choke point. stderr output is preserved verbatim by delegating to the inner
-/// logger after the tee.
+/// write choke point. **All** sinks (ring, file, and stderr) receive the redacted text.
 pub struct TeeLogger {
     pub(crate) inner: env_logger::Logger,
     pub(crate) file: Option<Mutex<BufWriter<File>>>,
@@ -20,6 +19,17 @@ pub struct TeeLogger {
 
 fn now_epoch_ms() -> i64 {
     chrono::Local::now().timestamp_millis()
+}
+
+/// Format a redacted log line the same way the file sink does (stable, greppable).
+fn format_line(line: &LogLine) -> String {
+    format!(
+        "{} {:5} {} {}",
+        line.format_ts(),
+        line.level_str(),
+        line.target,
+        line.message
+    )
 }
 
 impl Log for TeeLogger {
@@ -46,19 +56,14 @@ impl Log for TeeLogger {
 
         if let Some(file) = &self.file {
             if let Ok(mut writer) = file.lock() {
-                let _ = writeln!(
-                    writer,
-                    "{} {:5} {} {}",
-                    line.format_ts(),
-                    line.level_str(),
-                    line.target,
-                    msg
-                );
+                let _ = writeln!(writer, "{}", format_line(&line));
             }
         }
 
-        // Preserve the original env_logger stderr output verbatim.
-        self.inner.log(record);
+        // stderr: write the redacted line ourselves. Delegating to
+        // `self.inner.log(record)` would reprint the *original* Record args
+        // and bypass redaction (terminal transcripts, CI logs, support dumps).
+        let _ = writeln!(std::io::stderr(), "{}", format_line(&line));
     }
 
     fn flush(&self) {
@@ -68,5 +73,25 @@ impl Log for TeeLogger {
                 let _ = writer.flush();
             }
         }
+        let _ = std::io::stderr().flush();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use log::Level;
+
+    #[test]
+    fn format_line_includes_redacted_message_not_raw() {
+        let line = LogLine {
+            ts: 0,
+            level: Level::Info,
+            target: "qbz".into(),
+            message: "token=***REDACTED***".into(),
+        };
+        let s = format_line(&line);
+        assert!(s.contains("***REDACTED***"));
+        assert!(!s.contains("SEKRET"));
     }
 }

--- a/crates/qbz/src/auth.rs
+++ b/crates/qbz/src/auth.rs
@@ -243,6 +243,9 @@ where
             return Ok(None);
         }
     };
+    // Same redaction registration as the browser login path — cold restore
+    // must scrub bare token substrings from logs for the whole session.
+    qbz_log::register_secret(token.clone());
 
     let core = runtime.core();
     // Same scoped handling of the gated cold bundle init as the browser


### PR DESCRIPTION
## Summary

Secret redaction was applied to the in-memory ring and the log file, but stderr got the **original** record: `TeeLogger` delegated to the inner `env_logger`, which reprinted the unredacted message. Terminal transcripts, CI logs, and support dumps could therefore contain live tokens.

- `TeeLogger` now writes the redacted line to stderr itself (same stable format as the file sink) instead of delegating to `env_logger`; the inner logger is kept for level/filter decisions only.
- Register OAuth tokens restored from cold storage for literal scrubbing, matching the browser-login path, so a bare token substring is redacted for the whole session.
- Stop debug-logging the Last.fm `auth.getSession` response body, which includes the session key.
- `flush()` now also flushes stderr.

Trade-off: stderr loses `env_logger`'s coloring in exchange for never printing unredacted text.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.