### PR TITLE
fix(player): clear playing state when seek rebuild fails

### DIFF
--- a/crates/qbz-player/src/player/mod.rs
+++ b/crates/qbz-player/src/player/mod.rs
@@ -3113,18 +3113,25 @@ impl Player {
 
                             log::info!("Audio thread: seeking to {}s", position_secs);
 
+                            // After take(), every failure path must clear playing
+                            // state — otherwise UI can show "playing" with no engine.
                             if let Some(engine) = current_engine.take() {
                                 engine.stop();
                             }
+                            let seek_abort = |thread_state: &SharedState, why: &str| {
+                                log::error!("Audio thread: seek aborted: {why}");
+                                thread_state.is_playing.store(false, Ordering::SeqCst);
+                                thread_state.set_stream_error(true);
+                            };
 
                             let mut engine = match stream {
                                 StreamType::Rodio { sink: mixer_sink, .. } => {
                                     match PlaybackEngine::new_rodio(&mixer_sink.mixer()) {
                                         Ok(e) => e,
                                         Err(e) => {
-                                            log::error!(
-                                                "Failed to create rodio engine for seek: {}",
-                                                e
+                                            seek_abort(
+                                                &thread_state,
+                                                &format!("rodio engine create failed: {e}"),
                                             );
                                             return;
                                         }
@@ -3171,18 +3178,18 @@ impl Player {
                                 match IncrementalStreamingSource::new(stream_src.clone()) {
                                     Ok(mut s) => {
                                         if let Err(e) = s.seek_to(skip_duration) {
-                                            log::error!(
-                                                "Failed to native-seek streaming source: {}",
-                                                e
+                                            seek_abort(
+                                                &thread_state,
+                                                &format!("streaming native seek failed: {e}"),
                                             );
                                             return;
                                         }
                                         Box::new(s)
                                     }
                                     Err(e) => {
-                                        log::error!(
-                                            "Failed to create streaming source for seek: {}",
-                                            e
+                                        seek_abort(
+                                            &thread_state,
+                                            &format!("streaming source for seek failed: {e}"),
                                         );
                                         return;
                                     }
@@ -3202,9 +3209,11 @@ impl Player {
                                             match decode_with_fallback(audio_data) {
                                                 Ok(fb) => Box::new(fb.skip_duration(skip_duration)),
                                                 Err(e) => {
-                                                    log::error!(
-                                                        "Failed to decode audio for seek: {}",
-                                                        e
+                                                    seek_abort(
+                                                        &thread_state,
+                                                        &format!(
+                                                            "decode for seek failed: {e}"
+                                                        ),
                                                     );
                                                     return;
                                                 }
@@ -3219,9 +3228,11 @@ impl Player {
                                         match decode_with_fallback(audio_data) {
                                             Ok(fb) => Box::new(fb.skip_duration(skip_duration)),
                                             Err(e) => {
-                                                log::error!(
-                                                    "Failed to decode audio for seek: {}",
-                                                    e
+                                                seek_abort(
+                                                    &thread_state,
+                                                    &format!(
+                                                        "decode for seek failed: {e}"
+                                                    ),
                                                 );
                                                 return;
                                             }
@@ -3243,7 +3254,10 @@ impl Player {
                                 &analyzer_enabled,
                             );
                             if let Err(e) = engine.append(skipped_source) {
-                                log::error!("Failed to append source for seek: {}", e);
+                                seek_abort(
+                                    &thread_state,
+                                    &format!("append source for seek failed: {e}"),
+                                );
                                 return;
                             }
 
@@ -3258,6 +3272,7 @@ impl Player {
                             }
 
                             *current_engine = Some(engine);
+                            thread_state.set_stream_error(false);
                             log::info!(
                                 "Audio thread: seeked to {}s (was_playing: {})",
                                 position_secs,


### PR DESCRIPTION
## Summary

Seek rebuilds the playback engine after `current_engine.take()`. Every failure path after that point (rodio engine creation, streaming source creation, native seek, decode, append) used to just log and return, leaving no engine while `is_playing` stayed `true`: the UI showed a silent "playing" state with no way to recover except starting a new track.

- Introduce a `seek_abort` helper used by all seek failure paths: logs the cause, stores `is_playing = false`, and sets `stream_error` so the UI reflects the failure.
- Clear `stream_error` again once a seek rebuild succeeds.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.