### PR TITLE
fix(player): stop DoP writer on ALSA write failure

### DIFF
--- a/crates/qbz-player/src/player/playback_engine.rs
+++ b/crates/qbz-player/src/player/playback_engine.rs
@@ -956,7 +956,13 @@ fn dop_writer_thread(
 
         if !buf.is_empty() {
             if let Err(e) = stream.write_dop_i32(&buf) {
-                log::error!("[DoP Engine] Write failed: {}", e);
+                // Match PCM ALSA: a hard write failure must stop the writer.
+                // Continuing would desync DoP markers (harsh noise) and leave
+                // exclusive mode stuck while position still advances.
+                log::error!("[DoP Engine] Write failed: {e} — stopping writer");
+                is_playing.store(false, Ordering::SeqCst);
+                should_stop.store(true, Ordering::SeqCst);
+                break 'thread;
             }
             position_frames.fetch_add((buf.len() / channels as usize) as u64, Ordering::SeqCst);
         }


### PR DESCRIPTION
## Summary

On a hard `write_dop_i32` failure the DoP writer thread only logged the error and kept going, still advancing `position_frames`. Continuing after a failed write desyncs the DoP frame markers (audible as harsh noise) and can leave the ALSA exclusive-mode device stuck while the position keeps moving.

- Match the PCM ALSA path: on write failure, log, clear `is_playing`, set `should_stop`, and exit the writer thread.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.