### PR TITLE
fix(cast): use CSPRNG media path tokens and redact URIs in logs

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -5543,6 +5543,7 @@ name = "qbz-cast"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "getrandom 0.2.17",
  "log",
  "mdns-sd",
  "rupnp",

--- a/crates/qbz-cast/Cargo.toml
+++ b/crates/qbz-cast/Cargo.toml
@@ -34,5 +34,8 @@ thiserror = "2"
 # Logging
 log = "0.4"
 
+# CSPRNG for cast media path tokens (not RandomState hash)
+getrandom = "0.2"
+
 # Async runtime (for DLNA)
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -139,9 +139,13 @@ impl DlnaConnection {
         // Build DIDL-Lite metadata with actual content type
         let didl_metadata = build_didl_metadata(uri, metadata, content_type);
 
-        log::info!("DLNA: Loading media URI: {}", uri);
+        log::info!("DLNA: Loading media URI: {}", redact_media_uri(uri));
         log::info!("DLNA: Content-Type: {}", content_type);
-        log::info!("DLNA: DIDL Metadata:\n{}", didl_metadata);
+        // DIDL embeds the full URI; log only at debug and redacted.
+        log::debug!(
+            "DLNA: DIDL Metadata (redacted URI):\n{}",
+            redact_media_uri(&didl_metadata)
+        );
 
         let payload = format!(
             "<InstanceID>0</InstanceID><CurrentURI>{}</CurrentURI><CurrentURIMetaData>{}</CurrentURIMetaData>",
@@ -169,7 +173,7 @@ impl DlnaConnection {
         // later reports 702 "no contents" (see the retry loop in `play`).
         self.last_set_uri_payload = Some(payload);
         self.uri_freshly_set = true;
-        log::info!("DLNA: Set URI to {}", uri);
+        log::info!("DLNA: Set URI to {}", redact_media_uri(uri));
 
         Ok(())
     }
@@ -662,9 +666,42 @@ fn find_service_any_version(device: &Device, service: &str) -> Option<Service> {
         .cloned()
 }
 
+/// Redact the cast media path token in logs (`/audio/<token>/<id>` → `/audio/***/<id>`).
+fn redact_media_uri(s: &str) -> String {
+    // Fast path: no cast audio path.
+    if !s.contains("/audio/") {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.find("/audio/") {
+        out.push_str(&rest[..i]);
+        out.push_str("/audio/");
+        rest = &rest[i + "/audio/".len()..];
+        // token until next /
+        if let Some(slash) = rest.find('/') {
+            out.push_str("***/");
+            rest = &rest[slash + 1..];
+        } else {
+            out.push_str("***");
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use super::service_type_matches;
+    use super::{redact_media_uri, service_type_matches};
+
+    #[test]
+    fn redacts_path_token() {
+        assert_eq!(
+            redact_media_uri("http://192.168.1.2:9876/audio/deadbeefcafebabe/42"),
+            "http://192.168.1.2:9876/audio/***/42"
+        );
+    }
 
     #[test]
     fn matches_any_upnp_version() {

--- a/crates/qbz-cast/src/media_server.rs
+++ b/crates/qbz-cast/src/media_server.rs
@@ -91,12 +91,9 @@ impl MediaServer {
         let base_ip = local_ip().unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         let base_url = format_base_url(base_ip, port);
 
-        log::info!(
-            "MediaServer: Started on {}:{} (base_url: {})",
-            base_ip,
-            port,
-            base_url
-        );
+        // Do not log the full base_url once the path token is embedded in
+        // request paths — host:port is enough for diagnostics.
+        log::info!("MediaServer: Started on {base_ip}:{port}");
 
         let entries = Arc::new(Mutex::new(HashMap::new()));
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -501,14 +498,19 @@ fn content_type_for_path(path: &Path) -> String {
     }
 }
 
-/// Generate a 128-bit hex session token seeded from OS entropy (via
-/// `RandomState`), without pulling in a `rand` dependency. Not cryptographic,
-/// but enough to stop a LAN peer from guessing `/audio/<id>`.
+/// Generate a 128-bit hex session token from OS CSPRNG entropy.
+/// Embedded in the path (`/audio/<token>/<id>`) so LAN peers cannot guess
+/// a sequential id alone.
 fn generate_token() -> String {
-    use std::hash::BuildHasher;
-    let hi = std::collections::hash_map::RandomState::new().hash_one(0x9E37_79B9u64);
-    let lo = std::collections::hash_map::RandomState::new().hash_one(0x85EB_CA77u64);
-    format!("{:016x}{:016x}", hi, lo)
+    let mut bytes = [0u8; 16];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        // Extremely rare; fall back to a non-crypto scramble so cast still works.
+        use std::hash::BuildHasher;
+        let hi = std::collections::hash_map::RandomState::new().hash_one(0x9E37_79B9u64);
+        let lo = std::collections::hash_map::RandomState::new().hash_one(0x85EB_CA77u64);
+        return format!("{:016x}{:016x}", hi, lo);
+    }
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

The cast media server's `/audio/<token>/<id>` path token is the only thing keeping LAN peers from fetching the stream, but it was generated with `RandomState` hashing (explicitly not cryptographic) and then logged in full in several places.

- Generate the 128-bit token from OS CSPRNG entropy via `getrandom` (new dependency, already in the lock file); keep the old `RandomState` scramble only as a fallback if `getrandom` errors, so casting still works.
- Stop logging the full media base URL at server start; host:port is enough for diagnostics.
- Redact the token in DLNA logs (`/audio/***/<id>`) for the media URI, Set-URI confirmation, and DIDL metadata; the DIDL dump also drops from info to debug level.
- Adds a unit test for the redaction helper.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.