### PR TITLE
fix(player): clear loaded state when streaming setup fails

### DIFF
--- a/crates/qbz-player/src/player/mod.rs
+++ b/crates/qbz-player/src/player/mod.rs
@@ -2288,6 +2288,15 @@ impl Player {
                                                 "Failed to create engine for streaming: {}",
                                                 e
                                             );
+                                            *current_streaming_source = None;
+                                            *current_audio_data = None;
+                                            thread_state.set_loaded_audio(false);
+                                            thread_state
+                                                .is_playing
+                                                .store(false, Ordering::SeqCst);
+                                            thread_state.record_stream_error(
+                                                "Failed to create the playback engine for streaming",
+                                            );
                                             return;
                                         }
                                     }
@@ -2356,6 +2365,13 @@ impl Player {
 
                             if !source.has_min_buffer() {
                                 log::error!("Streaming: timeout waiting for initial buffer");
+                                *current_streaming_source = None;
+                                *current_audio_data = None;
+                                thread_state.set_loaded_audio(false);
+                                thread_state.is_playing.store(false, Ordering::SeqCst);
+                                thread_state.record_stream_error(
+                                    "Timed out waiting for the stream buffer to fill",
+                                );
                                 return;
                             }
                             if resume_buffer_target > 0
@@ -2383,6 +2399,13 @@ impl Player {
                                         log::error!(
                                             "Failed to create incremental streaming source: {}",
                                             e
+                                        );
+                                        *current_streaming_source = None;
+                                        *current_audio_data = None;
+                                        thread_state.set_loaded_audio(false);
+                                        thread_state.is_playing.store(false, Ordering::SeqCst);
+                                        thread_state.record_stream_error(
+                                            "Failed to start the streaming decoder",
                                         );
                                         return;
                                     }


### PR DESCRIPTION
## Summary
- The audio thread's streaming handler sets the streaming source and `loaded` flag before waiting for the initial buffer. On buffer timeout, engine-create failure, or incremental-source failure it previously bare-returned, leaving the UI claiming a loaded, seekable, playing track with no engine behind it.
- All three failure paths now clear the streaming source and audio data, drop the loaded/playing flags, and record a user-visible stream error.

Note: touches the same handler as the stream feeder PR; whichever merges second needs a trivial rebase.

## Verification
`cargo test -p qbz-player` passes.