### PR TITLE
fix(cast): redact media path tokens in request and DLNA logs

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -5543,6 +5543,7 @@ name = "qbz-cast"
 version = "0.1.0"
 dependencies = [
  "futures-util",
+ "getrandom 0.2.17",
  "log",
  "mdns-sd",
  "rupnp",

--- a/crates/qbz-cast/Cargo.toml
+++ b/crates/qbz-cast/Cargo.toml
@@ -34,5 +34,8 @@ thiserror = "2"
 # Logging
 log = "0.4"
 
+# CSPRNG for cast media path tokens (not RandomState hash)
+getrandom = "0.2"
+
 # Async runtime (for DLNA)
 tokio = { version = "1", features = ["rt", "sync"] }

--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -139,9 +139,13 @@ impl DlnaConnection {
         // Build DIDL-Lite metadata with actual content type
         let didl_metadata = build_didl_metadata(uri, metadata, content_type);
 
-        log::info!("DLNA: Loading media URI: {}", uri);
+        log::info!("DLNA: Loading media URI: {}", redact_media_uri(uri));
         log::info!("DLNA: Content-Type: {}", content_type);
-        log::info!("DLNA: DIDL Metadata:\n{}", didl_metadata);
+        // DIDL embeds the full URI; log only at debug and redacted.
+        log::debug!(
+            "DLNA: DIDL Metadata (redacted URI):\n{}",
+            redact_media_uri(&didl_metadata)
+        );
 
         let payload = format!(
             "<InstanceID>0</InstanceID><CurrentURI>{}</CurrentURI><CurrentURIMetaData>{}</CurrentURIMetaData>",
@@ -169,7 +173,7 @@ impl DlnaConnection {
         // later reports 702 "no contents" (see the retry loop in `play`).
         self.last_set_uri_payload = Some(payload);
         self.uri_freshly_set = true;
-        log::info!("DLNA: Set URI to {}", uri);
+        log::info!("DLNA: Set URI to {}", redact_media_uri(uri));
 
         Ok(())
     }
@@ -662,9 +666,42 @@ fn find_service_any_version(device: &Device, service: &str) -> Option<Service> {
         .cloned()
 }
 
+/// Redact the cast media path token in logs (`/audio/<token>/<id>` → `/audio/***/<id>`).
+fn redact_media_uri(s: &str) -> String {
+    // Fast path: no cast audio path.
+    if !s.contains("/audio/") {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.find("/audio/") {
+        out.push_str(&rest[..i]);
+        out.push_str("/audio/");
+        rest = &rest[i + "/audio/".len()..];
+        // token until next /
+        if let Some(slash) = rest.find('/') {
+            out.push_str("***/");
+            rest = &rest[slash + 1..];
+        } else {
+            out.push_str("***");
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 #[cfg(test)]
 mod tests {
-    use super::service_type_matches;
+    use super::{redact_media_uri, service_type_matches};
+
+    #[test]
+    fn redacts_path_token() {
+        assert_eq!(
+            redact_media_uri("http://192.168.1.2:9876/audio/deadbeefcafebabe/42"),
+            "http://192.168.1.2:9876/audio/***/42"
+        );
+    }
 
     #[test]
     fn matches_any_upnp_version() {

--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -139,12 +139,15 @@ impl DlnaConnection {
         // Build DIDL-Lite metadata with actual content type
         let didl_metadata = build_didl_metadata(uri, metadata, content_type);
 
-        log::info!("DLNA: Loading media URI: {}", redact_media_uri(uri));
+        log::info!(
+            "DLNA: Loading media URI: {}",
+            crate::media_server::redact_media_uri(uri)
+        );
         log::info!("DLNA: Content-Type: {}", content_type);
         // DIDL embeds the full URI; log only at debug and redacted.
         log::debug!(
             "DLNA: DIDL Metadata (redacted URI):\n{}",
-            redact_media_uri(&didl_metadata)
+            crate::media_server::redact_media_uri(&didl_metadata)
         );
 
         let payload = format!(
@@ -173,7 +176,10 @@ impl DlnaConnection {
         // later reports 702 "no contents" (see the retry loop in `play`).
         self.last_set_uri_payload = Some(payload);
         self.uri_freshly_set = true;
-        log::info!("DLNA: Set URI to {}", redact_media_uri(uri));
+        log::info!(
+            "DLNA: Set URI to {}",
+            crate::media_server::redact_media_uri(uri)
+        );
 
         Ok(())
     }
@@ -666,42 +672,9 @@ fn find_service_any_version(device: &Device, service: &str) -> Option<Service> {
         .cloned()
 }
 
-/// Redact the cast media path token in logs (`/audio/<token>/<id>` → `/audio/***/<id>`).
-fn redact_media_uri(s: &str) -> String {
-    // Fast path: no cast audio path.
-    if !s.contains("/audio/") {
-        return s.to_string();
-    }
-    let mut out = String::with_capacity(s.len());
-    let mut rest = s;
-    while let Some(i) = rest.find("/audio/") {
-        out.push_str(&rest[..i]);
-        out.push_str("/audio/");
-        rest = &rest[i + "/audio/".len()..];
-        // token until next /
-        if let Some(slash) = rest.find('/') {
-            out.push_str("***/");
-            rest = &rest[slash + 1..];
-        } else {
-            out.push_str("***");
-            rest = "";
-        }
-    }
-    out.push_str(rest);
-    out
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{redact_media_uri, service_type_matches};
-
-    #[test]
-    fn redacts_path_token() {
-        assert_eq!(
-            redact_media_uri("http://192.168.1.2:9876/audio/deadbeefcafebabe/42"),
-            "http://192.168.1.2:9876/audio/***/42"
-        );
-    }
+    use super::service_type_matches;
 
     #[test]
     fn matches_any_upnp_version() {

--- a/crates/qbz-cast/src/media_server.rs
+++ b/crates/qbz-cast/src/media_server.rs
@@ -278,7 +278,7 @@ fn handle_request(
         "MediaServer: {} request from {:?} for {}",
         method,
         request.remote_addr(),
-        url
+        redact_media_uri(url)
     );
 
     // Allow GET and HEAD. Strict DLNA renderers HEAD-probe the URL to validate
@@ -295,7 +295,7 @@ fn handle_request(
         None => {
             log::warn!(
                 "MediaServer: 404 - Could not parse audio request from URL: {}",
-                url
+                redact_media_uri(url)
             );
             return Response::from_data(Vec::new()).with_status_code(StatusCode(404));
         }
@@ -303,7 +303,10 @@ fn handle_request(
 
     // Constant-ish token check — reject LAN peers that don't hold the token.
     if token != expected_token {
-        log::warn!("MediaServer: 403 - token mismatch for URL: {}", url);
+        log::warn!(
+            "MediaServer: 403 - token mismatch for URL: {}",
+            redact_media_uri(url)
+        );
         return Response::from_data(Vec::new()).with_status_code(StatusCode(403));
     }
 
@@ -514,6 +517,31 @@ fn generate_token() -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
+/// Redact the cast media path token in logs (`/audio/<token>/<id>` → `/audio/***/<id>`).
+pub(crate) fn redact_media_uri(s: &str) -> String {
+    if !s.contains("/audio/") {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(i) = rest.find("/audio/") {
+        out.push_str(&rest[..i]);
+        out.push_str("/audio/");
+        rest = &rest[i + "/audio/".len()..];
+        // token is next path segment
+        if let Some(slash) = rest.find('/') {
+            out.push_str("***");
+            out.push('/');
+            rest = &rest[slash + 1..];
+        } else {
+            out.push_str("***");
+            rest = "";
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -556,5 +584,21 @@ mod tests {
         assert_eq!(a.len(), 32);
         assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
         assert_ne!(a, b, "two tokens should differ");
+    }
+
+    #[test]
+    fn redact_media_uri_hides_token() {
+        assert_eq!(
+            redact_media_uri("http://192.168.1.2:9876/audio/deadbeefcafebabe/42"),
+            "http://192.168.1.2:9876/audio/***/42"
+        );
+        assert_eq!(
+            redact_media_uri("/audio/tokentokentoken/7?x=1"),
+            "/audio/***/7?x=1"
+        );
+        let raw = "/audio/aabbccddeeff0011/9";
+        let red = redact_media_uri(raw);
+        assert!(!red.contains("aabbccddeeff0011"));
+        assert!(red.contains("***/9"));
     }
 }

--- a/crates/qbz-cast/src/media_server.rs
+++ b/crates/qbz-cast/src/media_server.rs
@@ -91,12 +91,9 @@ impl MediaServer {
         let base_ip = local_ip().unwrap_or_else(|| IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)));
         let base_url = format_base_url(base_ip, port);
 
-        log::info!(
-            "MediaServer: Started on {}:{} (base_url: {})",
-            base_ip,
-            port,
-            base_url
-        );
+        // Do not log the full base_url once the path token is embedded in
+        // request paths; host:port is enough for diagnostics.
+        log::info!("MediaServer: Started on {base_ip}:{port}");
 
         let entries = Arc::new(Mutex::new(HashMap::new()));
         let shutdown = Arc::new(AtomicBool::new(false));
@@ -501,14 +498,20 @@ fn content_type_for_path(path: &Path) -> String {
     }
 }
 
-/// Generate a 128-bit hex session token seeded from OS entropy (via
-/// `RandomState`), without pulling in a `rand` dependency. Not cryptographic,
-/// but enough to stop a LAN peer from guessing `/audio/<id>`.
+/// Generate a 128-bit hex session token from OS CSPRNG entropy.
+/// Embedded in the path (`/audio/<token>/<id>`) so LAN peers cannot guess
+/// a sequential id alone.
 fn generate_token() -> String {
-    use std::hash::BuildHasher;
-    let hi = std::collections::hash_map::RandomState::new().hash_one(0x9E37_79B9u64);
-    let lo = std::collections::hash_map::RandomState::new().hash_one(0x85EB_CA77u64);
-    format!("{:016x}{:016x}", hi, lo)
+    let mut bytes = [0u8; 16];
+    if getrandom::getrandom(&mut bytes).is_err() {
+        // Extremely rare; fall back to a non-crypto scramble so cast still works.
+        log::warn!("Cast: OS CSPRNG unavailable, using a weaker fallback media token");
+        use std::hash::BuildHasher;
+        let hi = std::collections::hash_map::RandomState::new().hash_one(0x9E37_79B9u64);
+        let lo = std::collections::hash_map::RandomState::new().hash_one(0x85EB_CA77u64);
+        return format!("{:016x}{:016x}", hi, lo);
+    }
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Every MediaServer request log (and the 404/403 warns) printed the full URL including the session token, so the token landed in on-disk logs and support bundles on every renderer request. These now go through a shared `redact_media_uri` helper (`/audio/<token>/<id>` becomes `/audio/***/<id>`).

Stacked on #602 and includes its commit; merge #602 first and this PR reduces to the redaction commit.

## Verification
`cargo test -p qbz-cast` passes (includes redaction tests).