### PR TITLE
fix(scrobble): skip tracks with unknown or sub-30s duration

### DIFF
--- a/crates/qbz-app/src/lib.rs
+++ b/crates/qbz-app/src/lib.rs
@@ -4,6 +4,7 @@ pub mod graphics_autoconfig;
 pub mod playback_context;
 pub mod qconnect_identity;
 pub mod runtime;
+pub mod scrobble_timing;
 pub mod session_store;
 pub mod shell;
 pub mod settings;

--- a/crates/qbz-app/src/scrobble_timing.rs
+++ b/crates/qbz-app/src/scrobble_timing.rs
@@ -3,13 +3,15 @@
 //! Shared so the Slint shell and unit tests agree on when a delayed scrobble
 //! may fire. Unknown duration (`0`) must never arm an immediate scrobble.
 
-/// `min(50% of duration, 240s)` in seconds — the Last.fm rule, applied to both
+/// `min(50% of duration, 240s)` in seconds, per the Last.fm scrobbling rules
+/// (track longer than 30 seconds, play half or 4 minutes), applied to both
 /// Last.fm and ListenBrainz.
 ///
-/// Returns `None` when duration is unknown (`0`): callers must **not** scrobble
-/// immediately — that would pollute history for local/Plex metadata holes.
+/// Returns `None` when duration is unknown (`0`) or 30 seconds or less:
+/// unknown durations would pollute history for local/Plex metadata holes, and
+/// the Last.fm spec says such short tracks must not be scrobbled at all.
 pub fn scrobble_delay_secs(duration_secs: u64) -> Option<u64> {
-    if duration_secs == 0 {
+    if duration_secs <= 30 {
         return None;
     }
     Some((duration_secs / 2).min(240))
@@ -25,11 +27,17 @@ mod tests {
     }
 
     #[test]
+    fn short_tracks_skip_scrobble() {
+        // Last.fm rule: the track must be longer than 30 seconds.
+        assert_eq!(scrobble_delay_secs(1), None);
+        assert_eq!(scrobble_delay_secs(29), None);
+        assert_eq!(scrobble_delay_secs(30), None);
+        assert_eq!(scrobble_delay_secs(31), Some(15));
+    }
+
+    #[test]
     fn half_duration_capped_at_240() {
         assert_eq!(scrobble_delay_secs(100), Some(50));
         assert_eq!(scrobble_delay_secs(600), Some(240));
-        // 1s track: half truncates to 0 — still Some, so we arm (immediate)
-        // rather than skip (duration is known, just very short).
-        assert_eq!(scrobble_delay_secs(1), Some(0));
     }
 }

--- a/crates/qbz-app/src/scrobble_timing.rs
+++ b/crates/qbz-app/src/scrobble_timing.rs
@@ -1,0 +1,35 @@
+//! Pure scrobble arming rules (no UI / network).
+//!
+//! Shared so the Slint shell and unit tests agree on when a delayed scrobble
+//! may fire. Unknown duration (`0`) must never arm an immediate scrobble.
+
+/// `min(50% of duration, 240s)` in seconds — the Last.fm rule, applied to both
+/// Last.fm and ListenBrainz.
+///
+/// Returns `None` when duration is unknown (`0`): callers must **not** scrobble
+/// immediately — that would pollute history for local/Plex metadata holes.
+pub fn scrobble_delay_secs(duration_secs: u64) -> Option<u64> {
+    if duration_secs == 0 {
+        return None;
+    }
+    Some((duration_secs / 2).min(240))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::scrobble_delay_secs;
+
+    #[test]
+    fn unknown_duration_skips_scrobble() {
+        assert_eq!(scrobble_delay_secs(0), None);
+    }
+
+    #[test]
+    fn half_duration_capped_at_240() {
+        assert_eq!(scrobble_delay_secs(100), Some(50));
+        assert_eq!(scrobble_delay_secs(600), Some(240));
+        // 1s track: half truncates to 0 — still Some, so we arm (immediate)
+        // rather than skip (duration is known, just very short).
+        assert_eq!(scrobble_delay_secs(1), Some(0));
+    }
+}

--- a/crates/qbz/src/scrobble.rs
+++ b/crates/qbz/src/scrobble.rs
@@ -406,17 +406,9 @@ pub struct ScrobbleMeta {
 /// `clearTimeout` equivalent). Like Tauri, pause/stop do NOT cancel it.
 static SCROBBLE_GEN: AtomicU64 = AtomicU64::new(0);
 
-/// `min(50% of duration, 240s)` in seconds — the Last.fm rule, applied to both
-/// services (matches the Svelte `Math.min(durationSecs * 0.5, 240) * 1000`).
-///
-/// Returns `None` when duration is unknown (`0`): callers must **not** scrobble
-/// immediately — that would pollute history for local/Plex metadata holes.
-fn scrobble_delay_secs(duration_secs: u64) -> Option<u64> {
-    if duration_secs == 0 {
-        return None;
-    }
-    Some((duration_secs / 2).min(240))
-}
+/// Pure arming rule lives in `qbz-app` so unit tests do not need the Slint
+/// binary compile (see `qbz_app::scrobble_timing`).
+use qbz_app::scrobble_timing::scrobble_delay_secs;
 
 /// Track-change entry point. Fires now-playing immediately for each enabled +
 /// authed service, then arms a delayed scrobble. No-op when no service is
@@ -781,23 +773,5 @@ async fn flush_listenbrainz_queue() {
         })
         .await;
         log::info!("[qbz-slint] ListenBrainz flush: {count} listen(s) sent");
-    }
-}
-
-#[cfg(test)]
-mod scrobble_delay_tests {
-    use super::scrobble_delay_secs;
-
-    #[test]
-    fn unknown_duration_skips_scrobble() {
-        assert_eq!(scrobble_delay_secs(0), None);
-    }
-
-    #[test]
-    fn half_duration_capped_at_240() {
-        assert_eq!(scrobble_delay_secs(100), Some(50));
-        assert_eq!(scrobble_delay_secs(600), Some(240));
-        // 1s track: half truncates to 0 — still Some, so we arm (immediate) rather than skip.
-        assert_eq!(scrobble_delay_secs(1), Some(0));
     }
 }

--- a/crates/qbz/src/scrobble.rs
+++ b/crates/qbz/src/scrobble.rs
@@ -408,8 +408,14 @@ static SCROBBLE_GEN: AtomicU64 = AtomicU64::new(0);
 
 /// `min(50% of duration, 240s)` in seconds — the Last.fm rule, applied to both
 /// services (matches the Svelte `Math.min(durationSecs * 0.5, 240) * 1000`).
-fn scrobble_delay_secs(duration_secs: u64) -> u64 {
-    (duration_secs / 2).min(240)
+///
+/// Returns `None` when duration is unknown (`0`): callers must **not** scrobble
+/// immediately — that would pollute history for local/Plex metadata holes.
+fn scrobble_delay_secs(duration_secs: u64) -> Option<u64> {
+    if duration_secs == 0 {
+        return None;
+    }
+    Some((duration_secs / 2).min(240))
 }
 
 /// Track-change entry point. Fires now-playing immediately for each enabled +
@@ -434,8 +440,15 @@ pub fn on_track_changed(meta: ScrobbleMeta) {
             send_now_playing(&meta, &cfg).await;
         }
 
-        // Delayed scrobble at min(dur/2, 240s).
-        let wait = scrobble_delay_secs(meta.duration_secs);
+        // Delayed scrobble at min(dur/2, 240s). Unknown duration: skip scrobble
+        // (still sent now-playing above when online).
+        let Some(wait) = scrobble_delay_secs(meta.duration_secs) else {
+            log::debug!(
+                "[scrobble] skip delayed scrobble: unknown duration for '{}'",
+                meta.track
+            );
+            return;
+        };
         if wait > 0 {
             tokio::time::sleep(Duration::from_secs(wait)).await;
         }
@@ -768,5 +781,23 @@ async fn flush_listenbrainz_queue() {
         })
         .await;
         log::info!("[qbz-slint] ListenBrainz flush: {count} listen(s) sent");
+    }
+}
+
+#[cfg(test)]
+mod scrobble_delay_tests {
+    use super::scrobble_delay_secs;
+
+    #[test]
+    fn unknown_duration_skips_scrobble() {
+        assert_eq!(scrobble_delay_secs(0), None);
+    }
+
+    #[test]
+    fn half_duration_capped_at_240() {
+        assert_eq!(scrobble_delay_secs(100), Some(50));
+        assert_eq!(scrobble_delay_secs(600), Some(240));
+        // 1s track: half truncates to 0 — still Some, so we arm (immediate) rather than skip.
+        assert_eq!(scrobble_delay_secs(1), Some(0));
     }
 }


### PR DESCRIPTION
## Summary
- A track with unknown (0) duration armed an immediate scrobble at track start, polluting history for local/Plex files with metadata holes. Unknown durations now never scrobble (now-playing is still sent).
- The Last.fm rule that tracks must be longer than 30 seconds is now enforced as well.
- The delay rule lives in `qbz-app` as a pure function with unit tests.

## Verification
`cargo test -p qbz-app` passes (156 tests).