### PR TITLE
feat(ui): open album from grid card title click

### DIFF
--- a/crates/qbz-ui/ui/discover/AlbumCard.slint
+++ b/crates/qbz-ui/ui/discover/AlbumCard.slint
@@ -407,14 +407,27 @@ export component AlbumCard inherits Rectangle {
                 spacing: 2px;
                 horizontal-stretch: 1;
 
-                Text {
-                    text: root.album.title;
+                // Album title, clickable with the same target as the artwork
+                // click: opens the album (or toggles selection in select-mode).
+                title-area := TouchArea {
                     height: 20px;
-                    color: Theme.text-primary;
-                    font-size: Typography.body - 2px;
-                    font-weight: Typography.medium;
-                    vertical-alignment: center;
-                    overflow: elide;
+                    mouse-cursor: pointer;
+                    clicked => {
+                        if (root.select-mode) {
+                            root.media-action("album", root.album.id, "toggle-select");
+                        } else {
+                            root.clicked(root.album.id);
+                        }
+                    }
+                    Text {
+                        width: 100%;
+                        text: root.album.title;
+                        color: title-area.has-hover ? Theme.accent : Theme.text-primary;
+                        font-size: Typography.body - 2px;
+                        font-weight: Typography.medium;
+                        vertical-alignment: center;
+                        overflow: elide;
+                    }
                 }
                 // Artist name — clickable when an artist id is known,
                 // navigating to the artist page (1:1 with Tauri).


### PR DESCRIPTION
## Summary
- Album titles on grid cards are now clickable: clicking the title opens the album, the same target as the artwork click (and toggles selection in select-mode), with a pointer cursor and accent hover mirroring the existing artist link below it.
- `AlbumCard` is the single card used by every album grid (Discover, Favorites, Search, Purchases, Local Library), so the change applies everywhere.

## Verification
`cargo check -p qbz-ui` compiles the Slint clean.