### PR TITLE
feat(themes): add Catppuccin Latte, Frappé, and Macchiato

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ sudo snap connect qbz-player:pipewire
 
 ```bash
 curl -fsSL https://vicrodh.github.io/qbz-apt/qbz-archive-keyring.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/qbz-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/qbz-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://vicrodh.github.io/qbz-apt stable main" | sudo tee /etc/apt/sources.list.d/qbz.list
+cat <<EOF | sudo tee /etc/apt/sources.list.d/qbz.sources
+Types: deb
+URIs: https://vicrodh.github.io/qbz-apt
+Suites: stable
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /usr/share/keyrings/qbz-archive-keyring.gpg
+EOF
 sudo apt update && sudo apt install qbz
 ```
 

--- a/crates/qbz-theme/src/id.rs
+++ b/crates/qbz-theme/src/id.rs
@@ -43,6 +43,9 @@ pub enum ThemeId {
     Dracula,
     TokyoNight, // P1
     CatppuccinMocha,
+    CatppuccinLatte,
+    CatppuccinFrappe,
+    CatppuccinMacchiato,
     BreezeDark,
     AdwaitaDark,
     Aurora,
@@ -82,6 +85,9 @@ pub const ALL: &[ThemeId] = &[
     ThemeId::Dracula,
     ThemeId::TokyoNight,
     ThemeId::CatppuccinMocha,
+    ThemeId::CatppuccinLatte,
+    ThemeId::CatppuccinFrappe,
+    ThemeId::CatppuccinMacchiato,
     ThemeId::BreezeDark,
     ThemeId::AdwaitaDark,
     ThemeId::Aurora,
@@ -134,6 +140,9 @@ impl ThemeId {
             ThemeId::Dracula => "dracula",
             ThemeId::TokyoNight => "tokyo-night",
             ThemeId::CatppuccinMocha => "catppuccin-mocha",
+            ThemeId::CatppuccinLatte => "catppuccin-latte",
+            ThemeId::CatppuccinFrappe => "catppuccin-frappe",
+            ThemeId::CatppuccinMacchiato => "catppuccin-macchiato",
             ThemeId::BreezeDark => "breeze-dark",
             ThemeId::AdwaitaDark => "adwaita-dark",
             ThemeId::Aurora => "aurora",
@@ -181,6 +190,9 @@ impl ThemeId {
             ThemeId::Dracula => "Dracula",
             ThemeId::TokyoNight => "Tokyo Night",
             ThemeId::CatppuccinMocha => "Catppuccin Mocha",
+            ThemeId::CatppuccinLatte => "Catppuccin Latte",
+            ThemeId::CatppuccinFrappe => "Catppuccin Frappé",
+            ThemeId::CatppuccinMacchiato => "Catppuccin Macchiato",
             ThemeId::BreezeDark => "Breeze Dark",
             ThemeId::AdwaitaDark => "Adwaita Dark",
             ThemeId::Aurora => "Aurora",
@@ -215,7 +227,7 @@ impl ThemeId {
         use ThemeId::*;
         match self {
             Dark | Oled | Light | System => ThemeCategory::Core,
-            Warm | Nord | Dracula | TokyoNight | CatppuccinMocha | BreezeDark | AdwaitaDark
+            Warm | Nord | Dracula | TokyoNight | CatppuccinMocha | CatppuccinLatte | CatppuccinFrappe | CatppuccinMacchiato | BreezeDark | AdwaitaDark
             | Aurora | Ikari | Ayanami | Iscariot | Stratego | Rumi | Zoey | Mira | Frost
             | Langley => ThemeCategory::Dark,
             Alucard | RosePineDawn | BreezeLight | AdwaitaLight | DuotoneSnow | SnowStorm

--- a/crates/qbz-theme/src/registry.rs
+++ b/crates/qbz-theme/src/registry.rs
@@ -63,6 +63,9 @@ pub fn palette(id: ThemeId) -> ThemeColors {
         ThemeId::Nord => nord(),
         ThemeId::Dracula => dracula(),
         ThemeId::CatppuccinMocha => catppuccin_mocha(),
+        ThemeId::CatppuccinLatte => catppuccin_latte(),
+        ThemeId::CatppuccinFrappe => catppuccin_frappe(),
+        ThemeId::CatppuccinMacchiato => catppuccin_macchiato(),
         ThemeId::BreezeDark => breeze_dark(),
         ThemeId::AdwaitaDark => adwaita_dark(),
         ThemeId::Aurora => aurora(),
@@ -486,6 +489,77 @@ fn catppuccin_mocha() -> ThemeColors {
         warning: Rgba::rgb(0xf9, 0xe2, 0xaf),
         border_subtle: Rgba::rgb(0x31, 0x32, 0x44),
         border_strong: Rgba::rgb(0x45, 0x47, 0x5a),
+        ..Default::default()
+    };
+    s.build(bg_is_light(s.bg_primary))
+}
+/// catppuccin-latte — light theme (Part B §latte). Black alpha base.
+fn catppuccin_latte() -> ThemeColors {
+    let s = StdSpec {
+        bg_primary: Rgba::rgb(0xef, 0xf1, 0xf5),
+        bg_secondary: Rgba::rgb(0xe6, 0xe9, 0xef),
+        bg_tertiary: Rgba::rgb(0xdc, 0xe0, 0xe8),
+        bg_hover: Rgba::rgb(0xcc, 0xd0, 0xda),
+        text_primary: Rgba::rgb(0x4c, 0x4f, 0x69),
+        text_secondary: Rgba::rgb(0x5c, 0x5f, 0x77),
+        text_muted: Rgba::rgb(0x6c, 0x6f, 0x85),
+        text_disabled: Rgba::rgb(0x9c, 0xa0, 0xb0),
+        accent: Rgba::rgb(0x88, 0x39, 0xef),
+        accent_hover: Rgba::rgb(0x1e, 0x66, 0xf5),
+        accent_pressed: Rgba::rgb(0xd2, 0x0f, 0x39),
+        accent_text: Rgba::rgb(0xef, 0xf1, 0xf5),
+        danger: Rgba::rgb(0xd2, 0x0f, 0x39),
+        warning: Rgba::rgb(0xdf, 0x8e, 0x1d),
+        border_subtle: Rgba::rgb(0xbc, 0xc0, 0xcc),
+        border_strong: Rgba::rgb(0xac, 0xb0, 0xbe),
+        ..Default::default()
+    };
+    s.build(bg_is_light(s.bg_primary))
+}
+
+/// catppuccin-frappe — dark theme. White alpha base.
+fn catppuccin_frappe() -> ThemeColors {
+    let s = StdSpec {
+        bg_primary: Rgba::rgb(0x30, 0x34, 0x46),
+        bg_secondary: Rgba::rgb(0x29, 0x2c, 0x3c),
+        bg_tertiary: Rgba::rgb(0x23, 0x26, 0x34),
+        bg_hover: Rgba::rgb(0x41, 0x45, 0x59),
+        text_primary: Rgba::rgb(0xc6, 0xd0, 0xf5),
+        text_secondary: Rgba::rgb(0xb5, 0xbf, 0xe2),
+        text_muted: Rgba::rgb(0xa5, 0xad, 0xce),
+        text_disabled: Rgba::rgb(0x73, 0x79, 0x94),
+        accent: Rgba::rgb(0xca, 0x9e, 0xe6),
+        accent_hover: Rgba::rgb(0x8c, 0xaa, 0xee),
+        accent_pressed: Rgba::rgb(0xe7, 0x82, 0x84),
+        accent_text: Rgba::rgb(0x30, 0x34, 0x46),
+        danger: Rgba::rgb(0xe7, 0x82, 0x84),
+        warning: Rgba::rgb(0xe5, 0xc8, 0x90),
+        border_subtle: Rgba::rgb(0x51, 0x57, 0x6d),
+        border_strong: Rgba::rgb(0x62, 0x68, 0x80),
+        ..Default::default()
+    };
+    s.build(bg_is_light(s.bg_primary))
+}
+
+/// catppuccin-macchiato — dark theme. White alpha base.
+fn catppuccin_macchiato() -> ThemeColors {
+    let s = StdSpec {
+        bg_primary: Rgba::rgb(0x24, 0x27, 0x3a),
+        bg_secondary: Rgba::rgb(0x1e, 0x20, 0x30),
+        bg_tertiary: Rgba::rgb(0x18, 0x19, 0x26),
+        bg_hover: Rgba::rgb(0x36, 0x3a, 0x4f),
+        text_primary: Rgba::rgb(0xca, 0xd3, 0xf5),
+        text_secondary: Rgba::rgb(0xb8, 0xc0, 0xe0),
+        text_muted: Rgba::rgb(0xa5, 0xad, 0xcb),
+        text_disabled: Rgba::rgb(0x6e, 0x73, 0x8d),
+        accent: Rgba::rgb(0xc6, 0xa0, 0xf6),
+        accent_hover: Rgba::rgb(0x8a, 0xad, 0xf4),
+        accent_pressed: Rgba::rgb(0xed, 0x87, 0x96),
+        accent_text: Rgba::rgb(0x24, 0x27, 0x3a),
+        danger: Rgba::rgb(0xed, 0x87, 0x96),
+        warning: Rgba::rgb(0xee, 0xd4, 0x9f),
+        border_subtle: Rgba::rgb(0x49, 0x4d, 0x64),
+        border_strong: Rgba::rgb(0x5b, 0x60, 0x78),
         ..Default::default()
     };
     s.build(bg_is_light(s.bg_primary))


### PR DESCRIPTION
Adds the remaining three Catppuccin flavor palettes to complete the set:
- Latte (light)
- Frappé (dark)
- Macchiato (dark)

All colors transcribed from the official [Catppuccin palette](https://github.com/catppuccin/catppuccin#-palette). Themes follow the existing StdSpec builder pattern and are fully integrated into the theme registry and UI.

## Screenshots

### Catppuccin Frappé (Dark)
<img width="2026" height="1144" alt="Screenshot-frappe" src="https://github.com/user-attachments/assets/b05c9b00-ef11-4daf-a1b0-127717acfb83" />

### Catppuccin Latte (Light)
<img width="2026" height="1144" alt="Screenshot-latte" src="https://github.com/user-attachments/assets/bc13ad99-b696-4bd2-be79-d3eb4125ecf9" />

### Macchiato (Dark)
<img width="2026" height="1144" alt="Screenshot-macchiato" src="https://github.com/user-attachments/assets/10a8512c-5664-4088-9a89-a3e5f7b32a20" />

### All four Catppuccin Themes (set)
<img width="2026" height="1144" alt="Screenshot-set" src="https://github.com/user-attachments/assets/20800a46-cfce-4fcd-9f81-96cdcd3db63e" />

## Summary

Adds Catppuccin Latte, Frappé, and Macchiato themes to complete the Catppuccin palette set.

## Testing

Built and tested locally on Debian Trixie. All three themes render correctly in Settings > Appearance. 

## Checklist

- [x] I have tested this change locally
- [ ] I have added/updated tests
- [x] This change does not break existing functionality
