### PR TITLE
 feat(themes): add Catppuccin Latte, Frappé, and Macchiato 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ sudo snap connect qbz-player:pipewire
 
 ```bash
 curl -fsSL https://vicrodh.github.io/qbz-apt/qbz-archive-keyring.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/qbz-archive-keyring.gpg > /dev/null
-echo "deb [signed-by=/usr/share/keyrings/qbz-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://vicrodh.github.io/qbz-apt stable main" | sudo tee /etc/apt/sources.list.d/qbz.list
+cat <<EOF | sudo tee /etc/apt/sources.list.d/qbz.sources
+Types: deb
+URIs: https://vicrodh.github.io/qbz-apt
+Suites: stable
+Components: main
+Architectures: $(dpkg --print-architecture)
+Signed-By: /usr/share/keyrings/qbz-archive-keyring.gpg
+EOF
 sudo apt update && sudo apt install qbz
 ```
 


### PR DESCRIPTION
Adds the remaining three Catppuccin flavor palettes to complete the set:
- Latte (light)
- Frappé (dark)
- Macchiato (dark)

All colors transcribed from the official [Catppuccin palette](https://github.com/catppuccin/catppuccin#-palette). Themes follow the existing StdSpec builder pattern and are fully integrated into the theme registry and UI.

## Screenshots

### Catppuccin Frappé (Dark)
<img width="2026" height="1144" alt="Screenshot-frappe" src="https://github.com/user-attachments/assets/b05c9b00-ef11-4daf-a1b0-127717acfb83" />

### Catppuccin Latte (Light)
<img width="2026" height="1144" alt="Screenshot-latte" src="https://github.com/user-attachments/assets/bc13ad99-b696-4bd2-be79-d3eb4125ecf9" />

### Macchiato (Dark)
<img width="2026" height="1144" alt="Screenshot-macchiato" src="https://github.com/user-attachments/assets/10a8512c-5664-4088-9a89-a3e5f7b32a20" />

### All four Catppuccin Themes (set)
<img width="2026" height="1144" alt="Screenshot-set" src="https://github.com/user-attachments/assets/20800a46-cfce-4fcd-9f81-96cdcd3db63e" />

## Summary

Adds Catppuccin Latte, Frappé, and Macchiato themes to complete the Catppuccin palette set.

## Testing

Built and tested locally on Debian Trixie. All three themes render correctly in Settings > Appearance. 

## Checklist

- [x] I have tested this change locally
- [ ] I have added/updated tests
- [x] This change does not break existing functionality
