### PR TITLE
fix(settings): make the theme-list filter actually work

### DIFF
--- a/crates/qbz-theme/src/registry.rs
+++ b/crates/qbz-theme/src/registry.rs
@@ -1839,13 +1839,13 @@ mod a11y_contrast_tests {
         // Count: the registry holds every ThemeId variant. The plan's prose
         // says "32 themes" but counts inconsistently (it variously treats the
         // System meta-entry as in/out). The enum is the source of truth: 4 Core
-        // + 17 Dark + 7 Light + 5 Accessibility = 33 rows. Assert the concrete
+        // + 19 Dark + 8 Light + 5 Accessibility = 36 rows. Assert the concrete
         // breakdown so a future add/remove can't silently drop a row.
         let n_a11y = ALL
             .iter()
             .filter(|id| id.category() == crate::id::ThemeCategory::Accessibility)
             .count();
         assert_eq!(n_a11y, 5, "exactly 5 accessibility themes (P3)");
-        assert_eq!(ALL.len(), 33, "registry must hold every ThemeId row");
+        assert_eq!(ALL.len(), 36, "registry must hold every ThemeId row");
     }
 }

--- a/crates/qbz-ui/ui/assets/icons/moon.svg
+++ b/crates/qbz-ui/ui/assets/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+</svg>

--- a/crates/qbz-ui/ui/assets/icons/sun-moon.svg
+++ b/crates/qbz-ui/ui/assets/icons/sun-moon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 8a2.83 2.83 0 0 0 4 4 4 4 0 1 1-4-4" />
+  <path d="M12 2v2" />
+  <path d="M12 20v2" />
+  <path d="m4.9 4.9 1.4 1.4" />
+  <path d="m17.7 17.7 1.4 1.4" />
+  <path d="M2 12h2" />
+  <path d="M20 12h2" />
+  <path d="m6.3 17.7-1.4 1.4" />
+  <path d="m19.1 4.9-1.4 1.4" />
+</svg>

--- a/crates/qbz-ui/ui/assets/icons/sun.svg
+++ b/crates/qbz-ui/ui/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#ffffff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="4" />
+  <path d="M12 2v2" />
+  <path d="M12 20v2" />
+  <path d="m4.93 4.93 1.41 1.41" />
+  <path d="m17.66 17.66 1.41 1.41" />
+  <path d="M2 12h2" />
+  <path d="M20 12h2" />
+  <path d="m6.34 17.66-1.41 1.41" />
+  <path d="m19.07 4.93-1.41 1.41" />
+</svg>

--- a/crates/qbz-ui/ui/settings/AppearanceSettings.slint
+++ b/crates/qbz-ui/ui/settings/AppearanceSettings.slint
@@ -188,11 +188,12 @@ export component AppearanceSettings inherits VerticalLayout {
                 border-color: Theme.border-subtle;
                 background: filter-ta.has-hover ? Theme.surface-hover : Theme.surface-elevated;
                 QbzIcon {
+                    // 0 = All, 1 = Dark, 2 = Light (SunMoon / Moon / Sun).
                     source: AppearanceState.theme-filter == 1
-                        ? @image-url("../assets/icons/disc.svg")
+                        ? @image-url("../assets/icons/moon.svg")
                         : AppearanceState.theme-filter == 2
-                        ? @image-url("../assets/icons/disc.svg")
-                        : @image-url("../assets/icons/disc.svg");
+                        ? @image-url("../assets/icons/sun.svg")
+                        : @image-url("../assets/icons/sun-moon.svg");
                     width: 16px;
                     height: 16px;
                     tint: Theme.text-secondary;

--- a/crates/qbz/src/main.rs
+++ b/crates/qbz/src/main.rs
@@ -7140,16 +7140,22 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // run before the shell renders so the first paint is the right palette.
     {
         let appearance = window.global::<AppearanceState>();
-        let labels: Vec<slint::SharedString> = crate::theme::dropdown_labels()
+        let prefs = crate::ui_prefs::load();
+        // Seed the dropdown honoring the persisted list filter (All/Dark/Light)
+        // so the list and the filter icon agree on the first paint.
+        let filter = prefs.theme_filter;
+        let labels: Vec<slint::SharedString> = crate::theme::filtered_dropdown_labels(filter)
             .into_iter()
             .map(slint::SharedString::from)
             .collect();
         appearance.set_themes(slint::ModelRc::new(slint::VecModel::from(labels)));
 
-        let slug = crate::ui_prefs::load().theme;
+        let slug = prefs.theme;
         let is_auto = slug == crate::theme::AUTO_SLUG;
         let is_custom = slug == crate::theme::CUSTOM_SLUG;
-        let selected_index = crate::theme::selected_index_for_slug(&slug);
+        // Highlight the active theme within the (possibly narrowed) list; -1 when
+        // it is filtered out — the palette is still applied below via the slug.
+        let selected_index = crate::theme::filtered_selected_index_for_slug(&slug, filter);
         appearance.set_theme_index(selected_index);
         appearance.set_theme_is_auto(is_auto);
         appearance.set_theme_is_custom(is_custom);
@@ -7172,9 +7178,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             appearance.set_theme_is_system(id == qbz_theme::ThemeId::System);
             crate::theme::apply_theme(&window, id);
         }
-        // Keep the legacy ThemeState.mode in sync with the dropdown index for
-        // any residual reads; the palette itself is driven above.
-        window.global::<ThemeState>().set_mode(selected_index);
+        // Keep the legacy ThemeState.mode in sync with the UNFILTERED dropdown
+        // index for any residual reads (the filtered index can be -1); the
+        // palette itself is driven above.
+        window
+            .global::<ThemeState>()
+            .set_mode(crate::theme::selected_index_for_slug(&slug));
     }
 
     // Tell the tray settings UI which platform it's on so it can show the
@@ -9595,7 +9604,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 // generates the palette off-thread; every other index maps to a
                 // stable registry id and hot-switches the static palette.
                 let mut prefs = crate::ui_prefs::load();
-                if crate::theme::is_auto_index(index) {
+                // The dropdown index is a position in the CURRENTLY filtered list
+                // (All/Dark/Light), so map it through the same filter. Auto/Custom
+                // only exist in the All view (filtered_*_index is -1 otherwise).
+                let filter = prefs.theme_filter;
+                if index == crate::theme::filtered_auto_index(filter) {
                     prefs.theme = crate::theme::AUTO_SLUG.to_string();
                     crate::ui_prefs::save(&prefs);
                     if let Some(w) = theme_weak.upgrade() {
@@ -9605,7 +9618,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         st.set_theme_is_system(false);
                     }
                     crate::auto_theme::regenerate(theme_weak.clone(), theme_handle.clone());
-                } else if crate::theme::is_custom_index(index) {
+                } else if index == crate::theme::filtered_custom_index(filter) {
                     // "Custom": persist the slug, derive from the persisted (or
                     // freshly seeded) custom base, and apply live. The editor
                     // swatches are seeded from the same base.
@@ -9628,7 +9641,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                     }
                 } else {
-                    let id = crate::theme::id_for_index(index);
+                    let id = crate::theme::filtered_id_for_index(index, filter);
                     prefs.theme = id.slug().to_string();
                     crate::ui_prefs::save(&prefs);
                     if let Some(w) = theme_weak.upgrade() {
@@ -9646,11 +9659,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 crate::auto_theme::set_source(index, theme_weak.clone(), theme_handle.clone());
             }
             "theme-filter" => {
-                // Theme-list filter cycle (0 = All, 1 = Dark, 2 = Light). Cosmetic,
-                // but persist it so the list doesn't reset to All every launch.
+                // Theme-list filter cycle (0 = All, 1 = Dark, 2 = Light): persist
+                // the choice, then rebuild the dropdown to show only matching
+                // themes and re-derive which row (if any) is the active theme. The
+                // applied palette is untouched — this only narrows the list.
                 let mut prefs = crate::ui_prefs::load();
                 prefs.theme_filter = index;
                 crate::ui_prefs::save(&prefs);
+                if let Some(w) = theme_weak.upgrade() {
+                    let st = w.global::<AppearanceState>();
+                    let labels: Vec<slint::SharedString> =
+                        crate::theme::filtered_dropdown_labels(index)
+                            .into_iter()
+                            .map(slint::SharedString::from)
+                            .collect();
+                    st.set_themes(slint::ModelRc::new(slint::VecModel::from(labels)));
+                    st.set_theme_index(crate::theme::filtered_selected_index_for_slug(
+                        &prefs.theme,
+                        index,
+                    ));
+                }
             }
             other => log::debug!("[qbz-slint] unhandled appearance-select '{other}'"),
         });

--- a/crates/qbz/src/theme.rs
+++ b/crates/qbz/src/theme.rs
@@ -141,6 +141,13 @@ pub const CUSTOM_SLUG: &str = "custom";
 /// data pushed from Rust, not a `@tr` catalog string (matches `AUTO_LABEL`).
 pub const CUSTOM_LABEL: &str = "Custom";
 
+/// Theme-list filter (persisted in `ui_prefs.theme_filter`, mirrored to the
+/// Slint `AppearanceState.theme-filter`): `All` shows every theme, `Dark`/`Light`
+/// narrow the dropdown by luminance (`ThemeListEntry.is_light`).
+pub const FILTER_ALL: i32 = 0;
+pub const FILTER_DARK: i32 = 1;
+pub const FILTER_LIGHT: i32 = 2;
+
 /// Dropdown index of the appended "Auto (dynamic)" entry (right after every
 /// registry theme; the "Custom" entry follows it).
 pub fn auto_index() -> i32 {
@@ -179,8 +186,20 @@ pub fn selected_index_for_slug(slug: &str) -> i32 {
 /// The themes shown in the Settings dropdown, in display order. P1 exposes only
 /// the implemented rows. The dropdown index is just a position in THIS list.
 pub fn dropdown_themes() -> Vec<ThemeId> {
+    filtered_dropdown_themes(FILTER_ALL)
+}
+
+/// The implemented themes for a given [filter](FILTER_ALL): `All` keeps every
+/// theme; `Dark`/`Light` narrow by luminance (`ThemeListEntry.is_light`). The
+/// order within each subset matches the full display order.
+pub fn filtered_dropdown_themes(filter: i32) -> Vec<ThemeId> {
     qbz_theme::implemented_theme_list()
         .into_iter()
+        .filter(|e| match filter {
+            FILTER_DARK => !e.is_light,
+            FILTER_LIGHT => e.is_light,
+            _ => true,
+        })
         .map(|e| e.id)
         .collect()
 }
@@ -189,13 +208,71 @@ pub fn dropdown_themes() -> Vec<ThemeId> {
 /// dynamic "Auto (dynamic)" entry (index == [`auto_index`]) and the "Custom"
 /// entry (index == [`custom_index`]) appended last, in that order.
 pub fn dropdown_labels() -> Vec<String> {
-    let mut labels: Vec<String> = dropdown_themes()
+    filtered_dropdown_labels(FILTER_ALL)
+}
+
+/// Display names for [`filtered_dropdown_themes`]. The synthetic "Auto
+/// (dynamic)" and "Custom" entries are appended ONLY in the `All` view — they
+/// have no fixed light/dark polarity, so a narrowed Dark/Light list omits them.
+pub fn filtered_dropdown_labels(filter: i32) -> Vec<String> {
+    let mut labels: Vec<String> = filtered_dropdown_themes(filter)
         .into_iter()
         .map(|id| id.display_name().to_string())
         .collect();
-    labels.push(AUTO_LABEL.to_string());
-    labels.push(CUSTOM_LABEL.to_string());
+    if filter == FILTER_ALL {
+        labels.push(AUTO_LABEL.to_string());
+        labels.push(CUSTOM_LABEL.to_string());
+    }
     labels
+}
+
+/// Dropdown index of the "Auto (dynamic)" entry within a filtered list, or `-1`
+/// when the filter is not `All` (Auto/Custom are only shown in the `All` view).
+pub fn filtered_auto_index(filter: i32) -> i32 {
+    if filter == FILTER_ALL {
+        filtered_dropdown_themes(filter).len() as i32
+    } else {
+        -1
+    }
+}
+
+/// Dropdown index of the "Custom" entry within a filtered list, or `-1` when the
+/// filter is not `All`.
+pub fn filtered_custom_index(filter: i32) -> i32 {
+    if filter == FILTER_ALL {
+        filtered_auto_index(filter) + 1
+    } else {
+        -1
+    }
+}
+
+/// Map a filtered-dropdown index to a `ThemeId`. Out-of-range indices (including
+/// the Auto/Custom rows, which the caller handles separately) fall back to the
+/// default theme.
+pub fn filtered_id_for_index(index: i32, filter: i32) -> ThemeId {
+    filtered_dropdown_themes(filter)
+        .get(index as usize)
+        .copied()
+        .unwrap_or_else(qbz_theme::default_theme_id)
+}
+
+/// Position of a persisted slug within a filtered dropdown, auto/custom-aware.
+/// Returns `-1` when the theme is not present under this filter (e.g. a dark
+/// theme while the Light filter is active): the dropdown then highlights no row
+/// while the theme itself stays applied (selection is slug-driven, not index).
+pub fn filtered_selected_index_for_slug(slug: &str, filter: i32) -> i32 {
+    if slug == AUTO_SLUG {
+        filtered_auto_index(filter)
+    } else if slug == CUSTOM_SLUG {
+        filtered_custom_index(filter)
+    } else {
+        let id = id_for_slug(slug);
+        filtered_dropdown_themes(filter)
+            .iter()
+            .position(|&t| t == id)
+            .map(|p| p as i32)
+            .unwrap_or(-1)
+    }
 }
 
 /// Map a persisted slug to a `ThemeId`, falling back to the default (OLED) when
@@ -271,5 +348,65 @@ mod tests {
         assert_eq!(selected_index_for_slug(CUSTOM_SLUG), custom_index());
         // A real slug still resolves through the registry.
         assert_eq!(selected_index_for_slug("oled"), index_for_id(ThemeId::Oled));
+    }
+
+    #[test]
+    fn filter_all_matches_the_unfiltered_list() {
+        // The `All` filter is a pure passthrough of the existing behaviour.
+        assert_eq!(filtered_dropdown_themes(FILTER_ALL), dropdown_themes());
+        assert_eq!(filtered_dropdown_labels(FILTER_ALL), dropdown_labels());
+        assert_eq!(filtered_auto_index(FILTER_ALL), auto_index());
+        assert_eq!(filtered_custom_index(FILTER_ALL), custom_index());
+        assert_eq!(
+            filtered_selected_index_for_slug("oled", FILTER_ALL),
+            selected_index_for_slug("oled")
+        );
+    }
+
+    #[test]
+    fn dark_and_light_partition_the_themes_by_luminance() {
+        let all = filtered_dropdown_themes(FILTER_ALL);
+        let dark = filtered_dropdown_themes(FILTER_DARK);
+        let light = filtered_dropdown_themes(FILTER_LIGHT);
+        // Every theme lands in exactly one subset; together they cover `All`.
+        assert_eq!(dark.len() + light.len(), all.len());
+        assert!(dark.iter().all(|&id| !qbz_theme::is_light(id)));
+        assert!(light.iter().all(|&id| qbz_theme::is_light(id)));
+        // OLED (dark) is in Dark, absent from Light.
+        assert!(dark.contains(&ThemeId::Oled));
+        assert!(!light.contains(&ThemeId::Oled));
+    }
+
+    #[test]
+    fn narrowed_lists_omit_auto_and_custom() {
+        for filter in [FILTER_DARK, FILTER_LIGHT] {
+            let labels = filtered_dropdown_labels(filter);
+            assert_eq!(labels.len(), filtered_dropdown_themes(filter).len());
+            assert!(!labels.iter().any(|l| l == AUTO_LABEL || l == CUSTOM_LABEL));
+            assert_eq!(filtered_auto_index(filter), -1);
+            assert_eq!(filtered_custom_index(filter), -1);
+            // Synthetic slugs have no row here.
+            assert_eq!(filtered_selected_index_for_slug(AUTO_SLUG, filter), -1);
+            assert_eq!(filtered_selected_index_for_slug(CUSTOM_SLUG, filter), -1);
+        }
+    }
+
+    #[test]
+    fn filtered_index_roundtrips_and_reports_absent_as_minus_one() {
+        // A theme filtered out of the active view reports index -1.
+        assert_eq!(
+            filtered_selected_index_for_slug("oled", FILTER_LIGHT),
+            -1
+        );
+        // Within a subset, slug->index->id round-trips.
+        for filter in [FILTER_DARK, FILTER_LIGHT] {
+            for (i, id) in filtered_dropdown_themes(filter).into_iter().enumerate() {
+                assert_eq!(
+                    filtered_selected_index_for_slug(id.slug(), filter),
+                    i as i32
+                );
+                assert_eq!(filtered_id_for_index(i as i32, filter), id);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What

The All/Dark/Light filter button next to the theme dropdown (in Appearance settings) did **nothing** when clicked, on every platform. Two stacked bugs:

1. **Icon never changed** — all three branches of the `QbzIcon` `source` ternary pointed at the same `disc.svg` (`AppearanceSettings.slint`). That "circle with a dot" is what users saw in every state.
2. **Filter never filtered** — the Rust `theme-filter` handler (`main.rs`) was explicitly *"Cosmetic"*: it persisted the integer but never re-filtered the dropdown. The theme list was built once at startup and never touched again.

So clicking cycled an invisible counter and nothing else.

## Changes

- Add distinct **`sun-moon` / `moon` / `sun`** icons (lucide, matching the existing 24×24 stroke format) and wire the ternary so the icon reflects All / Dark / Light.
- `theme.rs`: add a **luminance-based, filter-aware dropdown API** (`filtered_dropdown_themes` / `filtered_dropdown_labels` / `filtered_auto_index` / `filtered_custom_index` / `filtered_id_for_index` / `filtered_selected_index_for_slug`). `All` is a proven passthrough of the previous behaviour; Dark/Light narrow by the registry's existing `is_light` flag. Unit tests included.
- `main.rs`: startup now seeds the dropdown honoring the persisted filter; the `theme-filter` handler rebuilds the list and re-derives the highlighted row; the `theme` selection handler maps the index within the active filter so selecting the right theme still works.

## Behaviour notes

- Auto (dynamic) / Custom appear only in the **All** view (no fixed light/dark polarity).
- If the active theme is filtered out of the current view, the dropdown simply shows no highlighted row — the palette stays applied (selection is slug-driven, not index-driven).

## Verification

- `cargo check -p qbz` passes (compiles the Slint UI + new icons + Rust glue). Added `theme.rs` unit tests for the filter partitioning and index round-trips.

## Recommendation

Honestly, the cleaner long-term move may be to **remove this filter entirely** rather than maintain it. It's a niche affordance, it complicates the theme index/selection mapping, and the theme list isn't long enough to really need dark/light narrowing. This PR makes it work as originally intended; if we'd rather not carry it, I'm happy to open a follow-up that deletes the button and the `theme_filter` pref instead. Flagging for a call.