### PR TITLE
feature(ui): filter indicators for home page sections

### DIFF
--- a/crates/qbz-ui/ui/discover/Carousel.slint
+++ b/crates/qbz-ui/ui/discover/Carousel.slint
@@ -7,8 +7,7 @@
 
 import { Theme } from "../foundation/semantic-colors.slint";
 import { Typography } from "../foundation/typography.slint";
-import { DiscoverSection, ShellState, AppearanceState } from "../state.slint";
-import { AlbumCard } from "AlbumCard.slint";
+import { DiscoverSection, ShellState, AppearanceState, TooltipState } from "../state.slint";import { AlbumCard } from "AlbumCard.slint";
 import { QbzIcon } from "../primitives/QbzIcon.slint";
 import { QbzSelect } from "../primitives/QbzSelect.slint";
 
@@ -82,6 +81,8 @@ export component Carousel inherits VerticalLayout {
     in property <[string]> sort-options: [];
     in property <int> sort-index: 0;
     callback sort-changed(int);
+    in property <bool> filterable: false;
+    in property <bool> filter-active: false;
     callback album-clicked(string);
     callback media-action(string, string, string);
     callback view-all-clicked();
@@ -183,12 +184,44 @@ export component Carousel inherits VerticalLayout {
 
     // --- Header: title + page controls -----------------------------------
     HorizontalLayout {
+        spacing: 8px;
         Text {
             text: root.section.title;
             color: Theme.text-primary;
             font-size: Typography.section;
             font-weight: Typography.semibold;
             vertical-alignment: center;
+        }
+
+        if root.filterable && root.filter-active : Rectangle {
+            width: 14px;
+            height: 14px;
+            y: (parent.height - self.height) / 2;
+
+            QbzIcon {
+                source: @image-url("../assets/icons/list-filter.svg");
+                width: 14px;
+                height: 14px;
+                tint: Theme.accent;
+            }
+
+            ta := TouchArea {
+                mouse-cursor: default;
+                changed has-hover => {
+                    if (self.has-hover) {
+                        TooltipState.text = @tr("Filtered by selected genre(s)");
+                        TooltipState.anchor-x = self.absolute-position.x + self.width / 2;
+                        TooltipState.anchor-y = self.absolute-position.y;
+                        TooltipState.show = true;
+                    } else {
+                        TooltipState.show = false;
+                    }
+                }
+            }
+        }
+
+        // Spacer to push controls to the right
+        Rectangle {
             horizontal-stretch: 1;
         }
         HorizontalLayout {

--- a/crates/qbz-ui/ui/discover/HomeView.slint
+++ b/crates/qbz-ui/ui/discover/HomeView.slint
@@ -335,6 +335,8 @@ export component HomeView inherits Rectangle {
                         || (desc.id == "mostStreamed" && desc.kind == "albumCarousel"): Carousel {
                         section: desc.section;
                         show-view-all: desc.section.endpoint != "";
+                        filterable: true;
+                        filter-active: GenreFilterState.selected-count > 0;
                         album-clicked(id) => {
                             root.album-clicked(id);
                         }
@@ -365,13 +367,48 @@ export component HomeView inherits Rectangle {
                                 font-size: 18px;
                                 font-weight: Typography.semibold;
                                 vertical-alignment: center;
+                            }
+
+                            if GenreFilterState.selected-count > 0 || HomeState.playlist-tag-count > 0 : Rectangle {
+                                width: 14px;
+                                height: 14px;
+                                y: (parent.height - self.height) / 2;
+
+                                QbzIcon {
+                                    source: @image-url("../assets/icons/list-filter.svg");
+                                    width: 14px;
+                                    height: 14px;
+                                    tint: Theme.accent;
+                                }
+
+                                ta := TouchArea {
+                                    mouse-cursor: default;
+                                    changed has-hover => {
+                                        if (self.has-hover) {
+                                            TooltipState.text = GenreFilterState.selected-count > 0 && HomeState.playlist-tag-count > 0
+                                                ? @tr("Filtered by genre and category")
+                                                : (HomeState.playlist-tag-count > 0 ? @tr("Filtered by selected categories") : @tr("Filtered by selected genre(s)"));
+                                            TooltipState.anchor-x = self.absolute-position.x + self.width / 2;
+                                            TooltipState.anchor-y = self.absolute-position.y;
+                                            TooltipState.show = true;
+                                        } else {
+                                            TooltipState.show = false;
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Spacer to push the category dropdown to the right
+                            Rectangle {
                                 horizontal-stretch: 1;
                             }
+
                             if HomeState.playlist-tags.length > 0: VerticalLayout {
                                 alignment: center;
                                 PlaylistTagFilter { }
                             }
                         }
+
 
                         if HomeState.playlists.length > 0: PlaylistCarousel {
                             // Title shown on the header row above, not here.
@@ -456,12 +493,9 @@ export component HomeView inherits Rectangle {
                         && HomeState.popular.length > 0: SlimCarousel {
                         title: @tr("Popular albums");
                         items: HomeState.popular;
-                        // "View all" -> the mostStreamed DiscoverBrowse page
-                        // (Tauri parity: the Home slim grid's see-all landed
-                        // on the Most Streamed full listing). The slimGrid
-                        // descriptor carries no section payload, so the
-                        // endpoint + localized title are supplied here.
                         show-view-all: true;
+                        filterable: true;
+                        filter-active: GenreFilterState.selected-count > 0;
                         view-all-clicked => {
                             root.discover-view-all("/discover/mostStreamed", @tr("Most Streamed"));
                         }

--- a/crates/qbz-ui/ui/discover/SlimCarousel.slint
+++ b/crates/qbz-ui/ui/discover/SlimCarousel.slint
@@ -8,8 +8,7 @@
 
 import { Theme } from "../foundation/semantic-colors.slint";
 import { Typography } from "../foundation/typography.slint";
-import { SlimItem, ShellState, AppearanceState } from "../state.slint";
-import { SlimCard } from "SlimCard.slint";
+import { SlimItem, ShellState, AppearanceState, TooltipState } from "../state.slint";import { SlimCard } from "SlimCard.slint";
 import { QbzIcon } from "../primitives/QbzIcon.slint";
 
 component NavButton inherits Rectangle {
@@ -86,6 +85,8 @@ export component SlimCarousel inherits VerticalLayout {
     // Shown regardless of page count, unlike the chevrons.
     in property <bool> show-refresh: false;
     callback refresh-clicked();
+    in property <bool> filterable: false;
+    in property <bool> filter-active: false;
 
     property <int> columns: 4;
     property <int> rows: 3;
@@ -102,14 +103,47 @@ export component SlimCarousel inherits VerticalLayout {
 
     // --- Header: title + (conditional) page controls ---------------------
     HorizontalLayout {
+        spacing: 8px;
         Text {
             text: root.title;
             color: Theme.text-primary;
             font-size: 18px;
             font-weight: Typography.semibold;
             vertical-alignment: center;
+        }
+
+        if root.filterable && root.filter-active : Rectangle {
+            width: 14px;
+            height: 14px;
+            y: (parent.height - self.height) / 2;
+
+            QbzIcon {
+                source: @image-url("../assets/icons/list-filter.svg");
+                width: 14px;
+                height: 14px;
+                tint: Theme.accent;
+            }
+
+            ta := TouchArea {
+                mouse-cursor: default;
+                changed has-hover => {
+                    if (self.has-hover) {
+                        TooltipState.text = @tr("Filtered by selected genre(s)");
+                        TooltipState.anchor-x = self.absolute-position.x + self.width / 2;
+                        TooltipState.anchor-y = self.absolute-position.y;
+                        TooltipState.show = true;
+                    } else {
+                        TooltipState.show = false;
+                    }
+                }
+            }
+        }
+
+        // Spacer to push controls to the right
+        Rectangle {
             horizontal-stretch: 1;
         }
+
         // Title-adjacent list actions (P7): add the whole backing list to the
         // queue / create a playlist from it. Icon buttons (ADR-008, no pills).
         if root.show-list-actions: HorizontalLayout {


### PR DESCRIPTION
<!-- What does this PR do? -->

Add filter indicators to home screen Discover and Playlist sections. 

## Summary

Qbz (<=2.0.2) users cannot see which sections are actually affected by active genre or category filters. 

This commit aims to fix that by (dynamically) adding a filter (funnel icon) symbol to the title, in accent color, with hover hint to clarify what it indicates. 
<img width="1718" height="1340" alt="Screenshot_2026-07-28_16-39-48" src="https://github.com/user-attachments/assets/351a12a8-7a52-47e2-8433-5006e5963bbb" />


- Add 'filterable' and 'filter-active' properties to Carousel and SlimCarousel.
- Render list-filter icon with active theme accent color when filters are active.
- Display hover tooltips detailing active filters (genre and/or category).
- Support dual-filter visual indicator on Qobuz Playlists section.


## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.
