### PR TITLE
fix(qbz-app,qbz-qobuz): tests: add crypto provider selection where ap…

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -6299,6 +6299,7 @@ dependencies = [
  "futures-util",
  "log",
  "md-5",
+ "qbz-app",
  "qbz-cmaf",
  "qbz-credentials",
  "qbz-models",

--- a/crates/qbz-app/src/shell.rs
+++ b/crates/qbz-app/src/shell.rs
@@ -318,6 +318,7 @@ mod tests {
     }
 
     fn test_runtime() -> AppRuntime<NoOpAdapter> {
+        crate::ensure_crypto_provider();
         AppRuntime::with_audio_settings(NoOpAdapter, None, AudioSettings::default(), None)
     }
 

--- a/crates/qbz-qobuz/Cargo.toml
+++ b/crates/qbz-qobuz/Cargo.toml
@@ -44,3 +44,6 @@ anyhow = { workspace = true }
 # Used only by examples/lyrics_probe.rs (read-only live probe of the lyrics
 # endpoint): loads the saved OAuth token / credentials for login.
 qbz-credentials = { path = "../qbz-credentials" }
+ 
+# Used only by client.rs tests (rustls crypto provider selection).
+qbz-app = { path = "../qbz-app" }

--- a/crates/qbz-qobuz/src/client.rs
+++ b/crates/qbz-qobuz/src/client.rs
@@ -3105,6 +3105,7 @@ mod tests {
     /// drop guard reopens the gate even if the test panics.
     #[tokio::test]
     async fn offline_gate_fails_fast_with_typed_error() {
+        qbz_app::ensure_crypto_provider();
         let _lock = crate::offline_gate::test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -3138,6 +3139,7 @@ mod tests {
     /// and without touching the network.
     #[tokio::test]
     async fn offline_gate_exempts_login_methods() {
+        qbz_app::ensure_crypto_provider();
         let _lock = crate::offline_gate::test_lock()
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());


### PR DESCRIPTION
## Summary

Fix some tests which were missing the crypto provider selection.

Thanks to @afonsojramos for [reporting](https://github.com/vicrodh/qbz/pull/674#issuecomment-5134529187)!

I `cargo test`ed most crates, however there seems to be a problem compiling anything that depends on `qbz-ui` on my system: `rustc` fills up memory and disk until it gets kicked out.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.
