### PR TITLE
build(deps): bump lofty to 0.24

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -4160,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "lofty"
-version = "0.23.3"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0c107dba5af049cf1c36b646fc1ba0cd2705f40d766d2c4c64f1b797c5fbed"
+checksum = "dec4feeff6c7d75093278133a06e827d7af6d2bfe20b0f331f9d10338a5ec7ca"
 dependencies = [
  "byteorder",
  "data-encoding",

--- a/crates/qbz-library/Cargo.toml
+++ b/crates/qbz-library/Cargo.toml
@@ -24,7 +24,7 @@ walkdir = "2"
 dirs = "6"
 
 # Audio metadata
-lofty = "0.23"
+lofty = "0.24"
 qbz-dsd = { path = "../qbz-dsd" }
 
 # Image processing (thumbnails)

--- a/crates/qbz-offline-cache/Cargo.toml
+++ b/crates/qbz-offline-cache/Cargo.toml
@@ -22,7 +22,7 @@ reqwest = { workspace = true }
 futures-util = { workspace = true }
 
 # FLAC tag + artwork embedding (legacy-format post-processing)
-lofty = "0.23"
+lofty = "0.24"
 
 # Platform cache dir (default offline-root location)
 dirs = "6"


### PR DESCRIPTION
## Summary

Every `0.23.x` release of `lofty` is yanked on crates.io (0.23.0 through 0.23.3). `qbz-library` and `qbz-offline-cache` both request `lofty = "0.23"`, which still builds here because the committed `Cargo.lock` pins a yanked version, but a **fresh resolve fails outright**:

```
error: failed to select a version for the requirement `lofty = "^0.23"`
  version 0.23.3 is yanked
required by package `qbz-offline-cache v2.0.2`
```

That makes both crates unusable as git dependencies from another workspace.

`0.24.0` is published and unyanked, and needs no code changes across the 19 call sites in the two crates.

## Verification

- `cargo test -p qbz-library -p qbz-offline-cache` — 110 passed, 0 failed
- `cargo check --workspace` — clean, no new warnings
- Also confirmed the graph now cross-compiles to `aarch64-apple-ios` and `aarch64-linux-android` (bundled rusqlite + keyring included)

## Two behaviour changes the bump carries, found in review

Neither is a reason not to take it, but a reviewer weighing a semver-major bump should know about both.

**It silently repairs FLAC metadata corruption.** `0.23.3` rewound to byte 0 and wrote *without truncating*, so when new metadata is smaller than what it replaced, the tail of the longer file survived. `0.24.0` truncates (`lofty/src/flac/write.rs`). This repo drives that exact path in two places: `qbz-offline-cache/src/metadata.rs` clears the tag and repopulates it before saving, and `qbz-library/src/tag_writer.rs` removes keys before saving. So the bump fixes real corruption rather than merely unblocking resolution.

**APE multi-value reads change value.** `0.24.0` splits NUL-separated APE values, so `get_string(TrackArtist)` on `"A\0B"` now returns `"A"` where it previously returned `"A\0B"`. `.ape` is in `SUPPORTED_AUDIO_EXTENSIONS` and MP3s often carry APEv2 tags, so `qbz-library/src/scanner.rs` can see this. It is an improvement, but it is a changed return value.

## A caveat on the verification above

The 110 passing tests are reassurance this bump has not earned: there are no audio fixtures in the repo and no test invokes lofty's parser or writer. The lofty-touching tests in `metadata.rs` build a `Tag` in memory. A FLAC round-trip fixture asserting the shrink case would have caught the corruption bug above, and is the test worth adding if this area is touched again.
