### PR TITLE
Bugfix/internal/cast volume sync and write coalescing

### DIFF
--- a/crates/qbz-cast/Cargo.toml
+++ b/crates/qbz-cast/Cargo.toml
@@ -39,3 +39,7 @@ getrandom = "0.4"
 
 # Async runtime (for DLNA)
 tokio = { version = "1", features = ["rt", "sync"] }
+
+[dev-dependencies]
+# The DLNA volume test drives a real SOAP round trip against a fake renderer.
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/qbz-cast/src/dlna/device.rs
+++ b/crates/qbz-cast/src/dlna/device.rs
@@ -1,6 +1,7 @@
 //! DLNA device connection and playback via AVTransport SOAP
 
 use rupnp::http::Uri;
+use rupnp::scpd::{StateVariableKind, SCPD};
 use rupnp::{Device, Service};
 use serde::{Deserialize, Serialize};
 
@@ -35,6 +36,59 @@ pub struct DlnaStatus {
     pub current_uri: Option<String>,
 }
 
+/// A renderer's native volume scale, read from the RenderingControl SCPD
+/// (`allowedValueRange` of the `Volume` state variable).
+///
+/// 0..100 is the common case but NOT a given — plenty of renderers declare
+/// 0..31, 0..255 or a non-zero minimum. Both directions convert through the
+/// declared range so a percentage is never mistaken for a device value (on a
+/// 0..255 renderer that capped every request at ~39% of real max).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct VolumeRange {
+    min: i64,
+    max: i64,
+}
+
+impl Default for VolumeRange {
+    fn default() -> Self {
+        Self { min: 0, max: 100 }
+    }
+}
+
+impl VolumeRange {
+    /// Device value → 0.0..=1.0.
+    fn to_fraction(self, value: i64) -> f32 {
+        if self.max <= self.min {
+            return 0.0;
+        }
+        let span = (self.max - self.min) as f32;
+        ((value.clamp(self.min, self.max) - self.min) as f32 / span).clamp(0.0, 1.0)
+    }
+
+    /// 0.0..=1.0 → device value.
+    fn to_device_value(self, fraction: f32) -> i64 {
+        let span = (self.max - self.min) as f32;
+        let value = self.min as f32 + fraction.clamp(0.0, 1.0) * span;
+        (value.round() as i64).clamp(self.min, self.max)
+    }
+}
+
+/// Pull the `Volume` range out of a RenderingControl SCPD. `None` when the
+/// device declares no usable range — the caller then keeps the 0..100 default.
+fn volume_range_from_scpd(scpd: &SCPD) -> Option<VolumeRange> {
+    let variable = scpd
+        .state_variables()
+        .iter()
+        .find(|v| v.name() == "Volume")?;
+    let StateVariableKind::Range(range) = variable.kind() else {
+        return None;
+    };
+    let min = range.minimum().trim().parse::<i64>().ok()?;
+    let max = range.maximum().trim().parse::<i64>().ok()?;
+    // A degenerate/inverted range would make every conversion nonsense.
+    (max > min).then_some(VolumeRange { min, max })
+}
+
 /// DLNA connection with AVTransport and RenderingControl support
 pub struct DlnaConnection {
     device: DiscoveredDlnaDevice,
@@ -42,6 +96,9 @@ pub struct DlnaConnection {
     device_url: Uri,
     av_transport_service: Option<Service>,
     rendering_control_service: Option<Service>,
+    // The renderer's native volume scale, resolved once at connect. Both
+    // get_volume and set_volume convert through it.
+    volume_range: VolumeRange,
     // Current media URI
     current_uri: Option<String>,
     // Last SetAVTransportURI payload (URI + DIDL). Kept so `play()` can
@@ -83,6 +140,13 @@ impl DlnaConnection {
             rendering_control_service.is_some()
         );
 
+        // Resolve the renderer's volume scale once, up front: every later
+        // GetVolume/SetVolume converts through it.
+        let volume_range = match rendering_control_service.as_ref() {
+            Some(rc) => Self::fetch_volume_range(rc, &device_url).await,
+            None => VolumeRange::default(),
+        };
+
         // Clear any residual transport state the renderer kept from a previous
         // session/app run. Without this, a renderer left mid-playback re-requests
         // its orphaned CurrentURI against our fresh media server (new path token
@@ -107,6 +171,7 @@ impl DlnaConnection {
             device_url,
             av_transport_service,
             rendering_control_service,
+            volume_range,
             current_uri: None,
             last_set_uri_payload: None,
             uri_freshly_set: false,
@@ -447,6 +512,38 @@ impl DlnaConnection {
         Ok(())
     }
 
+    /// Read the renderer's declared `Volume` range from the RenderingControl
+    /// SCPD, falling back to 0..100 when the device is unreachable, slow, or
+    /// declares no range. Best-effort by design: a wrong-but-plausible scale
+    /// only matters for the conversion factor, and 0..100 is what the previous
+    /// hard-coded behavior assumed anyway.
+    async fn fetch_volume_range(rc_service: &Service, device_url: &Uri) -> VolumeRange {
+        let scpd = match tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            rc_service.scpd(device_url),
+        )
+        .await
+        {
+            Ok(Ok(scpd)) => scpd,
+            Ok(Err(e)) => {
+                log::warn!("DLNA: RenderingControl SCPD fetch failed ({e}); assuming volume 0-100");
+                return VolumeRange::default();
+            }
+            Err(_) => {
+                log::warn!("DLNA: RenderingControl SCPD fetch timed out; assuming volume 0-100");
+                return VolumeRange::default();
+            }
+        };
+        // NOTE: `SCPD` holds `Rc`s, so it must not be alive across an `.await`
+        // or `connect`'s future stops being `Send`. Extract and drop it here.
+        let range = volume_range_from_scpd(&scpd).unwrap_or_else(|| {
+            log::info!("DLNA: RenderingControl declares no Volume range; assuming 0-100");
+            VolumeRange::default()
+        });
+        log::info!("DLNA: volume range {}..={}", range.min, range.max);
+        range
+    }
+
     /// Set volume (0.0 - 1.0)
     pub async fn set_volume(&mut self, volume: f32) -> Result<(), DlnaError> {
         if !self.connected {
@@ -457,8 +554,7 @@ impl DlnaConnection {
             DlnaError::Playback("Device has no RenderingControl service".to_string())
         })?;
 
-        // DLNA volume is typically 0-100
-        let dlna_volume = ((volume.clamp(0.0, 1.0) * 100.0) as u32).min(100);
+        let dlna_volume = self.volume_range.to_device_value(volume);
 
         let payload = format!(
             "<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>{}</DesiredVolume>",
@@ -469,6 +565,49 @@ impl DlnaConnection {
 
         log::info!("DLNA: Set volume to {}", dlna_volume);
         Ok(())
+    }
+
+    /// Query the renderer's current volume as a 0.0..=1.0 fraction
+    /// (RenderingControl `GetVolume`, Master channel).
+    ///
+    /// This is what keeps the app's slider honest: without it the bar keeps
+    /// showing the LOCAL volume after connecting, and the first drag slams the
+    /// renderer to wherever that slider happened to sit — a speaker at 20%
+    /// jumping to 90% because the bar said 90%.
+    pub async fn get_volume(&self) -> Result<f32, DlnaError> {
+        if !self.connected {
+            return Err(DlnaError::NotConnected);
+        }
+
+        let rc_service = self.rendering_control_service.as_ref().ok_or_else(|| {
+            DlnaError::Playback("Device has no RenderingControl service".to_string())
+        })?;
+
+        let response = Self::run_action(
+            rc_service,
+            &self.device_url,
+            "GetVolume",
+            "<InstanceID>0</InstanceID><Channel>Master</Channel>",
+            5,
+        )
+        .await?;
+
+        let raw = response.get("CurrentVolume").ok_or_else(|| {
+            DlnaError::Playback("GetVolume response has no CurrentVolume".to_string())
+        })?;
+        let value = parse_volume_value(raw).ok_or_else(|| {
+            DlnaError::Playback(format!("GetVolume returned unparseable volume {raw:?}"))
+        })?;
+
+        let fraction = self.volume_range.to_fraction(value);
+        log::debug!(
+            "DLNA: GetVolume {} (range {}..={}) -> {:.3}",
+            value,
+            self.volume_range.min,
+            self.volume_range.max,
+            fraction
+        );
+        Ok(fraction)
     }
 
     /// Set mute on/off (RenderingControl SetMute, Master channel). Companion to
@@ -582,6 +721,20 @@ impl DlnaConnection {
             transport_state,
         })
     }
+}
+
+/// Parse a `CurrentVolume` value. The spec says `ui2`, but a few renderers
+/// answer with a decimal ("50.0"), so fall back to a float parse + round
+/// rather than dropping the reading and leaving the slider stale.
+fn parse_volume_value(raw: &str) -> Option<i64> {
+    let raw = raw.trim();
+    if let Ok(v) = raw.parse::<i64>() {
+        return Some(v);
+    }
+    raw.parse::<f64>()
+        .ok()
+        .filter(|v| v.is_finite())
+        .map(|v| v.round() as i64)
 }
 
 /// Parse time string "HH:MM:SS" or "H:MM:SS" to seconds
@@ -711,7 +864,61 @@ fn redact_media_uri(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{redact_media_uri, service_type_matches};
+    use super::{parse_volume_value, redact_media_uri, service_type_matches, VolumeRange};
+
+    #[test]
+    fn percent_range_round_trips() {
+        let r = VolumeRange::default();
+        assert_eq!(r.to_device_value(0.0), 0);
+        assert_eq!(r.to_device_value(1.0), 100);
+        assert_eq!(r.to_device_value(0.42), 42);
+        assert_eq!(r.to_fraction(0), 0.0);
+        assert_eq!(r.to_fraction(100), 1.0);
+        assert!((r.to_fraction(42) - 0.42).abs() < 1e-6);
+    }
+
+    #[test]
+    fn non_percent_range_scales_both_ways() {
+        // A 0..255 renderer: the old hard-coded percent math capped every
+        // request at 100/255 (~39% of real max) and would have read 255 back
+        // as "255%".
+        let r = VolumeRange { min: 0, max: 255 };
+        assert_eq!(r.to_device_value(1.0), 255);
+        assert_eq!(r.to_device_value(0.5), 128);
+        assert_eq!(r.to_fraction(255), 1.0);
+        assert!((r.to_fraction(128) - 0.502).abs() < 1e-3);
+    }
+
+    #[test]
+    fn offset_minimum_maps_endpoints() {
+        // `Volume` is unsigned in practice, but the range is the device's to
+        // declare — the conversion must key off min/max, not assume 0.
+        let r = VolumeRange { min: 10, max: 50 };
+        assert_eq!(r.to_device_value(0.0), 10);
+        assert_eq!(r.to_device_value(1.0), 50);
+        assert_eq!(r.to_device_value(0.5), 30);
+        assert_eq!(r.to_fraction(10), 0.0);
+        assert_eq!(r.to_fraction(50), 1.0);
+        assert!((r.to_fraction(30) - 0.5).abs() < 1e-6);
+    }
+
+    #[test]
+    fn out_of_range_values_clamp() {
+        let r = VolumeRange { min: 0, max: 31 };
+        assert_eq!(r.to_device_value(-1.0), 0);
+        assert_eq!(r.to_device_value(2.0), 31);
+        assert_eq!(r.to_fraction(-5), 0.0);
+        assert_eq!(r.to_fraction(99), 1.0);
+    }
+
+    #[test]
+    fn parses_volume_values() {
+        assert_eq!(parse_volume_value("42"), Some(42));
+        assert_eq!(parse_volume_value(" 42\n"), Some(42));
+        assert_eq!(parse_volume_value("50.0"), Some(50));
+        assert_eq!(parse_volume_value("NOT_IMPLEMENTED"), None);
+        assert_eq!(parse_volume_value(""), None);
+    }
 
     #[test]
     fn redacts_path_token() {

--- a/crates/qbz-cast/tests/dlna_volume.rs
+++ b/crates/qbz-cast/tests/dlna_volume.rs
@@ -1,0 +1,186 @@
+//! End-to-end volume round trip against a simulated UPnP MediaRenderer.
+//!
+//! Covers the actual failure the slider had: the app never asked the renderer
+//! what its volume was, and assumed every renderer counts 0-100. The fake
+//! device here deliberately declares a 0..31 scale so a percentage sent (or
+//! read) verbatim is unmistakably wrong.
+
+use std::sync::mpsc;
+
+use qbz_cast::{DiscoveredDlnaDevice, DlnaConnection};
+
+/// The renderer's declared scale — NOT 0-100, on purpose.
+const RC_MAX: i64 = 31;
+/// Where the fake renderer's volume sits when the app connects.
+const CURRENT_VOLUME: i64 = 8;
+
+fn device_description(port: u16) -> String {
+    // Only RenderingControl: `DlnaConnection::connect` sends an AVTransport
+    // Stop when that service exists, which this test has no use for.
+    format!(
+        r#"<?xml version="1.0"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <specVersion><major>1</major><minor>0</minor></specVersion>
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:MediaRenderer:1</deviceType>
+    <friendlyName>Fake Renderer</friendlyName>
+    <manufacturer>QBZ</manufacturer>
+    <modelName>Test</modelName>
+    <UDN>uuid:fake-renderer-{port}</UDN>
+    <serviceList>
+      <service>
+        <serviceType>urn:schemas-upnp-org:service:RenderingControl:1</serviceType>
+        <serviceId>urn:upnp-org:serviceId:RenderingControl</serviceId>
+        <SCPDURL>/rc.xml</SCPDURL>
+        <controlURL>/rc/control</controlURL>
+        <eventSubURL>/rc/event</eventSubURL>
+      </service>
+    </serviceList>
+  </device>
+</root>"#
+    )
+}
+
+fn rendering_control_scpd() -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<scpd xmlns="urn:schemas-upnp-org:service-1-0">
+  <specVersion><major>1</major><minor>0</minor></specVersion>
+  <actionList>
+    <action>
+      <name>GetVolume</name>
+      <argumentList>
+        <argument>
+          <name>CurrentVolume</name>
+          <direction>out</direction>
+          <relatedStateVariable>Volume</relatedStateVariable>
+        </argument>
+      </argumentList>
+    </action>
+    <action>
+      <name>SetVolume</name>
+      <argumentList>
+        <argument>
+          <name>DesiredVolume</name>
+          <direction>in</direction>
+          <relatedStateVariable>Volume</relatedStateVariable>
+        </argument>
+      </argumentList>
+    </action>
+  </actionList>
+  <serviceStateTable>
+    <stateVariable sendEvents="yes">
+      <name>Volume</name>
+      <dataType>ui2</dataType>
+      <allowedValueRange>
+        <minimum>0</minimum>
+        <maximum>{RC_MAX}</maximum>
+        <step>1</step>
+      </allowedValueRange>
+    </stateVariable>
+  </serviceStateTable>
+</scpd>"#
+    )
+}
+
+fn soap_envelope(action: &str, body: &str) -> String {
+    format!(
+        r#"<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <u:{action}Response xmlns:u="urn:schemas-upnp-org:service:RenderingControl:1">{body}</u:{action}Response>
+  </s:Body>
+</s:Envelope>"#
+    )
+}
+
+/// Pull `<DesiredVolume>N</DesiredVolume>` out of a SetVolume request body.
+fn desired_volume(body: &str) -> Option<i64> {
+    let start = body.find("<DesiredVolume>")? + "<DesiredVolume>".len();
+    let end = body[start..].find("</DesiredVolume>")? + start;
+    body[start..end].trim().parse().ok()
+}
+
+/// A minimal UPnP renderer: serves its description + RenderingControl SCPD and
+/// answers GetVolume/SetVolume. Every SetVolume value it receives is reported
+/// back over `set_volumes`.
+fn spawn_fake_renderer() -> (String, mpsc::Receiver<i64>) {
+    let server = tiny_http::Server::http("127.0.0.1:0").expect("bind fake renderer");
+    let port = server.server_addr().to_ip().expect("ip addr").port();
+    let (set_tx, set_rx) = mpsc::channel();
+
+    std::thread::spawn(move || {
+        for mut request in server.incoming_requests() {
+            let url = request.url().to_string();
+            let mut body = String::new();
+            let _ = request.as_reader().read_to_string(&mut body);
+
+            let response = if url.starts_with("/rc.xml") {
+                rendering_control_scpd()
+            } else if url.starts_with("/rc/control") {
+                if body.contains("SetVolume") {
+                    if let Some(v) = desired_volume(&body) {
+                        let _ = set_tx.send(v);
+                    }
+                    soap_envelope("SetVolume", "")
+                } else {
+                    soap_envelope(
+                        "GetVolume",
+                        &format!("<CurrentVolume>{CURRENT_VOLUME}</CurrentVolume>"),
+                    )
+                }
+            } else {
+                device_description(port)
+            };
+
+            let header = "Content-Type: text/xml; charset=\"utf-8\""
+                .parse::<tiny_http::Header>()
+                .expect("valid header");
+            let _ = request.respond(tiny_http::Response::from_string(response).with_header(header));
+        }
+    });
+
+    (format!("http://127.0.0.1:{port}/desc.xml"), set_rx)
+}
+
+fn fake_device(url: String) -> DiscoveredDlnaDevice {
+    DiscoveredDlnaDevice {
+        id: "uuid:fake-renderer".to_string(),
+        name: "Fake Renderer".to_string(),
+        manufacturer: "QBZ".to_string(),
+        model: "Test".to_string(),
+        ip: "127.0.0.1".to_string(),
+        url,
+        has_av_transport: false,
+        has_rendering_control: true,
+    }
+}
+
+#[tokio::test]
+async fn reads_and_writes_volume_on_the_devices_own_scale() {
+    let (url, set_volumes) = spawn_fake_renderer();
+    let mut conn = DlnaConnection::connect(fake_device(url))
+        .await
+        .expect("connect to fake renderer");
+
+    // READ: 8 of 31 is ~26% — not "8%", which is what a hard-coded percent
+    // scale would have reported, and not the app's own volume either.
+    let volume = conn.get_volume().await.expect("GetVolume");
+    let expected = CURRENT_VOLUME as f32 / RC_MAX as f32;
+    assert!(
+        (volume - expected).abs() < 1e-3,
+        "expected ~{expected:.3}, got {volume:.3}"
+    );
+
+    // WRITE: half way up the slider must land half way up the DEVICE's scale
+    // (16 of 31), not at "50" — which this renderer would have clamped to full.
+    conn.set_volume(0.5).await.expect("SetVolume");
+    let sent = set_volumes.recv().expect("renderer received SetVolume");
+    assert_eq!(sent, 16, "0.5 on a 0..{RC_MAX} renderer");
+
+    // The extremes must reach the real endpoints.
+    conn.set_volume(1.0).await.expect("SetVolume max");
+    assert_eq!(set_volumes.recv().expect("SetVolume max"), RC_MAX);
+    conn.set_volume(0.0).await.expect("SetVolume min");
+    assert_eq!(set_volumes.recv().expect("SetVolume min"), 0);
+}

--- a/crates/qbz/src/cast_service.rs
+++ b/crates/qbz/src/cast_service.rs
@@ -79,6 +79,12 @@ const CAST_VOLUME_ECHO_GUARD: std::time::Duration = std::time::Duration::from_se
 /// so a steady renderer doesn't jitter the bar by fractions of a percent.
 const CAST_VOLUME_EPSILON: f32 = 0.02;
 
+/// Floor between renderer volume writes. The slider emits a change per step
+/// while dragging, far faster than a renderer can absorb them, so the worker
+/// spaces its writes out — every tick that lands inside the gap collapses into
+/// the next single write instead of extending a queue.
+const CAST_VOLUME_WRITE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum CastProtocol {
     Chromecast,
@@ -177,6 +183,11 @@ struct CastInner {
     volume_set_at: Option<std::time::Instant>,
     // Poll ticks since the last renderer-volume refresh.
     volume_poll_tick: u32,
+    // Drag target handed to the volume worker (0..1), and the worker itself.
+    // Dropping the sender ends the worker; the handle is kept so disconnect can
+    // cut a write that is already in flight.
+    volume_tx: Option<tokio::sync::watch::Sender<f32>>,
+    volume_task: Option<tokio::task::JoinHandle<()>>,
     // QConnect coexistence: remember whether QConnect was on before casting.
     qconnect_was_on_before_cast: bool,
     // Position-poll task; aborted on disconnect.
@@ -323,6 +334,10 @@ impl SlintCastService {
             CastProtocol::Dlna => self.connect_dlna(&device_id).await?,
         };
 
+        // Before `protocol` goes live, so no slider move can arrive with nowhere
+        // to land.
+        self.start_volume_worker().await;
+
         {
             let mut inner = self.inner.lock().await;
             inner.protocol = Some(proto);
@@ -435,6 +450,7 @@ impl SlintCastService {
         // Stop the renderer first (disconnect alone leaves it playing).
         let _ = self.stop_renderer().await;
 
+        let volume_task;
         let (poll, was_on) = {
             let mut inner = self.inner.lock().await;
             if let Some(h) = inner.chromecast.take() {
@@ -461,9 +477,14 @@ impl SlintCastService {
             inner.cast_volume = None;
             inner.volume_set_at = None;
             inner.volume_poll_tick = 0;
+            inner.volume_tx = None;
+            volume_task = inner.volume_task.take();
             (inner.poll_task.take(), inner.qconnect_was_on_before_cast)
         };
         if let Some(task) = poll {
+            task.abort();
+        }
+        if let Some(task) = volume_task {
             task.abort();
         }
         if was_on {
@@ -817,34 +838,29 @@ impl SlintCastService {
         Ok(true)
     }
 
+    /// Route a slider move to the renderer.
+    ///
+    /// This does NOT talk to the device: it hands the target to the volume
+    /// worker and returns. The slider emits a change per step, and a renderer
+    /// write is orders of magnitude slower than the drag produces them — writing
+    /// inline queued them up, so a slow drag to max left the volume crawling
+    /// upward long after the user let go, with no way to stop it. The worker
+    /// keeps exactly one write in flight and always writes the newest value.
     pub async fn set_volume_if_cast(&self, volume: f32) -> Result<bool, String> {
-        let proto = {
-            let inner = self.inner.lock().await;
-            match inner.protocol {
-                Some(p) => p,
-                None => return Ok(false),
-            }
-        };
         let v = volume.clamp(0.0, 1.0);
-        match proto {
-            CastProtocol::Chromecast => {
-                let inner = self.inner.lock().await;
-                if let Some(h) = inner.chromecast.as_ref() {
-                    h.set_volume(v).map_err(|e| e.to_string())?;
-                }
-            }
-            CastProtocol::Dlna => {
-                let mut inner = self.inner.lock().await;
-                if let Some(c) = inner.dlna.as_mut() {
-                    c.set_volume(v).await.map_err(|e| e.to_string())?;
-                }
-            }
-        }
-        // Remember what the renderer was just told, and when: the periodic
-        // refresh compares against this instead of pushing every reading, and
-        // stays out of the way while the drag settles.
         {
             let mut inner = self.inner.lock().await;
+            if inner.protocol.is_none() {
+                return Ok(false);
+            }
+            if let Some(tx) = inner.volume_tx.as_ref() {
+                // Latest-wins: a send while a write is in flight replaces the
+                // pending target rather than queueing behind it.
+                let _ = tx.send(v);
+            }
+            // Remember what the renderer is being told, and when: the periodic
+            // refresh compares against this instead of pushing every reading,
+            // and stays out of the way while the drag settles.
             inner.cast_volume = Some(v);
             inner.volume_set_at = Some(std::time::Instant::now());
             inner.volume_poll_tick = 0;
@@ -853,6 +869,58 @@ impl SlintCastService {
         // moves the slider) is skipped while casting.
         self.push_volume(v);
         Ok(true)
+    }
+
+    /// Start the volume worker for this connection, replacing any prior one.
+    async fn start_volume_worker(self: &Arc<Self>) {
+        // The seed is never transmitted — `changed()` only wakes on sends made
+        // after the receiver exists — so its value is irrelevant.
+        let (tx, rx) = tokio::sync::watch::channel(0.0_f32);
+        let svc = self.clone();
+        let task = tokio::spawn(async move { svc.run_volume_worker(rx).await });
+        let mut inner = self.inner.lock().await;
+        inner.volume_tx = Some(tx);
+        if let Some(old) = inner.volume_task.replace(task) {
+            old.abort();
+        }
+    }
+
+    async fn run_volume_worker(self: Arc<Self>, rx: tokio::sync::watch::Receiver<f32>) {
+        let svc = self.clone();
+        coalesce_volume_writes(rx, CAST_VOLUME_WRITE_INTERVAL, move |target| {
+            let svc = svc.clone();
+            async move {
+                if let Err(e) = svc.write_volume_to_renderer(target).await {
+                    log::warn!("[Cast] set_volume: {e}");
+                }
+            }
+        })
+        .await;
+    }
+
+    async fn write_volume_to_renderer(&self, volume: f32) -> Result<(), String> {
+        let proto = {
+            let inner = self.inner.lock().await;
+            match inner.protocol {
+                Some(p) => p,
+                None => return Ok(()),
+            }
+        };
+        match proto {
+            CastProtocol::Chromecast => {
+                let inner = self.inner.lock().await;
+                if let Some(h) = inner.chromecast.as_ref() {
+                    h.set_volume(volume).map_err(|e| e.to_string())?;
+                }
+            }
+            CastProtocol::Dlna => {
+                let mut inner = self.inner.lock().await;
+                if let Some(c) = inner.dlna.as_mut() {
+                    c.set_volume(volume).await.map_err(|e| e.to_string())?;
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Read the connected renderer's REAL volume and mirror it onto the bar.
@@ -1318,6 +1386,10 @@ impl SlintCastService {
         if let Some(task) = inner.poll_task.take() {
             task.abort();
         }
+        inner.volume_tx = None;
+        if let Some(task) = inner.volume_task.take() {
+            task.abort();
+        }
         if let Some(h) = inner.chromecast.take() {
             let _ = h.disconnect();
         }
@@ -1753,5 +1825,94 @@ fn trim_khz(khz: f64) -> String {
         format!("{}", khz as i64)
     } else {
         format!("{:.1}", khz)
+    }
+}
+
+/// Apply volume targets to `write`, newest-first, one at a time.
+///
+/// The slider emits a change per step while dragging, far faster than a
+/// renderer can absorb writes. Writing each one queued them up, so a slow drag
+/// to max left the volume still crawling upward after the user let go, with no
+/// way to stop it. Here `changed()` resolves immediately when values arrived
+/// during the previous write and `borrow_and_update` reads only the LATEST, so
+/// a burst collapses into one write; `interval` spaces writes out so the burst
+/// has a window to collapse in. The value the user released on is always the
+/// last one written. Returns when the sender is dropped (disconnect).
+async fn coalesce_volume_writes<F, Fut>(
+    mut rx: tokio::sync::watch::Receiver<f32>,
+    interval: std::time::Duration,
+    mut write: F,
+) where
+    F: FnMut(f32) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    while rx.changed().await.is_ok() {
+        let target = *rx.borrow_and_update();
+        write(target).await;
+        tokio::time::sleep(interval).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::coalesce_volume_writes;
+    use std::sync::{Arc, Mutex};
+    use std::time::Duration;
+
+    /// A slow drag must not outlive the drag: the renderer sees a handful of
+    /// writes instead of one per slider step, and the value the user let go on
+    /// is the one it ends at.
+    #[tokio::test]
+    async fn volume_writes_coalesce_to_the_newest_target() {
+        const TICKS: usize = 40;
+        let (tx, rx) = tokio::sync::watch::channel(0.0_f32);
+        let writes: Arc<Mutex<Vec<f32>>> = Arc::new(Mutex::new(Vec::new()));
+
+        let sink = writes.clone();
+        let worker = tokio::spawn(coalesce_volume_writes(
+            rx,
+            Duration::from_millis(10),
+            move |v| {
+                let sink = sink.clone();
+                // Stand in for a renderer round trip — slower than the drag
+                // produces ticks, which is the whole problem.
+                async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    sink.lock().expect("writes").push(v);
+                }
+            },
+        ));
+
+        for i in 1..=TICKS {
+            tx.send(i as f32 / TICKS as f32).expect("worker alive");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // Wait for the trailing write, bounded generously so a loaded CI box
+        // doesn't fail on timing (slower = fewer writes, never more).
+        for _ in 0..100 {
+            if writes.lock().expect("writes").last() == Some(&1.0) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        drop(tx);
+        worker.await.expect("worker exits when the sender drops");
+
+        let writes = writes.lock().expect("writes");
+        assert!(
+            writes.len() < TICKS / 2,
+            "expected coalescing, got {} writes for {TICKS} ticks",
+            writes.len()
+        );
+        assert_eq!(
+            writes.last().copied(),
+            Some(1.0),
+            "the released value must be the one that sticks"
+        );
+        assert!(
+            writes.iter().all(|v| (0.0..=1.0).contains(v)),
+            "no write may overshoot the drag: {writes:?}"
+        );
     }
 }

--- a/crates/qbz/src/cast_service.rs
+++ b/crates/qbz/src/cast_service.rs
@@ -63,6 +63,22 @@ const CAST_POSITION_SIGNAL_MIN_SECS: f64 = 1.0;
 /// renderer that under-reports position or trims trailing silence).
 const CAST_PREMATURE_STOP_POLLS_MAX: u32 = 4;
 
+/// How many position polls between renderer-volume refreshes. The volume is
+/// authoritative on the DEVICE (its own remote/app can move it), so the slider
+/// re-reads it periodically — but far less often than the position, since it is
+/// an extra round trip to the renderer and volume rarely changes behind our back.
+const CAST_VOLUME_REFRESH_POLLS: u32 = 5;
+
+/// Ignore a refreshed volume within this window after a local drag: the renderer
+/// may not have applied the new value yet, and pushing its pre-drag reading back
+/// onto the bar would fight the user's own slider.
+const CAST_VOLUME_ECHO_GUARD: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Minimum change before a refreshed renderer volume moves the slider. Absorbs
+/// the rounding of the 0..1 fraction into the device's integer scale (and back)
+/// so a steady renderer doesn't jitter the bar by fractions of a percent.
+const CAST_VOLUME_EPSILON: f32 = 0.02;
+
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum CastProtocol {
     Chromecast,
@@ -153,6 +169,14 @@ struct CastInner {
     cast_max_position: f64,
     // Consecutive STOPPED polls the guard called premature (anti-wedge latch).
     cast_premature_stop_polls: u32,
+    // Renderer volume mirror (0..1). `cast_volume` is the last value we read
+    // from or sent to the renderer — the refresh only touches the slider when
+    // the device drifts away from it. `volume_set_at` stamps the last local
+    // drag so an in-flight read can't snap the slider back mid-drag.
+    cast_volume: Option<f32>,
+    volume_set_at: Option<std::time::Instant>,
+    // Poll ticks since the last renderer-volume refresh.
+    volume_poll_tick: u32,
     // QConnect coexistence: remember whether QConnect was on before casting.
     qconnect_was_on_before_cast: bool,
     // Position-poll task; aborted on disconnect.
@@ -318,6 +342,11 @@ impl SlintCastService {
         }
         self.push_connection_state().await;
         self.push_device_cap_row().await;
+        // Adopt the renderer's OWN volume before the user can touch the slider.
+        // Skipping this leaves the bar showing the local volume, so the first
+        // drag jumps the renderer to that value — dragging down from a local
+        // 100% to 70% turns a speaker sitting at 20% UP, hard.
+        self.refresh_renderer_volume(true).await;
         self.start_position_poll();
 
         // Re-cast the current track at its position, passing the REAL source
@@ -427,6 +456,11 @@ impl SlintCastService {
             inner.current_track_id = None;
             inner.is_playing = false;
             inner.track_end_detected = false;
+            // The bar goes back to showing the LOCAL volume (the local poll
+            // re-owns it within a tick), so the renderer's mirror is stale.
+            inner.cast_volume = None;
+            inner.volume_set_at = None;
+            inner.volume_poll_tick = 0;
             (inner.poll_task.take(), inner.qconnect_was_on_before_cast)
         };
         if let Some(task) = poll {
@@ -806,15 +840,113 @@ impl SlintCastService {
                 }
             }
         }
+        // Remember what the renderer was just told, and when: the periodic
+        // refresh compares against this instead of pushing every reading, and
+        // stays out of the way while the drag settles.
+        {
+            let mut inner = self.inner.lock().await;
+            inner.cast_volume = Some(v);
+            inner.volume_set_at = Some(std::time::Instant::now());
+            inner.volume_poll_tick = 0;
+        }
         // Reflect the drag on the bar: the local set_volume (which normally
-        // moves the slider) is skipped while casting, and the cast poll doesn't
-        // push volume, so update NowPlayingState.volume here.
+        // moves the slider) is skipped while casting.
+        self.push_volume(v);
+        Ok(true)
+    }
+
+    /// Read the connected renderer's REAL volume and mirror it onto the bar.
+    ///
+    /// The renderer owns its volume — its own remote or app can move it, and it
+    /// has its own idea of what "full" means (see `VolumeRange` in qbz-cast).
+    /// Whenever the bar shows something else, the next drag is a jump rather
+    /// than an adjustment.
+    ///
+    /// `adopt` (connect) takes the reading unconditionally. The periodic refresh
+    /// passes `false`: it defers to a recent local drag and ignores changes too
+    /// small to be anything but scale rounding. Best-effort throughout — a
+    /// renderer with no volume control, or one that faults, leaves the bar as is.
+    async fn refresh_renderer_volume(&self, adopt: bool) {
+        let (proto, last_known, set_at) = {
+            let inner = self.inner.lock().await;
+            match inner.protocol {
+                Some(p) => (p, inner.cast_volume, inner.volume_set_at),
+                None => return,
+            }
+        };
+        if !adopt {
+            if let Some(at) = set_at {
+                if at.elapsed() < CAST_VOLUME_ECHO_GUARD {
+                    return;
+                }
+            }
+        }
+
+        let reading = match proto {
+            CastProtocol::Chromecast => {
+                let status = {
+                    let inner = self.inner.lock().await;
+                    inner.chromecast.as_ref().map(|h| h.get_status())
+                };
+                match status {
+                    Some(Ok(s)) => s.volume_level,
+                    Some(Err(e)) => {
+                        log::debug!("[Cast] volume read failed: {e}");
+                        None
+                    }
+                    None => None,
+                }
+            }
+            CastProtocol::Dlna => {
+                let inner = self.inner.lock().await;
+                let Some(conn) = inner.dlna.as_ref() else {
+                    return;
+                };
+                match conn.get_volume().await {
+                    Ok(v) => Some(v),
+                    Err(e) => {
+                        log::debug!("[Cast] volume read failed: {e}");
+                        None
+                    }
+                }
+            }
+        };
+        let Some(volume) = reading.map(|v| v.clamp(0.0, 1.0)) else {
+            return;
+        };
+
+        let changed = last_known.is_none_or(|last| (volume - last).abs() >= CAST_VOLUME_EPSILON);
+        if !adopt && !changed {
+            return;
+        }
+        {
+            let mut inner = self.inner.lock().await;
+            // Lost the connection while the read was in flight.
+            if inner.protocol != Some(proto) {
+                return;
+            }
+            // A drag landed WHILE the read was in flight, so this reading is
+            // already stale — the user's value is the newer intent, and the
+            // renderer has it. Re-checked here (not only up front) because the
+            // read is a full round trip to the device.
+            if inner
+                .volume_set_at
+                .is_some_and(|at| at.elapsed() < CAST_VOLUME_ECHO_GUARD)
+            {
+                return;
+            }
+            inner.cast_volume = Some(volume);
+        }
+        log::info!("[Cast] renderer volume is {:.0}%", volume * 100.0);
+        self.push_volume(volume);
+    }
+
+    fn push_volume(&self, volume: f32) {
         let weak = self.window.clone();
         let _ = weak.upgrade_in_event_loop(move |w| {
             use slint::ComponentHandle;
-            w.global::<NowPlayingState>().set_volume(v);
+            w.global::<NowPlayingState>().set_volume(volume);
         });
-        Ok(true)
     }
 
     // No transport "stop" button in the bar today; kept for parity + a future
@@ -963,6 +1095,22 @@ impl SlintCastService {
                 None => return,
             }
         };
+
+        // Re-read the renderer's volume on a slower cadence than the position:
+        // the device owns it, so a change made on the device itself (its remote,
+        // its own app) has to reach the bar or the next drag jumps.
+        let refresh_volume = {
+            let mut inner = self.inner.lock().await;
+            inner.volume_poll_tick = inner.volume_poll_tick.saturating_add(1);
+            let due = inner.volume_poll_tick >= CAST_VOLUME_REFRESH_POLLS;
+            if due {
+                inner.volume_poll_tick = 0;
+            }
+            due
+        };
+        if refresh_volume {
+            self.refresh_renderer_volume(false).await;
+        }
 
         // Read position/state from the active renderer.
         let (position, duration, state, playing) = match proto {
@@ -1192,6 +1340,9 @@ impl SlintCastService {
         inner.connected_cap_key = None;
         inner.current_track_id = None;
         inner.is_playing = false;
+        inner.cast_volume = None;
+        inner.volume_set_at = None;
+        inner.volume_poll_tick = 0;
     }
 
     // ---- State push to the UI ----------------------------------------------

--- a/crates/qbz/src/main.rs
+++ b/crates/qbz/src/main.rs
@@ -13971,11 +13971,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             prefs.nav_header_compact = enabled;
             crate::ui_prefs::save(&prefs);
         });
-        window.global::<NowPlayingState>().on_persist_volume(|fraction| {
-            let mut prefs = crate::ui_prefs::load();
-            prefs.volume = fraction.clamp(0.0, 1.0);
-            crate::ui_prefs::save(&prefs);
-        });
+        let weak = window.as_weak();
+        window
+            .global::<NowPlayingState>()
+            .on_persist_volume(move |fraction| {
+                // While casting the slider shows the RENDERER's volume, not
+                // ours — persisting it would hand the speaker's level to the
+                // local player on the next launch. The cast service owns the
+                // renderer's volume; nothing to store on our side.
+                if let Some(w) = weak.upgrade() {
+                    if w.global::<NowPlayingState>().get_cast_active() {
+                        return;
+                    }
+                }
+                let mut prefs = crate::ui_prefs::load();
+                prefs.volume = fraction.clamp(0.0, 1.0);
+                crate::ui_prefs::save(&prefs);
+            });
         // Remember the last SAFE top-level view for "where you left off".
         let weak = window.as_weak();
         shell.on_persist_view(move || {


### PR DESCRIPTION
## Summary

Improves the volume slider for cast devices (DLNA + Chromecast).

The device's volume was never read, so the slider kept showing the local volume. Dragging down from a high value could spike a speaker that was set low internally. It's now read from the device. Renderers that don't count 0-100 (0-31 and 0.-255 exist) were also being set on the wrong scale, their declared range is now used.

Dragging sent one write per slider step, each waiting on the device. On slower speakers those queued up, so the volume kept moving after you let go and dragging back reacted late. Writes are now coalesced: one in flight at a time, always the newest value.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.
