### PR TITLE
Bugfix/external/wrap active lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ No API keys needed. No telemetry. No tracking. Just music.
 
 ## Why QBZ
 
-Browsers cap audio output at 48 kHz and resample everything through WebAudio. QBZ uses a native playback pipeline with direct device control so your DAC receives the original resolution — up to 24-bit / 192 kHz — with no forced resampling.
+QBZ exists as the player we wish a streaming company would give its users. It exists to fill the gap of an official client on Linux, because we don't like being second class citizens.
+
+But it is just as important to understand what QBZ is not, and never will be. It is not a web wrapper; I did not just package the web player and "Linuxify" it. It is not a download tool, and it never will be. I built QBZ and not TDL, SPTFY or DZR because I believe music belongs to the artists, and Qobuz is, so far, the fairest option and the one with the best quality. That is why QBZ exists.
+
+You can download songs to listen to them offline, but they carry the same locks as the official client and the same usage window once your membership expires.
+
+On the technical side: browsers cap audio output at 48 kHz and resample everything through WebAudio. QBZ uses a native playback pipeline with direct device control, so your DAC receives the original resolution, up to 24-bit / 192 kHz, with no forced resampling.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ QBZ exists as the player we wish a streaming company would give its users. It ex
 
 But it is just as important to understand what QBZ is not, and never will be. It is not a web wrapper; I did not just package the web player and "Linuxify" it. It is not a download tool, and it never will be. I built QBZ and not TDL, SPTFY or DZR because I believe music belongs to the artists, and Qobuz is, so far, the fairest option and the one with the best quality. That is why QBZ exists.
 
+It will never have a built-in equalizer or DSP, either. The point is to send audio to your DAC untouched, bit for bit, and any processing would break that. If you want an EQ or effects, add them at the system level, for example with EasyEffects on PipeWire or a JACK graph, which make it easy.
+
 You can download songs to listen to them offline, but they carry the same locks as the official client and the same usage window once your membership expires.
 
 On the technical side: browsers cap audio output at 48 kHz and resample everything through WebAudio. QBZ uses a native playback pipeline with direct device control, so your DAC receives the original resolution, up to 24-bit / 192 kHz, with no forced resampling.

--- a/crates/qbz-ui/ui/app.slint
+++ b/crates/qbz-ui/ui/app.slint
@@ -19,7 +19,7 @@ import { LoginScreen } from "login/LoginScreen.slint";
 import { AppShell } from "shell/AppShell.slint";
 import { KioskShell } from "shell/KioskShell.slint";
 import { Toast } from "primitives/Toast.slint";
-import { ShellState, MiniPlayerState, NowPlayingState, AppearanceState, UiScale, WindowControlActions } from "state.slint";
+import { ShellState, MiniPlayerState, NowPlayingState, AppearanceState, UiScale, WindowControlActions, LyricsWrapProbe } from "state.slint";
 import { MiniShell } from "miniplayer/MiniShell.slint";
 
 // Re-export the theming globals so the Rust layer can push palettes (Theme.c /
@@ -31,7 +31,7 @@ export { ThemeState } from "foundation/theme-state.slint";
 export { Typography } from "foundation/typography.slint";
 
 // Re-export the state globals so the Rust layer can populate them.
-export { HomeState, HomeActions, RecentAlbumsState, MostPlayedAlbumsState, MostPlayedAlbumsActions, DiscoverState, DiscoverActions, SectionDescriptor, ConfigRow, DiscoverBrowseState, DiscoverBrowseActions, PlaylistBrowseState, PlaylistBrowseActions, ForYouState, PinnedItem, PinnedState, PinnedActions, ExternalRecoState, ExternalRecoActions, MixState, GenreFilterState, GenreFilterActions, AlbumState, ArtistState, NavState, ShellState, SessionState, SettingsState, AlbumActions, ArtistActions, ArtworkActions, NowPlayingState, QueueState, LyricsState, LyricsLineItem, SearchState, SearchActions, NetworkSidebarState, NetworkSidebarActions, MusicianState, MusicianActions, LabelState, LabelActions, AwardState, AwardActions, AwardEntry, ArtistReleasesState, ArtistReleasesActions, LocationViewState, LocationViewActions, FavoritesState, FavoritesActions, LibraryFeedItem, LibraryAllState, LibraryAllActions, PlaylistPickerState, PlaylistPickerActions, DuplicateConfirmState, DuplicateConfirmActions, PlaylistState, PlaylistActions, SidebarState, SidebarActions, SidebarFolderPopupState, CreatePlaylistState, CreatePlaylistActions, EditPlaylistState, EditPlaylistActions, CreateFolderState, CreateFolderActions, SettingsExportState, SettingsExportActions, SandboxState, MyQbzCreateState, MyQbzCreateActions, DragState, DragActions, PlaylistManagerState, PlaylistManagerActions, OfflineManagerState, OfflineManagerActions, BlacklistState, BlacklistActions, BlacklistedArtistItem, MyQbzState, MyQbzActions, MixtapeCardItem, MyQbzAddState, MyQbzAddActions, MyQbzAddRow, MyQbzDetailState, MyQbzDetailActions, MixtapeDetailItem, MyQbzEditState, MyQbzEditActions, MyQbzMixState, MyQbzMixActions, DiscoBuilderState, DiscoBuilderActions, DiscoGroup, DiscoCandidate, LocalLibraryState, LocalLibraryActions, LibraryFoldersState, LibFolderEditState, LibraryManageActions, LibraryScanState, LibAlbumFilterState, LocalAlbumState, LocalAlbumActions, TagEditorState, TagEditorActions, FolderEditState, FolderEditActions, ToastState, TextUtil, QconnectDevState, QconnectDevice, CastState, CastDevice, CastActions, AppearanceState, MyQbzBrandingState, EphemeralPlayChoiceState, EphemeralPlayChoiceActions, PlexSettingsState, PlexAuthActions, PlexSectionItem, ScrobbleState, ScrobbleActions, DiscordState, OfflineState, LoginState, OfflineModeActions, OfflineFavoritesState, OfflineFavoritesActions, ImportLogEntry, PlaylistImportState, PlaylistImportActions, DacWizardState, DacWizardActions, DacCandidateRow, RemediationRow, DacConfigRow, InfoCreditRow, InfoCreditPair, AlbumCreditPerformer, AlbumCreditTrack, TrackInfoState, TrackInfoActions, AlbumInfoState, AlbumInfoActions, BookletState, BookletActions, SuggestionsState, SuggestionsActions, SuggestionCard, PlaylistSuggestionsState, PlaylistSuggestionsActions, PlaylistSuggestionRow, VisualizerState, ImmersiveState, ImmersiveSearchActions, ImmersiveActions, MiniPlayerState, WindowControlActions, PurchasesState, PurchasesActions, PurchaseAlbumItem, PurchaseTrackItem, PurchaseAlbumGroup, PurchaseTrackGroup, PurchaseFormatItem, PurchaseDetailState, PurchaseDetailActions, PurchaseDetailTrack, KeybindingRow, KeybindingCategoryGroup, KeybindingsState, KeybindingsActions, KeyboardShortcutsState, LinkResolverState, LinkResolverActions, UiFocusState, UiScale, SleepTimerState, SleepTimerActions, LogRow, LogViewerState, DiagRow, DiagnosticsState, ReportIssueState, ReportIssueActions, AboutState, AboutActions, AboutContributorRow, AboutContributorGroup, WhatsNewState, WhatsNewActions, WhatsNewBlock, WhatsNewTocEntry } from "state.slint";
+export { HomeState, HomeActions, RecentAlbumsState, MostPlayedAlbumsState, MostPlayedAlbumsActions, DiscoverState, DiscoverActions, SectionDescriptor, ConfigRow, DiscoverBrowseState, DiscoverBrowseActions, PlaylistBrowseState, PlaylistBrowseActions, ForYouState, PinnedItem, PinnedState, PinnedActions, ExternalRecoState, ExternalRecoActions, MixState, GenreFilterState, GenreFilterActions, AlbumState, ArtistState, NavState, ShellState, SessionState, SettingsState, AlbumActions, ArtistActions, ArtworkActions, NowPlayingState, QueueState, LyricsState, LyricsLineItem, LyricsWrapProbe, SearchState, SearchActions, NetworkSidebarState, NetworkSidebarActions, MusicianState, MusicianActions, LabelState, LabelActions, AwardState, AwardActions, AwardEntry, ArtistReleasesState, ArtistReleasesActions, LocationViewState, LocationViewActions, FavoritesState, FavoritesActions, LibraryFeedItem, LibraryAllState, LibraryAllActions, PlaylistPickerState, PlaylistPickerActions, DuplicateConfirmState, DuplicateConfirmActions, PlaylistState, PlaylistActions, SidebarState, SidebarActions, SidebarFolderPopupState, CreatePlaylistState, CreatePlaylistActions, EditPlaylistState, EditPlaylistActions, CreateFolderState, CreateFolderActions, SettingsExportState, SettingsExportActions, SandboxState, MyQbzCreateState, MyQbzCreateActions, DragState, DragActions, PlaylistManagerState, PlaylistManagerActions, OfflineManagerState, OfflineManagerActions, BlacklistState, BlacklistActions, BlacklistedArtistItem, MyQbzState, MyQbzActions, MixtapeCardItem, MyQbzAddState, MyQbzAddActions, MyQbzAddRow, MyQbzDetailState, MyQbzDetailActions, MixtapeDetailItem, MyQbzEditState, MyQbzEditActions, MyQbzMixState, MyQbzMixActions, DiscoBuilderState, DiscoBuilderActions, DiscoGroup, DiscoCandidate, LocalLibraryState, LocalLibraryActions, LibraryFoldersState, LibFolderEditState, LibraryManageActions, LibraryScanState, LibAlbumFilterState, LocalAlbumState, LocalAlbumActions, TagEditorState, TagEditorActions, FolderEditState, FolderEditActions, ToastState, TextUtil, QconnectDevState, QconnectDevice, CastState, CastDevice, CastActions, AppearanceState, MyQbzBrandingState, EphemeralPlayChoiceState, EphemeralPlayChoiceActions, PlexSettingsState, PlexAuthActions, PlexSectionItem, ScrobbleState, ScrobbleActions, DiscordState, OfflineState, LoginState, OfflineModeActions, OfflineFavoritesState, OfflineFavoritesActions, ImportLogEntry, PlaylistImportState, PlaylistImportActions, DacWizardState, DacWizardActions, DacCandidateRow, RemediationRow, DacConfigRow, InfoCreditRow, InfoCreditPair, AlbumCreditPerformer, AlbumCreditTrack, TrackInfoState, TrackInfoActions, AlbumInfoState, AlbumInfoActions, BookletState, BookletActions, SuggestionsState, SuggestionsActions, SuggestionCard, PlaylistSuggestionsState, PlaylistSuggestionsActions, PlaylistSuggestionRow, VisualizerState, ImmersiveState, ImmersiveSearchActions, ImmersiveActions, MiniPlayerState, WindowControlActions, PurchasesState, PurchasesActions, PurchaseAlbumItem, PurchaseTrackItem, PurchaseAlbumGroup, PurchaseTrackGroup, PurchaseFormatItem, PurchaseDetailState, PurchaseDetailActions, PurchaseDetailTrack, KeybindingRow, KeybindingCategoryGroup, KeybindingsState, KeybindingsActions, KeyboardShortcutsState, LinkResolverState, LinkResolverActions, UiFocusState, UiScale, SleepTimerState, SleepTimerActions, LogRow, LogViewerState, DiagRow, DiagnosticsState, ReportIssueState, ReportIssueActions, AboutState, AboutActions, AboutContributorRow, AboutContributorGroup, WhatsNewState, WhatsNewActions, WhatsNewBlock, WhatsNewTocEntry } from "state.slint";
 
 // Which top-level screen is shown. The app starts on `splash` while it
 // restores a saved session, then resolves to `shell` or `login`.
@@ -102,6 +102,18 @@ export component AppWindow inherits Window {
     changed pal-is-system => { root.sync-native-palette(); }
 
     in-out property <AppScreen> screen: AppScreen.splash;
+
+    // Lyrics-wrap measurement probe (true fix, issue #664 follow-on): does
+    // `LyricsWrapProbe.text` fit on ONE visual row at `LyricsWrapProbe.max-width`,
+    // as rendered by THIS window's actual active renderer? Root-level property
+    // (not on a global — globals can't reference visual items), so the Rust
+    // codegen exposes a plain `get_lyrics_wrap_probe_fits()` getter that
+    // pull-evaluates this expression fresh on every call: set the global's
+    // inputs, then read this, and the answer is always for what was just set,
+    // no staleness window. See the probe elements + LyricsWrapProbe (state.slint)
+    // for the full rationale.
+    out property <bool> lyrics-wrap-probe-fits:
+        lyrics-wrap-probe.preferred-height <= lyrics-wrap-probe-row-ref.preferred-height + 0.5px;
 
     // Forwarded to the Rust layer.
     callback sign-in-via-browser();
@@ -249,6 +261,42 @@ export component AppWindow inherits Window {
         }
         recovery-login => {
             root.recovery-login();
+        }
+    }
+
+    // Lyrics-wrap measurement probe elements (see `lyrics-wrap-probe-fits`
+    // above). Always mounted regardless of which screen/panel is showing —
+    // unlike LyricsLinesView, which only exists while a lyrics surface is
+    // open, `refresh_active_segments` (lyrics_sync.rs) needs an answer any
+    // time the sync engine ticks. Zero footprint: wrapped in a 0x0 clipped
+    // Rectangle, same trick as `row-height-ref` in LyricsLinesView.slint.
+    Rectangle {
+        width: 0px;
+        height: 0px;
+        clip: true;
+        // The candidate line, laid out exactly like the real active-line
+        // segments (LyricsLinesView.slint: wrap: word-wrap, same font props,
+        // width capped to the candidate budget) — so its preferred-height
+        // tells us in row-counts whether it fit.
+        lyrics-wrap-probe := Text {
+            text: LyricsWrapProbe.text;
+            width: LyricsWrapProbe.max-width;
+            wrap: word-wrap;
+            font-family: LyricsWrapProbe.font-name;
+            font-size: LyricsWrapProbe.font-size;
+            font-weight: LyricsWrapProbe.font-weight;
+            letter-spacing: LyricsWrapProbe.letter-spacing;
+        }
+        // Unconstrained (no-wrap, no width), so its preferred-height is
+        // unambiguously ONE row for these font props — the same
+        // row-height-ref trick LyricsLinesView.slint already uses.
+        lyrics-wrap-probe-row-ref := Text {
+            text: "Hg";
+            wrap: no-wrap;
+            font-family: LyricsWrapProbe.font-name;
+            font-size: LyricsWrapProbe.font-size;
+            font-weight: LyricsWrapProbe.font-weight;
+            letter-spacing: LyricsWrapProbe.letter-spacing;
         }
     }
 

--- a/crates/qbz-ui/ui/shell/LyricsLinesView.slint
+++ b/crates/qbz-ui/ui/shell/LyricsLinesView.slint
@@ -195,16 +195,25 @@ component LyricsLineRow inherits VerticalLayout {
         letter-spacing: 0.2px;
     }
 
-    // ACTIVE row: per-VISUAL-line karaoke highlight. The engine measured the
-    // active line's word-wrap (`lyrics_measure` / `lyrics_sync`) against this
-    // view's content-width + font + size and pushed one LyricsSegment per
-    // visual row, each carrying `start-weight` (cumulative width fraction
-    // before it) and `width-weight` (its share of the line). We render one
-    // dim-base + clipped-bright-overlay row PER segment with `wrap: no-wrap`
-    // (segments are already single visual lines, Tauri's `white-space:nowrap`),
-    // and re-map the single global `line-progress` to a per-segment local
-    // fraction so row 1 fills to 100% BEFORE row 2 starts — instead of the old
-    // single full-height clip rect that lit every wrapped row at once.
+    // ACTIVE row: per-VISUAL-line karaoke highlight. The engine measures the
+    // active line's word-wrap against THIS window's real active renderer
+    // (`lyrics_sync::slint_fits_one_line`, via the always-mounted probe on
+    // AppWindow — app.slint / state.slint) and pushes one LyricsSegment per
+    // INTENDED visual row, each carrying `start-weight` (cumulative width
+    // fraction before it) and `width-weight` (its share of the line).
+    //
+    // A segment is *supposed* to always be exactly one visual row (that's
+    // the whole point of the probe), but we still don't blindly trust that:
+    // `wrap: word-wrap` stays on as a fallback for when a segment's own Text
+    // ends up 2 rows tall anyway (DPI/scale-factor drift between the probe's
+    // measurement pass and the real paint pass, a stale probe read on the
+    // very first frame, etc.). Earlier this fallback capped the highlight to
+    // row 1 and left row 2 permanently dark — safe, but visually wrong (no
+    // sweep). Below instead renders 1 OR 2 independently-clipped fill bands
+    // per segment (capped at 2 — a segment overflowing further would mean
+    // the probe was wrong by more than a full row, which shouldn't happen),
+    // so the highlight sweeps every row a segment actually produced, however
+    // many that turns out to be.
     if root.is-active: VerticalLayout {
         for seg[i] in LyricsState.active-segments: HorizontalLayout {
             // Left-align each visual line; the segment's own width drives the
@@ -212,7 +221,8 @@ component LyricsLineRow inherits VerticalLayout {
             alignment: start;
             segbase := Text {
                 text: seg.text;
-                wrap: no-wrap;
+                wrap: word-wrap;
+                width: min(self.preferred-width, LyricsState.content-width);
                 // Active line is fully bright (opacity 1.0, dimming ladder
                 // returns 1.0 for the active row) — keep parity with the old
                 // base which animated opacity; active stays solid.
@@ -222,27 +232,78 @@ component LyricsLineRow inherits VerticalLayout {
                 font-weight: Typography.bold;
                 letter-spacing: 0.2px;
 
-                // Bright (sung) overlay, clipped to this segment's LOCAL fill.
-                // local = clamp((line-progress - start-weight) / width-weight, 0, 1)
+                // Zero-footprint reference giving this font/size's TRUE
+                // single-row height, independent of segbase's own height
+                // (which grows if the fallback above ever kicks in).
+                row-height-ref := Text {
+                    text: "Hg";
+                    wrap: no-wrap;
+                    font-family: root.font-name;
+                    font-size: root.size-active;
+                    font-weight: Typography.bold;
+                    letter-spacing: 0.2px;
+                    visible: false;
+                }
+
+                // ---- Shared fill math (both rows read these) ----
+                // Lite fill (pref) or reduce-motion (kiosk / weak GPU): the
+                // active line is fully lit and STATIC — no per-frame clip
+                // animation.
+                property <bool> cheap: ShellState.reduce-motion || LyricsState.lite-fill;
+                property <length> row-h: row-height-ref.preferred-height;
+                // True only when THIS segment's own Text actually rendered 2
+                // rows (the fallback path) — normally false.
+                property <bool> two-rows: self.height > self.row-h + 0.5px;
+                // The segment's own 0-1 local fill fraction, re-mapped from
+                // the single global line-progress via this segment's
+                // start/width weight.
+                property <float> seg-fill: seg.width-weight > 0
+                    ? Math.clamp((LyricsState.line-progress - seg.start-weight) / seg.width-weight, 0.0, 1.0)
+                    : 0.0;
+                // Estimated TIME share row 0 accounts for, when two-rows:
+                // this segment's natural (unwrapped) width vs how much of it
+                // content-width can hold. word-wrap packs row 0 close to
+                // full before breaking, so row 0 typically holds MOST of the
+                // segment's content — NOT half of it. (An earlier version
+                // assumed an equal 50/50 time split between the two rows,
+                // which was simple and always reached full width correctly,
+                // but was wrong on exactly this point: row 0 usually holds
+                // much more than half the line, so it was reported "done" at
+                // just the 50% line-progress mark — way ahead of the real
+                // singer. This ratio is still an estimate (Slint doesn't
+                // expose the real wrap point), but "row 0 gets its width
+                // share of the total" is a much closer approximation of
+                // reality than "row 0 gets half the time" ever was.)
+                property <float> row0-share: self.two-rows
+                    ? Math.clamp(min(LyricsState.content-width, self.preferred-width) / self.preferred-width, 0.05, 0.95)
+                    : 1.0;
+                property <float> row0-local: self.two-rows
+                    ? Math.clamp(self.seg-fill / self.row0-share, 0.0, 1.0)
+                    : self.seg-fill;
+                property <float> row1-local: self.two-rows
+                    ? Math.clamp((self.seg-fill - self.row0-share) / (1.0 - self.row0-share), 0.0, 1.0)
+                    : 0.0;
+
+                // Bright (sung) overlay, ROW 0. Always present. When
+                // `two-rows` is false this is the segment's only row (the
+                // normal case) and behaves exactly as before: local fill
+                // sweeps the full segment width. When `two-rows` is true,
+                // this band fills through row0-local's [0,1] first; row 1
+                // below then fills through its own [0,1] via row1-local.
                 Rectangle {
-                    // Lite fill (pref) or reduce-motion (kiosk / weak GPU): the
-                    // active line is fully lit and STATIC — no per-frame clip
-                    // animation, so the surface stops repainting the whole window
-                    // ~60x/s just to sweep the karaoke fill.
-                    property <bool> cheap: ShellState.reduce-motion || LyricsState.lite-fill;
                     x: 0;
                     y: 0;
-                    width: self.cheap
-                        ? segbase.width
-                        : segbase.width * Math.clamp(
-                            seg.width-weight > 0
-                                ? (LyricsState.line-progress - seg.start-weight) / seg.width-weight
-                                : 0,
-                            0.0, 1.0);
-                    height: segbase.height;
+                    // segbase.width is a generous ceiling (this row's real
+                    // glyphs never exceed it) — `clip: true` means overfilling
+                    // past the last glyph just shows blank space, harmless.
+                    // row0-local reaches exactly 1.0 at completion by
+                    // construction, so this always reaches exactly
+                    // segbase.width — no boundary estimate involved anymore.
+                    width: segbase.cheap ? segbase.width : segbase.row0-local * segbase.width;
+                    height: segbase.row-h;
                     clip: true;
                     animate width {
-                        duration: self.cheap ? 0ms : LyricsState.fill-anim-ms * 1ms;
+                        duration: segbase.cheap ? 0ms : LyricsState.fill-anim-ms * 1ms;
                         easing: linear;
                     }
                     Text {
@@ -251,7 +312,40 @@ component LyricsLineRow inherits VerticalLayout {
                         width: segbase.width;
                         height: segbase.height;
                         text: seg.text;
-                        wrap: no-wrap;
+                        wrap: word-wrap;
+                        color: root.active-color;
+                        font-family: root.font-name;
+                        font-size: root.size-active;
+                        font-weight: Typography.bold;
+                        letter-spacing: 0.2px;
+                    }
+                }
+
+                // Bright (sung) overlay, ROW 1 — only exists while `two-rows`
+                // is true (the fallback path). Positioned one row down; its
+                // own copy of the overlay text is shifted UP by one row so
+                // the SAME wrap points land inside this clip window, showing
+                // exactly row 1's slice of the glyphs (mirrors row 0's Text
+                // exactly, so they always agree on where the wrap fell).
+                if segbase.two-rows: Rectangle {
+                    x: 0;
+                    y: segbase.row-h;
+                    // Same reasoning as row 0's width above: generous ceiling,
+                    // row1-local reaches exactly 1.0 at completion.
+                    width: segbase.cheap ? segbase.width : segbase.row1-local * segbase.width;
+                    height: segbase.row-h;
+                    clip: true;
+                    animate width {
+                        duration: segbase.cheap ? 0ms : LyricsState.fill-anim-ms * 1ms;
+                        easing: linear;
+                    }
+                    Text {
+                        x: 0;
+                        y: -segbase.row-h;
+                        width: segbase.width;
+                        height: segbase.height;
+                        text: seg.text;
+                        wrap: word-wrap;
                         color: root.active-color;
                         font-family: root.font-name;
                         font-size: root.size-active;
@@ -327,6 +421,20 @@ export component LyricsLinesView inherits Rectangle {
     changed watched-active => {
         if (root.watched-active < 0) {
             root.last-centered-index = -1;
+            // Snap back to the top immediately (issue: track change left the
+            // previous track's scroll offset on screen). Rust sets
+            // active-index to -1 synchronously in on_track_changed, BEFORE
+            // the new doc even starts loading, so this fires right away on
+            // every track change — no need to wait for a real active line
+            // (which may be seconds away behind an intro, or may never come
+            // at all for unsynced/plain lyrics, where center-active() never
+            // runs). Direct writes here, same idiom as center-active(): kill
+            // any in-flight smooth animation so it can't fight this jump,
+            // then set both the animated target and the Flickable itself so
+            // there's nothing left to animate FROM on the next real center.
+            root.smooth-scroll = false;
+            root.scroll-target = 0px;
+            flick.viewport-y = 0px;
         }
     }
 

--- a/crates/qbz-ui/ui/state.slint
+++ b/crates/qbz-ui/ui/state.slint
@@ -4613,6 +4613,29 @@ export global LyricsState {
     callback cache-clear();
 }
 
+// Driving inputs for the always-mounted lyrics-wrap measurement probe
+// (`AppWindow`'s hidden probe elements, app.slint). This is the TRUE fix for
+// issue #664's follow-on bug: instead of guessing word-wrap points with an
+// independent swash reimplementation (lyrics_measure.rs) that can drift from
+// whatever backend Slint is ACTUALLY rendering with (Skia on macOS, femtovg
+// on Linux/Windows), Rust asks Slint itself — via a real `wrap: word-wrap`
+// Text fed through THIS SAME window's active renderer — whether a candidate
+// line fits in one visual row. A `global` can't reference a visual item
+// directly (no component-tree access), so the probe Text lives on AppWindow
+// and reads these; AppWindow then exposes the yes/no answer back as its own
+// root-level `lyrics-wrap-probe-fits` property, which Slint's Rust codegen
+// generates a plain getter for — a normal pull-evaluated read, so Rust gets a
+// synchronously-correct answer for the CURRENT text/max-width on every call,
+// no polling or staleness window.
+export global LyricsWrapProbe {
+    in property <string> text: "";
+    in property <length> max-width: 0px;
+    in property <string> font-name: "";
+    in property <length> font-size: 15px;
+    in property <int> font-weight: 700;
+    in property <length> letter-spacing: 0.2px;
+}
+
 // One row in the QConnect device picker (a session renderer). Populated by the
 // event sink from `session.renderers`.
 export struct QconnectDevice {

--- a/crates/qbz/src/lyrics_measure.rs
+++ b/crates/qbz/src/lyrics_measure.rs
@@ -16,13 +16,31 @@
 //!
 //! # How it measures
 //!
-//! femtovg (the Linux/Windows renderer) shapes glyphs with `swash`, so a swash
-//! advance pass at the same font + ppem + weight axis + letter-spacing matches
-//! what is actually rendered. The four bundled variable lyric fonts plus the
-//! Inter "System"/default bold are embedded here via `include_bytes!` (the
-//! same TTFs `LyricsLinesView.slint` registers via `import`) and parsed once
-//! into process-global `swash::FontRef`s (held as owned byte buffers in a
-//! `OnceLock`).
+//! **The wrap DECISION** (does candidate line L fit in `max_width_px`?) is
+//! answered by the ACTUAL Slint window via [`crate::lyrics_sync::slint_fits_one_line`] —
+//! a hidden, always-mounted `wrap: word-wrap` `Text` on `AppWindow`
+//! (`LyricsWrapProbe` in state.slint / the probe elements in app.slint) laid
+//! out with the exact same font/size/weight/letter-spacing/width as the real
+//! segments. This is a genuine measurement by whatever backend is actually
+//! active (Skia on macOS, femtovg on Linux/Windows, ...), so the wrap points
+//! this module computes are — by construction — the same ones Slint itself
+//! would choose. (Earlier revisions of this module re-implemented the
+//! measurement independently with `swash`, calibrated for femtovg; that
+//! silently drifted from Skia's shaping on macOS — issue #664 — which is why
+//! this indirection exists at all.)
+//!
+//! **Per-segment pixel widths** (`Segment::width_px`, used only to
+//! proportion the single global karaoke-fill fraction across visual rows by
+//! width share) are still measured with `swash` below — those don't need to
+//! match the real renderer pixel-for-pixel, only be self-consistent with each
+//! other, and a probe round-trip per segment would be needless overhead for a
+//! number that's discarded as soon as it's turned into a ratio.
+//!
+//! swash advance pass at the same font + ppem + weight axis + letter-spacing.
+//! The four bundled variable lyric fonts plus the Inter "System"/default bold
+//! are embedded here via `include_bytes!` (the same TTFs `LyricsLinesView.slint`
+//! registers via `import`) and parsed once into process-global `swash::FontRef`s
+//! (held as owned byte buffers in a `OnceLock`).
 //!
 //! The active lyric line is rendered BOLD; for the variable fonts we set the
 //! `wght` variation axis to 700 so the advances match the bold raster. (Inter
@@ -39,10 +57,12 @@
 //!
 //! Greedy word wrap, matching `wrap: word-wrap`: split the text on ASCII/Unicode
 //! whitespace into words; keep appending words (with their separating space) to
-//! the current visual line while they fit `max_width_px`; otherwise start a new
-//! visual line. A single word longer than the budget is broken per grapheme
-//! cluster (CJK / no-space runs also break per character this way). Each
-//! emitted segment carries its measured pixel width.
+//! the current visual line while the LIVE PROBE reports they still fit;
+//! otherwise start a new visual line. A single word the probe reports doesn't
+//! fit alone is broken per grapheme cluster (CJK / no-space runs also break
+//! per character this way; each candidate piece is checked against the probe
+//! too). Each emitted segment carries its `swash`-measured pixel width (for
+//! fill-fraction weighting only — see above).
 
 use std::sync::OnceLock;
 
@@ -147,32 +167,32 @@ fn measure_width(ctx: &mut ShapeContext, font: &LoadedFont, text: &str, size_px:
 }
 
 /// Split a single over-long word into per-grapheme-cluster pieces that each fit
-/// `max_width_px` (CJK and other no-space runs land here too). Appends the
-/// resulting segments to `out`.
+/// on one visual row per `fits` (CJK and other no-space runs land here too).
+/// Appends the resulting segments (with their `swash`-measured width, for
+/// fill-fraction weighting) to `out`.
 fn break_long_word(
     ctx: &mut ShapeContext,
     font: &LoadedFont,
     word: &str,
     size_px: f32,
-    max_width_px: f32,
+    fits: &mut impl FnMut(&str) -> bool,
     out: &mut Vec<Segment>,
 ) {
     let mut current = String::new();
-    let mut current_w = 0.0_f32;
     // Break per Unicode scalar (good enough for CJK; avoids pulling in a
     // grapheme-segmentation dependency — lyric runs are short).
     for ch in word.chars() {
-        let piece: String = ch.to_string();
-        let piece_w = measure_width(ctx, font, &piece, size_px);
-        if !current.is_empty() && current_w + piece_w > max_width_px {
-            out.push(Segment { text: std::mem::take(&mut current), width_px: current_w });
-            current_w = 0.0;
+        let mut candidate = current.clone();
+        candidate.push(ch);
+        if !current.is_empty() && !fits(&candidate) {
+            let width_px = measure_width(ctx, font, &current, size_px);
+            out.push(Segment { text: std::mem::take(&mut current), width_px });
         }
         current.push(ch);
-        current_w += piece_w;
     }
     if !current.is_empty() {
-        out.push(Segment { text: current, width_px: current_w });
+        let width_px = measure_width(ctx, font, &current, size_px);
+        out.push(Segment { text: current, width_px });
     }
 }
 
@@ -180,13 +200,25 @@ fn break_long_word(
 /// inside `max_width_px`, at the given `font_index` + `size_px` (bold weight,
 /// 0.2px letter spacing — matching the active lyric line render).
 ///
+/// `fits(candidate)` is the wrap oracle: true iff `candidate` renders on ONE
+/// visual row at `max_width_px` in the CALLER's actual active Slint renderer
+/// (see `crate::lyrics_sync::slint_fits_one_line` — the real fix for issue
+/// #664's follow-on: this used to be answered by an independent swash
+/// re-measurement here, which could disagree with the real renderer).
+///
 /// Returns one [`Segment`] per visual line, each with the segment text and its
-/// rendered pixel width. An empty / whitespace-only input yields a single empty
-/// segment so the caller always has at least one row to render.
-pub fn wrap_segments(text: &str, font_index: i32, size_px: f32, max_width_px: f32) -> Vec<Segment> {
+/// `swash`-measured pixel width (fill-fraction weighting only). An empty /
+/// whitespace-only input yields a single empty segment so the caller always
+/// has at least one row to render.
+pub fn wrap_segments(
+    text: &str,
+    font_index: i32,
+    size_px: f32,
+    max_width_px: f32,
+    mut fits: impl FnMut(&str) -> bool,
+) -> Vec<Segment> {
     let font = loaded_font(font_index);
     let mut ctx = ShapeContext::new();
-    let budget = max_width_px.max(1.0);
 
     // Tokenize into words, preserving nothing of the original whitespace except
     // that each inter-word gap becomes a single space when re-joined.
@@ -195,58 +227,50 @@ pub fn wrap_segments(text: &str, font_index: i32, size_px: f32, max_width_px: f3
         return vec![Segment { text: String::new(), width_px: 0.0 }];
     }
 
-    let space_w = measure_width(&mut ctx, font, " ", size_px);
-
     let mut out: Vec<Segment> = Vec::new();
     let mut line = String::new();
-    let mut line_w = 0.0_f32;
 
     for word in words {
-        let word_w = measure_width(&mut ctx, font, word, size_px);
-
         if line.is_empty() {
             // First word on a fresh line.
-            if word_w > budget {
+            if !fits(word) {
                 // Word alone overflows — hard-break it into pieces.
-                break_long_word(&mut ctx, font, word, size_px, budget, &mut out);
+                break_long_word(&mut ctx, font, word, size_px, &mut fits, &mut out);
                 // The tail piece (if any) becomes the start of the current line
                 // so following words can still pack onto it.
                 if let Some(last) = out.pop() {
                     line = last.text;
-                    line_w = last.width_px;
                 }
             } else {
                 line.push_str(word);
-                line_w = word_w;
             }
             continue;
         }
 
         // Subsequent word: does it fit with a leading space?
-        let added = space_w + word_w;
-        if line_w + added <= budget {
-            line.push(' ');
-            line.push_str(word);
-            line_w += added;
+        let mut candidate = line.clone();
+        candidate.push(' ');
+        candidate.push_str(word);
+        if fits(&candidate) {
+            line = candidate;
         } else {
             // Flush the current line and start anew with this word.
-            out.push(Segment { text: std::mem::take(&mut line), width_px: line_w });
-            line_w = 0.0;
-            if word_w > budget {
-                break_long_word(&mut ctx, font, word, size_px, budget, &mut out);
+            let width_px = measure_width(&mut ctx, font, &line, size_px);
+            out.push(Segment { text: std::mem::take(&mut line), width_px });
+            if !fits(word) {
+                break_long_word(&mut ctx, font, word, size_px, &mut fits, &mut out);
                 if let Some(last) = out.pop() {
                     line = last.text;
-                    line_w = last.width_px;
                 }
             } else {
                 line.push_str(word);
-                line_w = word_w;
             }
         }
     }
 
     if !line.is_empty() || out.is_empty() {
-        out.push(Segment { text: line, width_px: line_w });
+        let width_px = measure_width(&mut ctx, font, &line, size_px);
+        out.push(Segment { text: line, width_px });
     }
     out
 }
@@ -255,9 +279,22 @@ pub fn wrap_segments(text: &str, font_index: i32, size_px: f32, max_width_px: f3
 mod tests {
     use super::*;
 
+    /// Test-only stand-in for the live Slint probe (`slint_fits_one_line`):
+    /// no window exists in a unit test, so fall back to the same swash
+    /// measurement `wrap_segments` used before the probe existed. This is
+    /// exactly the drift-prone approximation issue #664 was about — fine
+    /// here since these tests only check the ALGORITHM's shape (does it
+    /// wrap, does it hard-break, ...), not real-renderer pixel accuracy.
+    fn swash_oracle(font_index: i32, size_px: f32, max_width_px: f32) -> impl FnMut(&str) -> bool {
+        let font = loaded_font(font_index);
+        let mut ctx = ShapeContext::new();
+        let budget = max_width_px.max(1.0);
+        move |candidate: &str| measure_width(&mut ctx, font, candidate, size_px) <= budget
+    }
+
     #[test]
     fn single_short_line_one_segment() {
-        let segs = wrap_segments("hello world", 0, 15.0, 10_000.0);
+        let segs = wrap_segments("hello world", 0, 15.0, 10_000.0, swash_oracle(0, 15.0, 10_000.0));
         assert_eq!(segs.len(), 1);
         assert_eq!(segs[0].text, "hello world");
         assert!(segs[0].width_px > 0.0);
@@ -265,7 +302,7 @@ mod tests {
 
     #[test]
     fn empty_input_yields_one_empty_segment() {
-        let segs = wrap_segments("   ", 0, 15.0, 100.0);
+        let segs = wrap_segments("   ", 0, 15.0, 100.0, swash_oracle(0, 15.0, 100.0));
         assert_eq!(segs.len(), 1);
         assert_eq!(segs[0].text, "");
         assert_eq!(segs[0].width_px, 0.0);
@@ -274,7 +311,13 @@ mod tests {
     #[test]
     fn narrow_budget_wraps_to_multiple_segments() {
         // A budget too small for the whole phrase must split it.
-        let segs = wrap_segments("alpha beta gamma delta", 0, 15.0, 40.0);
+        let segs = wrap_segments(
+            "alpha beta gamma delta",
+            0,
+            15.0,
+            40.0,
+            swash_oracle(0, 15.0, 40.0),
+        );
         assert!(segs.len() >= 2, "expected a wrap, got {} segs", segs.len());
         // Every emitted segment must be non-empty (no dangling blank rows).
         for seg in &segs {
@@ -285,7 +328,13 @@ mod tests {
     #[test]
     fn over_long_word_is_hard_broken() {
         // One unbreakable token wider than the budget breaks per character.
-        let segs = wrap_segments("aaaaaaaaaaaaaaaaaaaa", 0, 15.0, 20.0);
+        let segs = wrap_segments(
+            "aaaaaaaaaaaaaaaaaaaa",
+            0,
+            15.0,
+            20.0,
+            swash_oracle(0, 15.0, 20.0),
+        );
         assert!(segs.len() >= 2, "expected hard break, got {}", segs.len());
     }
 }

--- a/crates/qbz/src/lyrics_sync.rs
+++ b/crates/qbz/src/lyrics_sync.rs
@@ -53,7 +53,7 @@ use qbz_app::shell::AppRuntime;
 
 use crate::adapter::SlintAdapter;
 use crate::lyrics_measure;
-use crate::{AppWindow, ImmersiveState, LyricsSegment, LyricsState, ShellState};
+use crate::{AppWindow, ImmersiveState, LyricsSegment, LyricsState, LyricsWrapProbe, ShellState};
 
 type Runtime = Arc<AppRuntime<SlintAdapter>>;
 
@@ -214,7 +214,7 @@ fn lyrics_surface_open(window: &AppWindow) -> bool {
     let imm = window.global::<ImmersiveState>();
     imm.get_open()
         && ((imm.get_view_mode() == 0 && imm.get_mode() == 4)
-            || (imm.get_view_mode() == 1 && imm.get_split_panel() == 0))
+        || (imm.get_view_mode() == 1 && imm.get_split_panel() == 0))
 }
 
 fn compute_and_push(window: &AppWindow, runtime: &Runtime, require_playing: bool) -> bool {
@@ -234,6 +234,7 @@ fn compute_and_push(window: &AppWindow, runtime: &Runtime, require_playing: bool
         // font/size pref change WHILE PAUSED re-flows the wrapped highlight
         // (cache-guarded — a no-op when nothing relevant changed).
         refresh_active_segments(
+            window,
             &lyrics,
             lyrics.get_active_index(),
             main_render_prefs(&lyrics),
@@ -279,7 +280,7 @@ fn compute_and_push(window: &AppWindow, runtime: &Runtime, require_playing: bool
 
     // Per-visual-line karaoke segmentation: recompute (cache-guarded) when the
     // active line, content-width, font, size tier, or uppercase pref changes.
-    refresh_active_segments(&lyrics, index, main_render_prefs(&lyrics), SegSurface::Main);
+    refresh_active_segments(window, &lyrics, index, main_render_prefs(&lyrics), SegSurface::Main);
 
     // REQ-1 fan-out: mirror the karaoke scalars to the miniplayer (30Hz; no-op
     // when the mini is closed) so the mini lyrics highlight stays smooth.
@@ -322,6 +323,51 @@ fn size_active_px(size_index: i32) -> f32 {
     }
 }
 
+/// `font-index` -> font-family STRING, matching `LyricsSidebar.slint`'s
+/// `font-name:` binding exactly ("" = window default). The probe (below)
+/// must use the identical family name or it isn't measuring the same font
+/// the real active line renders with.
+fn font_family_name(font_index: i32) -> &'static str {
+    match font_index {
+        1 => "LINE Seed JP",
+        2 => "Montserrat",
+        3 => "Noto Sans",
+        4 => "Source Sans 3",
+        _ => "",
+    }
+}
+
+/// THE fix for issue #664's follow-on (wrapped-line karaoke highlight taking
+/// the whole block height): ask the ACTUAL Slint window whether `candidate`
+/// renders on ONE visual row at `max_width_px`, instead of guessing with an
+/// independent swash re-measurement that can disagree with whatever backend
+/// is really active (Skia on macOS, femtovg on Linux/Windows, ...).
+///
+/// Synchronous and side-effect-free from the caller's point of view: this
+/// writes `LyricsWrapProbe`'s driving inputs (a hidden, always-mounted probe
+/// `Text` on `AppWindow` — see state.slint / app.slint) and reads back
+/// `AppWindow.lyrics-wrap-probe-fits`, a root-level property whose binding is
+/// pull-evaluated fresh on every read — so the answer always reflects what
+/// was JUST set, never a stale prior candidate. Must run on the UI thread
+/// (same requirement as every other Slint property access here); every
+/// caller already holds a live `&AppWindow`.
+fn slint_fits_one_line(
+    window: &AppWindow,
+    candidate: &str,
+    max_width_px: f32,
+    font_index: i32,
+    size_px: f32,
+) -> bool {
+    let probe = window.global::<LyricsWrapProbe>();
+    probe.set_text(SharedString::from(candidate));
+    probe.set_max_width(max_width_px);
+    probe.set_font_name(SharedString::from(font_family_name(font_index)));
+    probe.set_font_size(size_px);
+    probe.set_font_weight(700);
+    probe.set_letter_spacing(0.2);
+    window.get_lyrics_wrap_probe_fits()
+}
+
 /// The font + size tier + uppercase the active line is RENDERED with — the
 /// segmentation must measure against these so segment widths match the draw.
 /// The main sidebar drives them from the persisted prefs on `LyricsState`; the
@@ -340,12 +386,18 @@ pub(crate) struct RenderPrefs {
 /// When there is no active line, clears the model. `surface` selects the
 /// per-window cache cell (main window vs miniplayer).
 pub(crate) fn refresh_active_segments(
+    window: &AppWindow,
     lyrics: &LyricsState,
     index: i32,
     prefs: RenderPrefs,
     surface: SegSurface,
 ) {
-    let content_width = lyrics.get_content_width();
+    // Tiny rounding cushion only (NOT a cross-renderer fudge factor anymore —
+    // the wrap decision itself now comes straight from the real Slint
+    // renderer via `slint_fits_one_line`, see below). This just absorbs
+    // float/subpixel rounding right at the exact boundary width.
+    const MEASURE_ROUNDING_CUSHION_PX: f32 = 1.0;
+    let content_width = (lyrics.get_content_width() - MEASURE_ROUNDING_CUSHION_PX).max(0.0);
     let font_index = prefs.font_index;
     let size_index = prefs.size_index;
     let uppercase = prefs.uppercase;
@@ -399,16 +451,40 @@ pub(crate) fn refresh_active_segments(
     let text = if uppercase { raw.to_uppercase() } else { raw };
 
     let size_px = size_active_px(size_index);
-    let segments = lyrics_measure::wrap_segments(&text, font_index, size_px, content_width);
+    let segments = lyrics_measure::wrap_segments(&text, font_index, size_px, content_width, |candidate| {
+        slint_fits_one_line(window, candidate, content_width, font_index, size_px)
+    });
 
-    // Convert measured widths into cumulative start-weight + per-segment
-    // width-weight (Tauri's getSegmentProgress partition) so the row can
-    // re-map the single global `line-progress` to a per-segment local fill.
-    let total: f32 = segments.iter().map(|seg| seg.width_px).sum();
+    // Convert into cumulative start-weight + per-segment width-weight so the
+    // row can re-map the single global `line-progress` to a per-segment local
+    // fill. Weighted by CHARACTER COUNT, not pixel width — matching exactly
+    // how `qbz_lyrics::sync::line_fill_fraction` paces `line-progress` itself
+    // for word-synced (wsync) docs: word chars + 1 separator char per word,
+    // except the line's very last word (see crates/qbz-lyrics/src/sync.rs).
+    // `line-progress`'s [0,1] domain is built in THAT space. Remapping it
+    // here with a DIFFERENT measurement (pixel width, as this used to do)
+    // put the two systems out of step wherever a segment boundary landed at
+    // a point where character count and pixel width disagree (a run of
+    // narrow letters vs one wide word, etc.) — invisible for single-segment
+    // lines (nothing to remap against), but increasingly audible as
+    // multi-segment lines became reliably correct once the true-fix probe
+    // landed (issue #664 follow-on): the fill visibly finished well ahead of
+    // the singer on any line that actually wrapped. Matching the SAME space
+    // line-progress was built in removes the mismatch outright rather than
+    // trading one approximation for another.
+    let weights: Vec<f32> = segments
+        .iter()
+        .enumerate()
+        .map(|(i, seg)| {
+            let chars = seg.text.chars().count() as f32;
+            if i + 1 < segments.len() { chars + 1.0 } else { chars }
+        })
+        .collect();
+    let total: f32 = weights.iter().sum();
     let mut cumulative = 0.0_f32;
     let mut out: Vec<LyricsSegment> = Vec::with_capacity(segments.len());
-    for seg in &segments {
-        let width_weight = if total > 0.0 { seg.width_px / total } else { 0.0 };
+    for (seg, weight) in segments.iter().zip(weights.iter()) {
+        let width_weight = if total > 0.0 { weight / total } else { 0.0 };
         out.push(LyricsSegment {
             text: SharedString::from(seg.text.as_str()),
             start_weight: cumulative,

--- a/crates/qbz/src/miniplayer.rs
+++ b/crates/qbz/src/miniplayer.rs
@@ -513,7 +513,7 @@ pub fn mirror_lyrics_scalars(main: &AppWindow) {
     d.set_active_index(s.get_active_index());
     d.set_line_progress(s.get_line_progress());
     d.set_fill_anim_ms(s.get_fill_anim_ms());
-    refresh_mini_segments(&d);
+    refresh_mini_segments(main, &d);
 }
 
 /// Recompute the mini's per-visual-line karaoke segmentation against ITS OWN
@@ -521,8 +521,13 @@ pub fn mirror_lyrics_scalars(main: &AppWindow) {
 /// sidebar). The mini renders with FIXED render prefs — Inter / 15px / no
 /// uppercase (`MiniLyricsSurface.slint` binds none of the display prefs) — so
 /// it passes those rather than the persisted sidebar prefs. Cache-guarded.
-fn refresh_mini_segments(d: &LyricsState) {
+/// Takes `main` (not the mini window) for the wrap-fit probe: the probe
+/// elements only exist on `AppWindow` (app.slint) — a pure measurement
+/// utility, so it's fine to answer for text that ends up on a DIFFERENT
+/// window's LyricsState (`d`) than the one hosting the probe.
+fn refresh_mini_segments(main: &AppWindow, d: &LyricsState) {
     crate::lyrics_sync::refresh_active_segments(
+        main,
         d,
         d.get_active_index(),
         crate::lyrics_sync::RenderPrefs {
@@ -610,7 +615,7 @@ fn mirror_lyrics_gated(main: &AppWindow, mini: &MiniPlayerWindow) {
     // Translation toggle (v10): the mini surface has no button of its own —
     // it follows the sidebar's bilingual state through the shared model.
     d.set_show_translation(s.get_show_translation());
-    refresh_mini_segments(&d);
+    refresh_mini_segments(&main, &d);
 
     // Gate the lines-model copy on (status, line-count) so we don't thrash the
     // lyrics view (which would reset its scroll) every tick.


### PR DESCRIPTION
## Summary

Fixes #664  (lyrics cropped when highlighted, split view) and the follow-on
issues found while fixing it: the highlight not scrolling to the top on
track change, and the karaoke highlight not correctly tracking wrapped
lines.

(the changes were made using claude code)

**Root cause of #664:** the active line's karaoke segments were rendered
with `wrap: no-wrap`, trusting a Rust-side word-wrap measurement
(`lyrics_measure.rs`) that used `swash`, calibrated for femtovg's text
shaping. On macOS the active renderer is always Skia, not femtovg, so a
segment measured as "fits" could render a few px wider than the panel and
get clipped instead of wrapping.

**Fix:** Rust now asks the real Slint window whether a line fits, via a
small always-mounted probe (`LyricsWrapProbe` in `state.slint`, probe
elements on `AppWindow` in `app.slint`) instead of an independent
measurement. `LyricsLinesView.slint` keeps `wrap: word-wrap` as a
defensive fallback for the rare case a segment still overflows (DPI/paint
timing edge cases), so the crop can't reproduce even if a future
measurement mismatch shows up elsewhere.

**Follow-on fixes found while testing:**
- Segment fill-progress weighting was changed from pixel width to
  character count, matching how `qbz_lyrics::sync::line_fill_fraction`
  already paces word-synced (wsync) lyrics. The two were in different
  measurement spaces, which was invisible for single-row lines but caused
  the highlight to finish visibly ahead of the singer on any line that
  genuinely wrapped into multiple Rust-side segments.

## Files changed

- `crates/qbz-ui/ui/shell/LyricsLinesView.slint` — wrap/clip fix, scroll
  reset on track change, multi-row karaoke fill.
- `crates/qbz-ui/ui/state.slint` — `LyricsWrapProbe` global.
- `crates/qbz-ui/ui/app.slint` — hidden probe elements + root-level
  `lyrics-wrap-probe-fits` property.
- `crates/qbz/src/lyrics_measure.rs` — `wrap_segments` now takes a `fits`
  oracle instead of an internal pixel-budget check; `swash` is kept only
  for per-segment width used in test coverage.
- `crates/qbz/src/lyrics_sync.rs` — `slint_fits_one_line` /
  `font_family_name` helpers; segment weighting switched from pixel width
  to character count.
- `crates/qbz/src/miniplayer.rs` — threaded `&AppWindow` through so the
  mini surface can use the main window's probe.

## Testing

- Manually verified on a narrowed SPLIT lyrics panel that previously
  reproduced the crop: long lines now wrap instead of clipping.
- Verified the karaoke fill sweeps both rows on a wrapped line, reaching
  full width on each, and finishing in sync with the vocal rather than
  early.

## Screenshots

**Before**

<img width="1209" height="601" alt="qbz-fix-before" src="https://github.com/user-attachments/assets/9987a338-e9ab-4de7-a4e8-a93b5586c0da" />

**After**

<img width="1204" height="562" alt="qbz-fix-after" src="https://github.com/user-attachments/assets/6e0ee693-88f7-4396-9873-a111401cf3ff" />

## Checklist

- [x] My change targets the `crates/` workspace.
- [x] PR is targeted at `pre-release`, not `main`.
