### PR TITLE
feat(nav): go to the first entry when a sidebar section row is clicked

### DIFF
--- a/crates/qbz-ui/ui/shell/Sidebar.slint
+++ b/crates/qbz-ui/ui/shell/Sidebar.slint
@@ -542,15 +542,17 @@ component SidebarRow inherits Rectangle {
     }
 }
 
-// One section-nav row in the sidebar. Clicking (or hovering) opens the same
-// dropdown the header tab used, but flown out to the RIGHT of the row. In the
-// mini state the label is hidden (icon only). Mirrors NavTabWithMenu.
+// One section-nav row in the sidebar. Hovering opens the same dropdown the
+// header tab used, but flown out to the RIGHT of the row; clicking navigates
+// straight to the section's first entry. In the mini state the label is
+// hidden (icon only). Mirrors NavTabWithMenu.
 component SidebarNavRow inherits Rectangle {
     in property <image> icon;
     in property <string> label;
     in property <int> tab-index;
     in property <[NavMenuEntry]> items;
     in property <int> home-item: -1;
+    callback navigate(string /* route */);
     // When true the leading icon is a user-supplied image rendered as-is
     // (no theme tint). Used by the My QBZ row to show a custom icon with its
     // own colours; default branded glyphs stay tinted via QbzIcon.
@@ -620,7 +622,11 @@ component SidebarNavRow inherits Rectangle {
         enabled: !root.disabled;
         mouse-cursor: pointer;
         clicked => {
-            root.open-menu();
+            if (root.items.length > 0 && root.items[0].route != "") {
+                root.navigate(root.items[0].route);
+            } else {
+                root.open-menu();
+            }
         }
         changed has-hover => {
             if (self.has-hover) {
@@ -734,6 +740,9 @@ export component Sidebar inherits Rectangle {
                     { label: @tr("For You"), has-glyph: false, route: "discover-forYou" },
                     { label: @tr("Recommendations"), has-glyph: false, route: "discover-recommendations" },
                 ];
+                navigate(route) => {
+                    root.navigate(route);
+                }
             }
             if !OfflineState.offline && !SettingsState.show-recommendations: SidebarNavRow {
                 tab-index: 0;
@@ -745,6 +754,9 @@ export component Sidebar inherits Rectangle {
                     { label: @tr("Editor's Picks"), has-glyph: false, route: "discover-editorPicks" },
                     { label: @tr("For You"), has-glyph: false, route: "discover-forYou" },
                 ];
+                navigate(route) => {
+                    root.navigate(route);
+                }
             }
             // Qobuz favorites — HIDDEN entirely while offline.
             if !OfflineState.offline: SidebarNavRow {
@@ -759,6 +771,9 @@ export component Sidebar inherits Rectangle {
                     { label: @tr("Playlists"), icon: @image-url("../assets/icons/list-music.svg"), has-glyph: true, route: "favorites-playlists" },
                     { label: @tr("Labels"), icon: @image-url("../assets/icons/disc-3.svg"), has-glyph: true, route: "favorites-labels" },
                 ];
+                navigate(route) => {
+                    root.navigate(route);
+                }
             }
             SidebarNavRow {
                 tab-index: 2;
@@ -770,6 +785,9 @@ export component Sidebar inherits Rectangle {
                     { label: @tr("Folders"), icon: @image-url("../assets/icons/folder.svg"), has-glyph: true, route: "local-folders" },
                     { label: @tr("Tracks"), icon: @image-url("../assets/icons/music.svg"), has-glyph: true, route: "local-tracks" },
                 ];
+                navigate(route) => {
+                    root.navigate(route);
+                }
             }
             SidebarNavRow {
                 tab-index: 3;
@@ -785,6 +803,9 @@ export component Sidebar inherits Rectangle {
                     { label: @tr("Mixtapes"), icon: @image-url("../assets/icons/cassette.svg"), has-glyph: true, route: "myqbz-mixtapes" },
                     { label: @tr("Collections"), icon: @image-url("../assets/icons/collection.svg"), has-glyph: true, route: "myqbz-collections" },
                 ];
+                navigate(route) => {
+                    root.navigate(route);
+                }
             }
             // Purchases — opt-in (Settings > Appearance, default OFF). A DIRECT
             // destination (no tab dropdown). HIDDEN entirely while offline (the


### PR DESCRIPTION
## Summary

The sidebar section rows (Discover, Library, Local Library, My QBZ) are pure menu triggers today. Their `clicked` handler calls `open-menu()`, which the hover that necessarily precedes a click has already done, so clicking a row looks like it does nothing. The only way out of the row is to pick an entry from the flyout.

A click now goes to the row's first entry:

| Row | Destination |
| --- | --- |
| Discover | Home |
| Library | All |
| Local Library | Albums |
| My QBZ | Mixtapes |

The route strings are the ones the flyout rows already emit, so this reuses the existing `Sidebar.navigate` -> `AppShell.header-menu-navigate` path and needs no Rust-side change.

Rows whose first entry carries no route keep the old behaviour and just open the menu. That branch also covers the pointer-less path, where no hover precedes the click.

The flyout is deliberately left open after the click so the sibling entries stay one click away; the overlay's existing 1s idle timer closes it once the pointer leaves.

The forwarding handler is repeated at each mount site because the rows sit behind separate `if` gates (offline, the recommendations opt-out), so there is no shared parent to bind it on once.

## Testing

Not built. I don't have a Rust toolchain on the machine I wrote this on, and per CONTRIBUTING the UI crates are a ~20-30 GB compile. The change is one `.slint` file; `.length` and `items[0].field` are both already used elsewhere in the UI (`BlacklistState.items.length`, `PlaylistState.tracks[0].artwork`), and the callback forwarding matches how `AppShell` already mounts `Sidebar`. **Please confirm `cargo check -p qbz` passes before merging.**

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri `src-tauri/` trees were removed in 2.0.2; this touches neither.
- [x] No new or changed UI strings, so no `.po` updates needed.
