### PR TITLE
feat(mixtape): make local and Plex resolution optional features

### DIFF
--- a/crates/qbz-mixtape/Cargo.toml
+++ b/crates/qbz-mixtape/Cargo.toml
@@ -5,12 +5,23 @@ edition = "2021"
 description = "Mixtapes & Collections backend for QBZ — schema, repo, shuffle, enqueue (headless, frontend-agnostic)"
 authors = ["blitzkriegfc"]
 
+[features]
+default = ["local", "plex"]
+# Resolving Mixtape items that live in the on-disk library (`qbz-library`).
+local = ["dep:qbz-library"]
+# Resolving `plex:`-prefixed album keys against the Plex cache. Reached through
+# `resolve_local_album`, so it builds on `local`.
+plex = ["local", "dep:qbz-plex"]
+
 [dependencies]
 # Shared QBZ crates (the real models + resolvers, not src-tauri shims)
 qbz-models = { path = "../qbz-models" }
 qbz-qobuz = { path = "../qbz-qobuz" }
-qbz-library = { path = "../qbz-library" }
-qbz-plex = { path = "../qbz-plex" }
+# Optional so the schema/repo/shuffle half of this crate is reusable where there
+# are no local files and no LAN peer to reach — a phone, for one. Both default
+# on, so the desktop build is unchanged.
+qbz-library = { path = "../qbz-library", optional = true }
+qbz-plex = { path = "../qbz-plex", optional = true }
 
 # Database
 rusqlite = { version = "0.31", features = ["bundled"] }

--- a/crates/qbz-mixtape/src/enqueue.rs
+++ b/crates/qbz-mixtape/src/enqueue.rs
@@ -333,6 +333,7 @@ pub async fn resolve_qobuz_playlist(
 /// Routes the `plex:`-prefixed keys to the Plex cache; everything else is a
 /// true local album resolved against the passed `&LibraryDatabase`. Both
 /// branches are synchronous — no `&LibraryDatabase` is held across an `.await`.
+#[cfg(feature = "local")]
 pub fn resolve_local_album(
     db: &qbz_library::LibraryDatabase,
     group_key: &str,
@@ -341,13 +342,23 @@ pub fn resolve_local_album(
     // rows live in the Plex cache DB (plex_cache_tracks), not local_tracks,
     // so route them to the Plex cache fetcher instead of db.get_album_tracks.
     if group_key.starts_with("plex:") {
+        #[cfg(feature = "plex")]
         return resolve_plex_album_tracks(group_key);
+        // Refused rather than looked up in local_tracks: a Plex key is not a
+        // local album group, and resolving it there would silently return the
+        // wrong tracks or none at all.
+        #[cfg(not(feature = "plex"))]
+        return Err(format!(
+            "plex album {} cannot be resolved: this build has no Plex support",
+            group_key
+        ));
     }
 
     resolve_local_album_tracks(db, group_key)
 }
 
 /// Resolve a true local album group (no `plex:` prefix) against the library DB.
+#[cfg(feature = "local")]
 pub fn resolve_local_album_tracks(
     db: &qbz_library::LibraryDatabase,
     group_key: &str,
@@ -364,6 +375,7 @@ pub fn resolve_local_album_tracks(
 }
 
 /// Resolve a `plex:`-prefixed album key against the shared Plex cache.
+#[cfg(feature = "plex")]
 pub fn resolve_plex_album_tracks(group_key: &str) -> Result<Vec<CoreQueueTrack>, String> {
     let tracks = qbz_plex::plex_cache_get_album_tracks(group_key.to_string())
         .map_err(|e| format!("plex cache get_album_tracks({}) failed: {}", group_key, e))?;
@@ -378,6 +390,7 @@ pub fn resolve_plex_album_tracks(group_key: &str) -> Result<Vec<CoreQueueTrack>,
 
 // ── Local track (synchronous) ──
 
+#[cfg(feature = "local")]
 pub fn resolve_local_track(
     db: &qbz_library::LibraryDatabase,
     track_id: i64,
@@ -402,6 +415,7 @@ pub fn resolve_local_track(
 /// - Album    → [`resolve_local_album`] (handles the `plex:` prefix internally)
 /// - Track    → parse `source_item_id` to `i64` (`invalid local track id`) → [`resolve_local_track`]
 /// - Playlist → hard error `local playlists not supported in this release`
+#[cfg(feature = "local")]
 pub fn resolve_local_item(
     db: &qbz_library::LibraryDatabase,
     item: &MixtapeCollectionItem,
@@ -476,6 +490,7 @@ pub fn track_to_queue_track_from_api(track: &ApiTrack) -> CoreQueueTrack {
 /// (`v2_plex_play_track` with `ratingKey: String(track.id)`) resolves to the
 /// same Plex object. source="plex" lets playback route to the Plex branch
 /// instead of the local-file branch.
+#[cfg(feature = "plex")]
 pub fn plex_cached_track_to_queue_track(track: &qbz_plex::PlexCachedTrack) -> CoreQueueTrack {
     let id: u64 = track.rating_key.parse().unwrap_or(track.id);
     let sample_rate_khz = if track.sample_rate > 0 {
@@ -510,6 +525,7 @@ pub fn plex_cached_track_to_queue_track(track: &qbz_plex::PlexCachedTrack) -> Co
 /// Map a `LocalTrack` to a `CoreQueueTrack`.
 /// `is_local = true`, `source = "local"`, `sample_rate` is converted from Hz
 /// to kHz to match the Qobuz convention used elsewhere in the queue display.
+#[cfg(feature = "local")]
 pub fn local_track_to_queue_track(track: &qbz_library::LocalTrack) -> CoreQueueTrack {
     // Artwork: local tracks store a file path; expose it as a `file://` URL
     // so the frontend's <img> can load it. Falls back to None when absent.
@@ -622,6 +638,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "local")]
     #[test]
     fn resolve_local_item_playlist_is_unsupported() {
         // The (Playlist, Local) hard error is a load-bearing contract (spec §5.4/§10);
@@ -632,6 +649,7 @@ mod tests {
         assert_eq!(err, "local playlists not supported in this release");
     }
 
+    #[cfg(feature = "local")]
     #[test]
     fn resolve_local_item_track_rejects_non_numeric_id() {
         let db = qbz_library::LibraryDatabase::open(std::path::Path::new(":memory:")).unwrap();


### PR DESCRIPTION
## Summary

Makes `qbz-mixtape`'s `qbz-library` and `qbz-plex` dependencies optional, behind
two default-on features. Desktop behaviour and its dependency graph are
unchanged; the point is to let the crate be reused where those two make no
sense.

`schema.rs`, `repo.rs` and `shuffle.rs` already touch nothing but `&Connection`.
Only `enqueue.rs` reaches for the other crates, and only in its local/Plex
resolvers, which `ProdItemResolver` already delegates to a caller-supplied
closure rather than calling itself. So the split falls along a seam the crate
had anyway.

```toml
[features]
default = ["local", "plex"]
local = ["dep:qbz-library"]
plex  = ["local", "dep:qbz-plex"]   # reached via resolve_local_album
```

With `--no-default-features`, `qbz-library`, `qbz-plex`, `open`, `lofty` and
`image` all leave the graph. `resolve_local_album` still recognises a `plex:`
key with `plex` off, but returns an error rather than looking it up in
`local_tracks` — resolving a Plex key as a local album group would silently
return the wrong tracks.

### Why

The `qbz-mobile` iOS/Android clients reuse the QBZ crates rather than
reimplementing them, and Mixtapes & Collections is the largest qbz-original
feature still missing there. Two things block taking the crate as-is on a phone:

- `qbz-plex`'s `open_plex_cache_db()` resolves its path through
  `dirs::data_dir()` with no injectable alternative, across 16 call sites. On
  Android that is outside the app sandbox, so it compiles and then fails or
  writes somewhere the app cannot reach.
- `qbz-plex` pulls `open`, which reaches iOS via `Command::new("uiopen")`.
  Sandboxed iOS apps cannot spawn subprocesses, and process-spawning APIs are a
  known App Store review trigger. It is linked but unreachable code.

Neither matters on desktop, which is why they default on.

### Verification

- `cargo build -p qbz-mixtape` and `--no-default-features` both clean.
- `cargo test -p qbz-mixtape`: 57 passed. `--no-default-features`: 55 passed —
  the two dropped are the `LibraryDatabase`-backed `resolve_local_item` tests,
  gated with the code they cover.
- `cargo check -p qbz` clean, so the Slint app is unaffected.

## Correcting the stated rationale, after review

The description above credits this with keeping `qbz-library` off the phone. That is wrong, and worth fixing so the next reader does not over-trust it: in the real mobile graph `qbz-library` arrives anyway via `qbz-offline-cache <- qbz-mobile-ffi`, so the phone compiles it regardless of this change.

The whole win is the `plex` gate. `qbz-plex` hardcodes `dirs::data_dir()`, which on iOS is outside the app sandbox, and pulls `open`, which reaches the platform through a subprocess spawn. Neither belongs in a mobile build, and that is what this makes optional.

Two smaller notes from the same review:

- `plex = ["local", "dep:qbz-plex"]` implies `local`, but that is not a build requirement. `plex = ["dep:qbz-plex"]` alone compiles, and drops `qbz-library` entirely. Keeping the implication is a defensible API-shape choice, but the comment should say so rather than imply the compiler needs it.
- The reduced configuration is not built by CI. `cargo-test.sh` runs `--workspace`, so `qbz-mixtape` always builds with its defaults, and nothing in `.github/workflows/` or `scripts/` passes `--no-default-features`. The next commit adding an ungated `qbz_library::` call ships green and breaks the downstream pin. A gate modelled on the qbzd dep-graph one already in `test-crates.yml` would hold it.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.

