### PR TITLE
fix(secrets): take the KDF path on mobile instead of keyring's mock backend

### DIFF
--- a/crates/qbz-secrets/Cargo.toml
+++ b/crates/qbz-secrets/Cargo.toml
@@ -16,11 +16,6 @@ sha2 = "0.10"
 # RNG for nonces + install UUID generation
 rand = "0.9"
 
-# OS keyring backends: libsecret/secret-service (Linux), Keychain (macOS),
-# DPAPI (Windows). Default features on v3 already pick the right backend
-# per platform; if it fails at runtime we fall through to the KDF path.
-keyring = "3"
-
 # UUID for the persistent install identifier (salt component for fallback)
 uuid = { version = "1", features = ["v4", "serde"] }
 
@@ -36,3 +31,14 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+
+# OS keyring backends: libsecret/secret-service (Linux), Keychain (macOS),
+# DPAPI (Windows). **Desktop only, deliberately.** keyring 3.x compiles no real
+# backend for Android, and none for iOS without its `apple-native` feature — it
+# routes both to an in-memory `mock` whose writes *succeed*. Depending on it
+# there would not fail loudly; it would hand back a master key that never
+# leaves the process, so every blob wrapped in one run is undecryptable in the
+# next. Mobile takes the KDF path, which is derived from a persisted install id
+# and is stable across launches. See `backend.rs`.
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+keyring = "3"

--- a/crates/qbz-secrets/src/backend.rs
+++ b/crates/qbz-secrets/src/backend.rs
@@ -5,6 +5,16 @@
 //! AES-256-GCM wraps. Failure (for any reason) = we fall back to HKDF
 //! over device identifiers.
 //!
+//! **Mobile skips the keyring entirely and goes straight to the KDF path.**
+//! Not a preference — a correctness requirement. `keyring` 3.x compiles no real
+//! backend for Android, and none for iOS without its `apple-native` feature;
+//! both resolve to an in-memory `mock`. The mock's writes *succeed*, so the
+//! attempt below would not fail into the fallback: it would report success and
+//! hand back a key that dies with the process, silently making every blob
+//! wrapped in one run undecryptable in the next. The KDF path derives from a
+//! persisted install id and is stable across launches, which is what a phone
+//! needs. `keyring` is a desktop-only dependency for the same reason.
+//!
 //! The backend discriminator is baked into every wrapped blob so a blob
 //! produced by one backend can't be silently decrypted by another (and
 //! so that if a user later gains keyring access, we don't accidentally
@@ -13,6 +23,8 @@
 use std::path::Path;
 
 use hkdf::Hkdf;
+// Only the keyring path mints a random master key; the KDF path derives one.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use rand::RngCore;
 use sha2::Sha256;
 
@@ -21,6 +33,7 @@ use crate::error::SecretError;
 use crate::install_id;
 
 const MASTER_KEY_LEN: usize = 32;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 const KEYRING_ENTRY_NAME: &str = "master-key-v1";
 const HKDF_INFO: &[u8] = b"qbz-secrets master-key derivation v1";
 
@@ -47,7 +60,9 @@ pub struct Backend {
 
 impl Backend {
     pub fn new(service_name: &str, storage_dir: &Path) -> Result<Self, SecretError> {
-        // Try keyring first.
+        // Try keyring first — desktop only; see the module comment for why
+        // mobile must not, and why a mock's *success* is the dangerous case.
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         match try_open_keyring(service_name) {
             Ok(master_key) => {
                 log::info!("[qbz-secrets] Using OS keyring backend");
@@ -94,6 +109,7 @@ impl Backend {
 }
 
 /// Read (or create and store) the master key from the OS keyring.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn try_open_keyring(service_name: &str) -> Result<[u8; MASTER_KEY_LEN], SecretError> {
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine;
@@ -125,9 +141,7 @@ fn try_open_keyring(service_name: &str) -> Result<[u8; MASTER_KEY_LEN], SecretEr
             entry
                 .set_password(&encoded)
                 .map_err(|e| SecretError::Keyring(format!("set_password: {}", e)))?;
-            log::info!(
-                "[qbz-secrets] Generated fresh 256-bit master key and stored in OS keyring"
-            );
+            log::info!("[qbz-secrets] Generated fresh 256-bit master key and stored in OS keyring");
             Ok(key)
         }
         Err(e) => Err(SecretError::Keyring(format!("get_password: {}", e))),


### PR DESCRIPTION
## Summary

`qbz-secrets` silently falls back to a **per-process** master key on Android and
iOS, which makes anything it wraps undecryptable after a restart. This takes the
KDF path on both, and makes `keyring` a desktop-only dependency.

The failure is not the keyring erroring — it is the keyring *succeeding*:

1. `keyring` 3.x compiles no real backend for Android, and none for iOS without
   its `apple-native` feature. Both resolve to the in-memory `mock`
   (`keyring-3.6.3/src/lib.rs:287-288`, plus the catch-all at `:304-308` that
   Android's `target_os` falls into). Confirmed by resolution, not inference:
   `security-framework` appears zero times in a mobile `Cargo.lock`.
2. `Backend::new` falls through to the KDF path **only on `Err`**.
3. The mock's `set_secret` returns `Ok(())` (`keyring-3.6.3/src/mock.rs:99-109`).

So `try_open_keyring` finds `NoEntry`, mints a random key, "persists" it into a
mock that is empty again next launch, and returns `Ok`. `Backend::new` logs
*"Using OS keyring backend"* and never reaches the fallback. Every subsequent
launch gets a different master key.

The `keyring = "3"` comment claimed *"Default features on v3 already pick the
right backend per platform"*. That is what disguised it; this corrects it.

### Verified on a device, not just reasoned about

Downstream in the mobile client, an instrumented test on a real Android
emulator reported the vault backend as `Keyring` where no keyring backend
exists — proving the mock path. After this change it reports `KdfFallback`.

The KDF path is the right one for mobile regardless: `derive_fallback_key`
derives from `install_id::load_or_create(storage_dir)`, a UUID persisted beside
the data, so it is stable across launches.

### Scope

Desktop behaviour is unchanged — the keyring is still tried first on every
platform that has one. No migration concern on mobile: no wrapped blob there
survives a restart today, so there is no existing ciphertext to preserve.

### Verification

- `cargo build -p qbz-secrets` and `--target aarch64-linux-android`: both clean,
  zero warnings.
- `cargo test -p qbz-secrets`: 4 passed.
- `cargo clippy -p qbz-secrets`: clean.

## Checklist

- [x] My change targets the `crates/` workspace. The Svelte `src/` and Tauri
      `src-tauri/` trees were **removed in 2.0.2** (preserved only at git tag
      `legacy-tauri-svelte` for reference); PRs against those paths can't be
      merged. If your fix targets the old tree, open an issue instead and we'll
      help you port it.
