### PR TITLE
fix(offline-cache): locate a CMAF bundle under the root the cache is open at

### DIFF
--- a/crates/qbz-offline-cache/src/cmaf_store.rs
+++ b/crates/qbz-offline-cache/src/cmaf_store.rs
@@ -284,13 +284,31 @@ mod tests {
     #[test]
     fn the_layout_is_the_same_one_persist_wrote_to() {
         let root = tempfile::tempdir().unwrap();
-        let (written, _) = persist_bundle(root.path(), 7, &raw_bundle()).unwrap();
+        persist_bundle(root.path(), 7, &raw_bundle()).unwrap();
 
         // Playback derives rather than reading the row back, so the two must
         // agree for every track: this is what makes deriving safe.
+        //
+        // Asserted against the filesystem rather than against what
+        // `persist_bundle` returned. That value is built by the same pure
+        // function this derives from, so comparing the two compares a value
+        // with itself: it stays green even when both are wrong, which is no
+        // guard at all.
         let derived = BundleLayout::new(root.path(), 7);
-        assert_eq!(derived.init_path, written.init_path);
-        assert_eq!(derived.segments_path, written.segments_path);
-        assert_eq!(derived.manifest_path, written.manifest_path);
+        assert!(
+            derived.init_path.exists(),
+            "nothing at the derived init path {:?}",
+            derived.init_path
+        );
+        assert!(
+            derived.segments_path.exists(),
+            "nothing at the derived segments path {:?}",
+            derived.segments_path
+        );
+        assert!(
+            derived.manifest_path.exists(),
+            "nothing at the derived manifest path {:?}",
+            derived.manifest_path
+        );
     }
 }

--- a/crates/qbz-offline-cache/src/cmaf_store.rs
+++ b/crates/qbz-offline-cache/src/cmaf_store.rs
@@ -236,3 +236,61 @@ fn write_atomic(path: &Path, data: &[u8]) -> std::io::Result<()> {
     fs::rename(&tmp, path)?;
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw_bundle() -> CmafRawBundle {
+        CmafRawBundle {
+            init_bytes: b"init-segment-bytes".to_vec(),
+            segments: vec![b"segment-one".to_vec(), b"segment-two".to_vec()],
+            content_key: [7u8; 16],
+            infos: "infos".to_string(),
+            format_id: 6,
+            sampling_rate: Some(44100),
+            bit_depth: Some(16),
+            n_segments: 2,
+        }
+    }
+
+    /// The bundle is found by deriving its location from the root the cache is
+    /// open at, so an application directory that moves underneath it costs
+    /// nothing. iOS reassigns an app's data container on reinstall, which is
+    /// what makes this more than theoretical: every absolute path recorded at
+    /// download time names a directory that no longer exists, while the bundle
+    /// itself is untouched.
+    #[test]
+    fn a_bundle_is_found_after_its_root_moves() {
+        let old_root = tempfile::tempdir().unwrap();
+        let (written, _) = persist_bundle(old_root.path(), 42, &raw_bundle()).unwrap();
+
+        // What a reinstall does: same bytes, same layout, different prefix.
+        let new_parent = tempfile::tempdir().unwrap();
+        let new_root = new_parent.path().join("audio");
+        std::fs::rename(old_root.path(), &new_root).unwrap();
+        assert!(
+            !written.segments_path.exists(),
+            "the recorded path is stale"
+        );
+
+        let loaded = read_bundle(&BundleLayout::new(&new_root, 42)).unwrap();
+
+        assert_eq!(loaded.init_bytes, b"init-segment-bytes");
+        assert_eq!(loaded.segments.len(), 2);
+        assert_eq!(loaded.segments[1], b"segment-two");
+    }
+
+    #[test]
+    fn the_layout_is_the_same_one_persist_wrote_to() {
+        let root = tempfile::tempdir().unwrap();
+        let (written, _) = persist_bundle(root.path(), 7, &raw_bundle()).unwrap();
+
+        // Playback derives rather than reading the row back, so the two must
+        // agree for every track: this is what makes deriving safe.
+        let derived = BundleLayout::new(root.path(), 7);
+        assert_eq!(derived.init_path, written.init_path);
+        assert_eq!(derived.segments_path, written.segments_path);
+        assert_eq!(derived.manifest_path, written.manifest_path);
+    }
+}

--- a/crates/qbz-offline-cache/src/playback.rs
+++ b/crates/qbz-offline-cache/src/playback.rs
@@ -64,8 +64,11 @@ pub async fn load_cmaf_bundle_with_ui_events(
 /// caller should treat `None` as a cache miss — continue to the next
 /// tier or the network.
 ///
-/// `offline_root_path` is only used to locate the secret vault's
-/// install UUID file; it must match the path used at download time.
+/// `offline_root_path` is what the bundle itself is located under, and what
+/// locates the secret vault's install UUID file. It is the current root rather
+/// than the one the row recorded, which is the whole point of this change: iOS
+/// reassigns an app's data container on reinstall, so a recorded absolute path
+/// stops existing while the bytes are still on disk.
 /// Passing `OfflineCacheState::get_cache_path()` is correct.
 pub fn load_cmaf_bundle(
     track_id: u64,
@@ -221,9 +224,15 @@ mod tests {
         let BundleLoadError::Read(message) = &err else {
             panic!("expected a read failure with nothing on disk, got {err:?}");
         };
+        // The *whole* derived path, not just the root prefix. Matching the
+        // prefix alone leaves the guard blind to the two ways this can still be
+        // wrong while looking under the right root: the wrong subdirectory, and
+        // the wrong track id.
+        let expected = BundleLayout::new(root.path(), 42);
         assert!(
-            message.contains(root.path().to_str().unwrap()),
-            "the read should have been attempted under the current root: {message}"
+            message.contains(expected.init_path.to_str().unwrap()),
+            "the read should have been attempted at {:?}, got: {message}",
+            expected.init_path
         );
         assert!(
             !message.contains("/recorded-elsewhere/"),

--- a/crates/qbz-offline-cache/src/playback.rs
+++ b/crates/qbz-offline-cache/src/playback.rs
@@ -72,80 +72,7 @@ pub fn load_cmaf_bundle(
     row: &CmafBundleRow,
     offline_root_path: &Path,
 ) -> Option<Vec<u8>> {
-    if row.cache_format != 2 {
-        return None;
-    }
-
-    let init_path = row.init_path.as_ref().or_else(|| {
-        log::warn!(
-            "[OfflineCache/Play] Track {} cache_format=2 but init_path is null",
-            track_id
-        );
-        None
-    })?;
-    let content_key_wrapped = row.content_key_wrapped.as_ref().or_else(|| {
-        log::warn!(
-            "[OfflineCache/Play] Track {} cache_format=2 but content_key_wrapped is null",
-            track_id
-        );
-        None
-    })?;
-
-    let segments_path = std::path::PathBuf::from(&row.segments_path);
-    let track_dir = segments_path.parent()?.to_path_buf();
-    let layout = BundleLayout {
-        track_dir,
-        init_path: std::path::PathBuf::from(init_path),
-        segments_path: segments_path.clone(),
-        manifest_path: segments_path.with_file_name("manifest.json"),
-    };
-
-    let loaded = match cmaf_store::read_bundle(&layout) {
-        Ok(lb) => lb,
-        Err(e) => {
-            log::warn!(
-                "[OfflineCache/Play] Track {} failed to read CMAF bundle: {}",
-                track_id,
-                e
-            );
-            return None;
-        }
-    };
-
-    let vault = match secret_vault::get_or_init(offline_root_path) {
-        Ok(v) => v,
-        Err(e) => {
-            log::warn!(
-                "[OfflineCache/Play] Track {} SecretBox init failed: {}",
-                track_id,
-                e
-            );
-            return None;
-        }
-    };
-    let unwrapped = match vault.unwrap(content_key_wrapped) {
-        Ok(k) => k,
-        Err(e) => {
-            log::warn!(
-                "[OfflineCache/Play] Track {} content_key unwrap failed: {}",
-                track_id,
-                e
-            );
-            return None;
-        }
-    };
-    if unwrapped.len() != 16 {
-        log::warn!(
-            "[OfflineCache/Play] Track {} unwrapped content_key wrong size ({} bytes)",
-            track_id,
-            unwrapped.len()
-        );
-        return None;
-    }
-    let mut content_key = [0u8; 16];
-    content_key.copy_from_slice(&unwrapped);
-
-    match loaded.decrypt_to_flac(&content_key) {
+    match load_bundle(track_id, row, offline_root_path) {
         Ok(flac_bytes) => {
             log::info!(
                 "[OfflineCache/Play] Track {} unwrapped + decrypted ({:.2} MB FLAC)",
@@ -154,13 +81,184 @@ pub fn load_cmaf_bundle(
             );
             Some(flac_bytes)
         }
+        // A v1 row is not a failure, it is simply not this function's business.
+        Err(BundleLoadError::NotCmaf) => None,
         Err(e) => {
-            log::warn!(
-                "[OfflineCache/Play] Track {} CMAF decrypt failed: {}",
-                track_id,
-                e
-            );
+            log::warn!("[OfflineCache/Play] Track {} {}", track_id, e);
             None
         }
+    }
+}
+
+/// Why a bundle could not be turned back into FLAC.
+///
+/// The public entry point collapses all of these to `None`, because to a caller
+/// they mean the same thing: fall through to the next tier. They are kept apart
+/// **so a test can tell which stage failed** — without that, an implementation
+/// that looked for the bundle in the wrong place would be indistinguishable from
+/// one that simply could not decrypt it (see
+/// `resolution_looks_under_the_current_root_not_the_recorded_path`).
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum BundleLoadError {
+    /// A v1 (plain FLAC) row. The caller reads `file_path` itself.
+    NotCmaf,
+    /// The row was written before the bundle finished landing.
+    IncompleteRow(&'static str),
+    Read(String),
+    Vault(String),
+    Unwrap(String),
+    KeySize(usize),
+    Decrypt(String),
+}
+
+impl std::fmt::Display for BundleLoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotCmaf => write!(f, "not a CMAF bundle"),
+            Self::IncompleteRow(col) => write!(f, "cache_format=2 but {col} is null"),
+            Self::Read(e) => write!(f, "failed to read CMAF bundle: {e}"),
+            Self::Vault(e) => write!(f, "SecretBox init failed: {e}"),
+            Self::Unwrap(e) => write!(f, "content_key unwrap failed: {e}"),
+            Self::KeySize(n) => write!(f, "unwrapped content_key wrong size ({n} bytes)"),
+            Self::Decrypt(e) => write!(f, "CMAF decrypt failed: {e}"),
+        }
+    }
+}
+
+fn load_bundle(
+    track_id: u64,
+    row: &CmafBundleRow,
+    offline_root_path: &Path,
+) -> Result<Vec<u8>, BundleLoadError> {
+    if row.cache_format != 2 {
+        return Err(BundleLoadError::NotCmaf);
+    }
+    // The column is not read for its value — the layout below is derived — but a
+    // null here means the row was written before the bundle was complete, and
+    // that is the one thing it still distinguishes.
+    if row.init_path.is_none() {
+        return Err(BundleLoadError::IncompleteRow("init_path"));
+    }
+    let content_key_wrapped = row
+        .content_key_wrapped
+        .as_ref()
+        .ok_or(BundleLoadError::IncompleteRow("content_key_wrapped"))?;
+
+    // Derived from the root the cache is open at, not from the absolute paths
+    // the row recorded. The two agree until the application directory moves,
+    // and then only the recorded ones are wrong: iOS reassigns an app's data
+    // container on reinstall (and can on restore or migration), which leaves
+    // every stored path naming a directory that no longer exists while the
+    // bundle itself sits untouched under the new one.
+    //
+    // Deriving is safe because the index lives *inside* the root
+    // (`<root>/index.db`), so a row can only ever describe a bundle under that
+    // same root, and `persist_bundle` writes nowhere else. Removal and eviction
+    // already resolve this way — see `maintenance::remove_album_cached_tracks`.
+    let layout = BundleLayout::new(offline_root_path, track_id);
+    if layout.segments_path != std::path::Path::new(&row.segments_path) {
+        log::info!(
+            "[OfflineCache/Play] Track {} bundle resolved under the current root; \
+             the recorded path predates a move",
+            track_id
+        );
+    }
+
+    let loaded = cmaf_store::read_bundle(&layout).map_err(BundleLoadError::Read)?;
+
+    let vault = secret_vault::get_or_init(offline_root_path)
+        .map_err(|e| BundleLoadError::Vault(e.to_string()))?;
+    let unwrapped = vault
+        .unwrap(content_key_wrapped)
+        .map_err(|e| BundleLoadError::Unwrap(e.to_string()))?;
+    if unwrapped.len() != 16 {
+        return Err(BundleLoadError::KeySize(unwrapped.len()));
+    }
+    let mut content_key = [0u8; 16];
+    content_key.copy_from_slice(&unwrapped);
+
+    loaded
+        .decrypt_to_flac(&content_key)
+        .map_err(BundleLoadError::Decrypt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn row_recording(segments_path: &str) -> CmafBundleRow {
+        CmafBundleRow {
+            cache_format: 2,
+            segments_path: segments_path.to_string(),
+            init_path: Some("/gone/init.mp4".to_string()),
+            // Deliberately not a real wrapped key: the point of these tests is
+            // which stage is *reached*, and the key stage is past the read.
+            content_key_wrapped: Some(vec![0u8; 8]),
+            infos_wrapped: None,
+            format_id: Some(6),
+            n_segments: Some(1),
+        }
+    }
+
+    /// The regression guard for the container-move bug.
+    ///
+    /// The row records a path that no longer exists — which is exactly what iOS
+    /// leaves behind when it reassigns an app's data container. With nothing on
+    /// disk either way this fails at the read, and `read_bundle` names the path
+    /// it tried, so the message is the assertion: it must be the root the cache
+    /// is open at, never the one the row recorded.
+    ///
+    /// Deliberately stops at the read rather than persisting a bundle and
+    /// checking it got further. Getting further means reaching the secret vault,
+    /// and that opens the OS keyring under the *production* service name — a
+    /// unit test has no business touching a developer's login keychain.
+    #[test]
+    fn resolution_looks_under_the_current_root_not_the_recorded_path() {
+        let root = tempfile::tempdir().unwrap();
+        let row = row_recording("/recorded-elsewhere/tracks-cmaf/42/segments.bin");
+
+        let err = load_bundle(42, &row, root.path()).unwrap_err();
+
+        let BundleLoadError::Read(message) = &err else {
+            panic!("expected a read failure with nothing on disk, got {err:?}");
+        };
+        assert!(
+            message.contains(root.path().to_str().unwrap()),
+            "the read should have been attempted under the current root: {message}"
+        );
+        assert!(
+            !message.contains("/recorded-elsewhere/"),
+            "the recorded path was used, which is the bug this guards: {message}"
+        );
+    }
+
+    #[test]
+    fn a_v1_row_is_not_this_functions_business() {
+        let root = tempfile::tempdir().unwrap();
+        let mut row = row_recording("/gone/x.flac");
+        row.cache_format = 1;
+
+        assert_eq!(
+            load_bundle(1, &row, root.path()).unwrap_err(),
+            BundleLoadError::NotCmaf
+        );
+    }
+
+    #[test]
+    fn a_row_written_before_the_bundle_landed_is_reported_as_incomplete() {
+        let root = tempfile::tempdir().unwrap();
+
+        let mut row = row_recording("/gone/tracks-cmaf/42/segments.bin");
+        row.init_path = None;
+        assert_eq!(
+            load_bundle(42, &row, root.path()).unwrap_err(),
+            BundleLoadError::IncompleteRow("init_path")
+        );
+
+        let mut row = row_recording("/gone/tracks-cmaf/42/segments.bin");
+        row.content_key_wrapped = None;
+        assert_eq!(
+            load_bundle(42, &row, root.path()).unwrap_err(),
+            BundleLoadError::IncompleteRow("content_key_wrapped")
+        );
     }
 }


### PR DESCRIPTION
## The problem

`load_cmaf_bundle` rebuilt the bundle layout from the absolute paths stored on the row:

```rust
let segments_path = std::path::PathBuf::from(&row.segments_path);
let track_dir = segments_path.parent()?.to_path_buf();
```

Those agree with reality until the application directory moves, and on iOS it does: the OS reassigns an app's Data container on reinstall, and it can change on restore-from-backup or device migration. Every recorded path then names a directory that no longer exists, while the bundle itself sits untouched under the new one.

The result is that **every download reports "Downloaded copy could not be opened. Download it again." with the bytes still on disk**:

```
[OfflineCache/Play] Track 438974689 failed to read CMAF bundle: Failed to read init
".../Application/3E22A98E-.../tracks-cmaf/438974689/init.mp4": No such file or directory
```

…while `.../Application/CAD2E2A8-.../tracks-cmaf/438974689/` contained `init.mp4`, `segments.bin`, `manifest.json` and `cover.jpg`. Rewriting the stored UUID to the current one made the same rows playable again, which pins the cause exactly.

Desktop is unaffected in practice (its cache root is stable), so this is latent there and fatal on iOS. Android is unaffected too: `/data/user/0/<pkg>/...` does not move.

## The fix

Derive the layout from the root the cache is open at, which is what `persist_bundle` wrote to:

```rust
let layout = BundleLayout::new(offline_root_path, track_id);
```

Safe because the index lives *inside* the root (`<root>/index.db`), so a row can only ever describe a bundle beneath that same root, and `persist_bundle` writes nowhere else. `maintenance::remove_album_cached_tracks` and cache eviction already resolve this way — this brings playback in line with them rather than introducing a new convention.

Checked every caller: `qbz-core/src/offline_resolve.rs:44,50` are the only two, and both take the row from `offline.db` and the root from `offline.get_cache_path()` on the same `OfflineCacheState`, with the same `track_id` that fetched the row — so no root/index or id/layout skew is reachable.

The v1 (`cache_format = 1`) path is untouched: it still reads `row.segments_path` directly in `offline_resolve.rs`, which is correct, since a legacy plain FLAC can live anywhere.

## Why the error enum

The fallible core moved into a private `load_bundle -> Result<_, BundleLoadError>`; the public `load_cmaf_bundle` still returns `Option` and logs, so **no call site changes**.

That is not decoration. With a bare `Option`, "looked in the wrong place" and "could not decrypt" are the same value, so no test can tell them apart — the regression this PR fixes would have been invisible to the suite. Splitting the failures is what makes the guard below possible.

## Tests

- `resolution_looks_under_the_current_root_not_the_recorded_path` — the regression guard. With nothing on disk, resolution fails at the read and `read_bundle` names the path it tried, so the message *is* the assertion: it must contain the current root and must not contain the recorded one. **Verified to fail** against the previous implementation and pass against this one.
- `a_row_written_before_the_bundle_landed_is_reported_as_incomplete`, `a_v1_row_is_not_this_functions_business` — the early exits.
- `a_bundle_is_found_after_its_root_moves`, `the_layout_is_the_same_one_persist_wrote_to` (in `cmaf_store`) — persist under one root, move the directory, read it back; and the invariant that makes deriving safe.

The guard deliberately stops *at* the read rather than persisting a bundle and checking it got further. Getting further reaches `secret_vault::get_or_init`, which opens the OS keyring under the production service name `qbz` — a unit test has no business touching a developer's login keychain or a CI secret-service.

`cargo test -p qbz-offline-cache`: 45 passed.

## Verified on device

On an iOS simulator, against the bug occurring naturally rather than a simulated one: a reinstall moved the container (`CAD2E2A8…` → `C3B88A87…`), the recorded paths went dead, and with the network blocked the track still played:

```
[OfflineCache/Play] Track 438974690 bundle resolved under the current root; the recorded path predates a move
[OfflineCache/Vault] Opened SecretBox backend=KdfFallback
[OfflineCache/Play] Track 438974690 unwrapped + decrypted (37.48 MB FLAC)
```

No re-download and no data migration: the bytes were already correct, only the lookup was wrong.