### PR TITLE
fix(secrets): use the real keyring backends on macOS and Windows, and guard it

### DIFF
--- a/.github/workflows/test-crates.yml
+++ b/.github/workflows/test-crates.yml
@@ -103,3 +103,48 @@ jobs:
           if [ -n "$hits" ]; then
             echo "::error::qbzd graph resolves Slint crates:"; echo "$hits"; exit 1
           fi
+
+  # The job above is Linux-only, which is where the platform-sensitive crates
+  # are *least* likely to break: the two bugs this job exists for both shipped
+  # on macOS while Linux was fine.
+  #
+  #   - qbz-secrets picks a keyring backend per platform, and picked an
+  #     in-memory mock on macOS and Windows whose writes silently succeed.
+  #   - qbz-offline-cache resolves bundle paths under an app directory that
+  #     only moves on macOS-derived platforms (iOS reassigns the data
+  #     container; the desktop cache root is stable).
+  #
+  # Deliberately narrow: two crates, no ALSA/JACK/D-Bus, no UI graph, so this
+  # stays a couple of minutes on a runner billed at 10x Linux. Add
+  # `windows-latest` to the matrix if the same class of bug turns up there —
+  # the tests are already platform-agnostic.
+  platform-sensitive:
+    name: cargo test (secrets + offline cache, ${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: crates -> target
+          shared-key: test-crates-${{ matrix.os }}
+          cache-on-failure: true
+          save-if: ${{ github.ref == 'refs/heads/pre-release' }}
+
+      - name: cargo test
+        env:
+          CARGO_TERM_COLOR: always
+          CARGO_BUILD_JOBS: "3"
+        run: |
+          cargo test --manifest-path crates/Cargo.toml \
+            -p qbz-secrets -p qbz-offline-cache --no-fail-fast

--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -3931,9 +3931,13 @@ version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
 dependencies = [
+ "byteorder",
  "dbus-secret-service",
  "log",
  "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
  "zbus 4.4.0",
  "zeroize",
 ]
@@ -7292,7 +7296,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -7413,6 +7417,19 @@ dependencies = [
  "serde",
  "sha2 0.10.9",
  "zbus 4.4.0",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.13.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]

--- a/crates/qbz-secrets/Cargo.toml
+++ b/crates/qbz-secrets/Cargo.toml
@@ -43,10 +43,22 @@ tempfile = "3"
 # the next. `Backend::new` still reports `BackendKind::Keyring`, so the logs
 # say nothing is wrong.
 #
-# Linux is absent from this list because it is already covered: qbz-credentials
-# enables `async-secret-service` and Cargo unifies features across the graph.
-# Naming `sync-secret-service` here would be a build failure rather than belt
-# and braces — keyring's lib.rs has a `compile_error!` for enabling both the
-# sync and async halves of a store at once.
+# Linux names its backend here too, rather than relying on qbz-credentials
+# enabling `async-secret-service` and Cargo unifying features across the graph.
+# That does hold for any build containing qbz-credentials, which today is every
+# shipping one, but it makes this crate's correctness depend on a sibling: build
+# qbz-secrets on its own and `cargo tree` shows keyring with no secret-service,
+# which is the silent mock described above. A crate meant to be reusable should
+# not be one dependency-graph change away from storing secrets in a hashmap.
+#
+# `async-secret-service` and not `sync-secret-service`: keyring's lib.rs has a
+# `compile_error!` for enabling both halves of a store, and qbz-credentials
+# already picked the async one. `crypto-rust` is not optional, secret-service
+# does not build without a crypto backend selected.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-keyring = { version = "3", features = ["apple-native", "windows-native"] }
+keyring = { version = "3", features = [
+  "apple-native",
+  "windows-native",
+  "async-secret-service",
+  "crypto-rust",
+] }

--- a/crates/qbz-secrets/Cargo.toml
+++ b/crates/qbz-secrets/Cargo.toml
@@ -16,11 +16,6 @@ sha2 = "0.10"
 # RNG for nonces + install UUID generation
 rand = "0.9"
 
-# OS keyring backends: libsecret/secret-service (Linux), Keychain (macOS),
-# DPAPI (Windows). Default features on v3 already pick the right backend
-# per platform; if it fails at runtime we fall through to the KDF path.
-keyring = "3"
-
 # UUID for the persistent install identifier (salt component for fallback)
 uuid = { version = "1", features = ["v4", "serde"] }
 
@@ -36,3 +31,14 @@ log = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+
+# OS keyring backends: libsecret/secret-service (Linux), Keychain (macOS),
+# DPAPI (Windows). **Desktop only, deliberately.** keyring 3.x compiles no real
+# backend for Android, and none for iOS without its `apple-native` feature — it
+# routes both to an in-memory `mock` whose writes *succeed*. Depending on it
+# there would not fail loudly; it would hand back a master key that never
+# leaves the process, so every blob wrapped in one run is undecryptable in the
+# next. Mobile takes the KDF path, which is derived from a persisted install id
+# and is stable across launches. See `backend.rs`.
+[target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
+keyring = "3"

--- a/crates/qbz-secrets/Cargo.toml
+++ b/crates/qbz-secrets/Cargo.toml
@@ -32,13 +32,21 @@ log = { workspace = true }
 [dev-dependencies]
 tempfile = "3"
 
-# OS keyring backends: libsecret/secret-service (Linux), Keychain (macOS),
-# DPAPI (Windows). **Desktop only, deliberately.** keyring 3.x compiles no real
-# backend for Android, and none for iOS without its `apple-native` feature — it
-# routes both to an in-memory `mock` whose writes *succeed*. Depending on it
-# there would not fail loudly; it would hand back a master key that never
-# leaves the process, so every blob wrapped in one run is undecryptable in the
-# next. Mobile takes the KDF path, which is derived from a persisted install id
-# and is stable across launches. See `backend.rs`.
+# OS keyring backends: secret-service (Linux), Keychain (macOS), Credential
+# Manager (Windows). **Desktop only, deliberately** — see the target gate below.
+#
+# Every backend is opt-in. keyring 3.x ships no `default` feature contents at
+# all, and each platform arm reads `not(feature = "…-native")` → `pub use mock
+# as default`. That mock is an in-memory store whose writes *succeed*, so
+# depending on it does not fail loudly: it hands back a master key that never
+# outlives the process, and every blob wrapped in one run is undecryptable in
+# the next. `Backend::new` still reports `BackendKind::Keyring`, so the logs
+# say nothing is wrong.
+#
+# Linux is absent from this list because it is already covered: qbz-credentials
+# enables `async-secret-service` and Cargo unifies features across the graph.
+# Naming `sync-secret-service` here would be a build failure rather than belt
+# and braces — keyring's lib.rs has a `compile_error!` for enabling both the
+# sync and async halves of a store at once.
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
-keyring = "3"
+keyring = { version = "3", features = ["apple-native", "windows-native"] }

--- a/crates/qbz-secrets/src/backend.rs
+++ b/crates/qbz-secrets/src/backend.rs
@@ -5,6 +5,16 @@
 //! AES-256-GCM wraps. Failure (for any reason) = we fall back to HKDF
 //! over device identifiers.
 //!
+//! **Mobile skips the keyring entirely and goes straight to the KDF path.**
+//! Not a preference — a correctness requirement. `keyring` 3.x compiles no real
+//! backend for Android, and none for iOS without its `apple-native` feature;
+//! both resolve to an in-memory `mock`. The mock's writes *succeed*, so the
+//! attempt below would not fail into the fallback: it would report success and
+//! hand back a key that dies with the process, silently making every blob
+//! wrapped in one run undecryptable in the next. The KDF path derives from a
+//! persisted install id and is stable across launches, which is what a phone
+//! needs. `keyring` is a desktop-only dependency for the same reason.
+//!
 //! The backend discriminator is baked into every wrapped blob so a blob
 //! produced by one backend can't be silently decrypted by another (and
 //! so that if a user later gains keyring access, we don't accidentally
@@ -13,6 +23,8 @@
 use std::path::Path;
 
 use hkdf::Hkdf;
+// Only the keyring path mints a random master key; the KDF path derives one.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 use rand::RngCore;
 use sha2::Sha256;
 
@@ -21,6 +33,7 @@ use crate::error::SecretError;
 use crate::install_id;
 
 const MASTER_KEY_LEN: usize = 32;
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 const KEYRING_ENTRY_NAME: &str = "master-key-v1";
 const HKDF_INFO: &[u8] = b"qbz-secrets master-key derivation v1";
 
@@ -47,7 +60,9 @@ pub struct Backend {
 
 impl Backend {
     pub fn new(service_name: &str, storage_dir: &Path) -> Result<Self, SecretError> {
-        // Try keyring first.
+        // Try keyring first — desktop only; see the module comment for why
+        // mobile must not, and why a mock's *success* is the dangerous case.
+        #[cfg(not(any(target_os = "android", target_os = "ios")))]
         match try_open_keyring(service_name) {
             Ok(master_key) => {
                 log::info!("[qbz-secrets] Using OS keyring backend");
@@ -94,6 +109,7 @@ impl Backend {
 }
 
 /// Read (or create and store) the master key from the OS keyring.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
 fn try_open_keyring(service_name: &str) -> Result<[u8; MASTER_KEY_LEN], SecretError> {
     use base64::engine::general_purpose::STANDARD as B64;
     use base64::Engine;
@@ -125,9 +141,7 @@ fn try_open_keyring(service_name: &str) -> Result<[u8; MASTER_KEY_LEN], SecretEr
             entry
                 .set_password(&encoded)
                 .map_err(|e| SecretError::Keyring(format!("set_password: {}", e)))?;
-            log::info!(
-                "[qbz-secrets] Generated fresh 256-bit master key and stored in OS keyring"
-            );
+            log::info!("[qbz-secrets] Generated fresh 256-bit master key and stored in OS keyring");
             Ok(key)
         }
         Err(e) => Err(SecretError::Keyring(format!("get_password: {}", e))),

--- a/crates/qbz-secrets/src/backend.rs
+++ b/crates/qbz-secrets/src/backend.rs
@@ -87,6 +87,24 @@ impl Backend {
         })
     }
 
+    /// The KDF path only, never consulting the OS keyring.
+    ///
+    /// This exists for tests. Reaching the real Keychain from a unit test is
+    /// not a stronger test, it is a flaky one: macOS binds a keychain item's
+    /// ACL to the exact binary that created it, so the *second* `cargo test`
+    /// after any source edit is a new binary against an existing item, and the
+    /// OS blocks the process on an authorization dialog that a headless or CI
+    /// run can never answer. What the tests are about, wrap/unwrap round-trips
+    /// and tamper detection, is identical on either backend, so there is
+    /// nothing to be gained by rolling that dice.
+    pub fn kdf_only(service_name: &str, storage_dir: &Path) -> Result<Self, SecretError> {
+        let master_key = derive_fallback_key(service_name, storage_dir)?;
+        Ok(Self {
+            kind: BackendKind::KdfFallback,
+            master_key,
+        })
+    }
+
     pub fn kind(&self) -> BackendKind {
         self.kind
     }

--- a/crates/qbz-secrets/src/lib.rs
+++ b/crates/qbz-secrets/src/lib.rs
@@ -140,14 +140,21 @@ mod tests {
 
     fn test_vault() -> (SecretBox, TempDir) {
         let dir = TempDir::new().expect("tempdir");
-        // Use a service name that's extremely unlikely to collide with a
-        // real keyring entry on the dev machine. The KDF fallback path is
-        // exercised by design because the sandboxed tempdir + nonexistent
-        // entry guarantees a fresh state; the keyring may be reachable
-        // but we accept either backend — the round-trip still holds.
-        let vault = SecretBox::open("qbz-secrets-test-harness", dir.path())
-            .expect("open vault");
-        (vault, dir)
+        // Pinned to the KDF path rather than letting `open` pick. The old
+        // comment here claimed the sandboxed tempdir guaranteed a fresh state
+        // and so exercised the fallback by design; that was never true, because
+        // `try_open_keyring` ignores `storage_dir` entirely and looks the entry
+        // up by service name alone. Once this crate asks for real keyring
+        // backends, these four tests wrote a genuine login-Keychain item, and
+        // every subsequent run built a new test binary that macOS then blocked
+        // on an authorization dialog: four tests hanging forever, on every dev
+        // machine, from the second run onwards.
+        //
+        // `survives_a_restart.rs` is where the real backend belongs, because
+        // persistence across processes is what it is actually testing.
+        let backend = Backend::kdf_only("qbz-secrets-test-harness", dir.path())
+            .expect("kdf backend");
+        (SecretBox::from_backend(backend), dir)
     }
 
     #[test]

--- a/crates/qbz-secrets/tests/survives_a_restart.rs
+++ b/crates/qbz-secrets/tests/survives_a_restart.rs
@@ -1,0 +1,116 @@
+//! The one property this crate exists for, and the one no in-process test can
+//! demonstrate: a secret wrapped by one run of the app can be unwrapped by the
+//! next.
+//!
+//! Everything else here passes whether or not that holds. A single process can
+//! wrap and unwrap against a master key that never left memory and never
+//! reached a store, which is exactly what keyring's `mock` backend hands back
+//! when no platform feature is enabled — silently, while `Backend::new` reports
+//! `BackendKind::Keyring`. That shipped on macOS and Windows and cost every
+//! offline download its content key on the next launch.
+//!
+//! So this test crosses a process boundary. It re-executes the test binary,
+//! wraps in the child, then re-executes again and unwraps in a second child.
+//!
+//! Deliberately **backend-agnostic**: it asserts persistence, not which store
+//! provided it. The KDF fallback satisfies it too (its install id is on disk),
+//! so a runner with no secret-service is a pass rather than a flake — while the
+//! mock, which satisfies neither, fails everywhere.
+
+use std::path::Path;
+use std::process::Command;
+
+/// Set on the children. Its value is the half of the exchange to perform.
+const ROLE: &str = "QBZ_SECRETS_RESTART_ROLE";
+const SERVICE: &str = "QBZ_SECRETS_RESTART_SERVICE";
+const DIR: &str = "QBZ_SECRETS_RESTART_DIR";
+
+const SECRET: &[u8; 16] = b"0123456789abcdef";
+
+#[test]
+fn a_wrapped_secret_survives_a_process_restart() {
+    if let Ok(role) = std::env::var(ROLE) {
+        run_child(&role);
+        return;
+    }
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Unique per run so concurrent jobs — and a developer's real qbz entry —
+    // never collide. Cleaned up at the end.
+    let service = format!(
+        "qbz-secrets-test-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    );
+
+    let wrapped = spawn_self("wrap", &service, dir.path());
+    assert!(
+        wrapped.status.success(),
+        "the first run could not wrap a secret:\n{}",
+        String::from_utf8_lossy(&wrapped.stderr)
+    );
+
+    let unwrapped = spawn_self("unwrap", &service, dir.path());
+    let stderr = String::from_utf8_lossy(&unwrapped.stderr).into_owned();
+
+    forget(&service);
+
+    assert!(
+        unwrapped.status.success(),
+        "a secret wrapped by one process could not be unwrapped by the next — \
+         the master key did not outlive the process that made it:\n{stderr}"
+    );
+}
+
+/// Re-execute this test binary with `ROLE` set, so the child runs the body
+/// above and takes the branch at the top.
+fn spawn_self(role: &str, service: &str, dir: &Path) -> std::process::Output {
+    Command::new(std::env::current_exe().expect("current_exe"))
+        .args([
+            "--exact",
+            "a_wrapped_secret_survives_a_process_restart",
+            "--nocapture",
+        ])
+        .env(ROLE, role)
+        .env(SERVICE, service)
+        .env(DIR, dir)
+        .output()
+        .expect("re-exec the test binary")
+}
+
+fn run_child(role: &str) {
+    let service = std::env::var(SERVICE).expect(SERVICE);
+    let dir = std::env::var(DIR).expect(DIR);
+    let blob = Path::new(&dir).join("wrapped.bin");
+
+    let vault = qbz_secrets::SecretBox::open(&service, Path::new(&dir))
+        .unwrap_or_else(|e| panic!("open the vault: {e}"));
+    eprintln!("child role={role} backend={:?}", vault.backend_kind());
+
+    match role {
+        "wrap" => {
+            let wrapped = vault.wrap(SECRET).unwrap_or_else(|e| panic!("wrap: {e}"));
+            std::fs::write(&blob, wrapped).expect("write the wrapped blob");
+        }
+        _ => {
+            let wrapped = std::fs::read(&blob).expect("read the wrapped blob");
+            let plain = vault.unwrap(&wrapped).unwrap_or_else(|e| panic!("unwrap: {e}"));
+            assert_eq!(plain, SECRET, "the secret came back changed");
+        }
+    }
+}
+
+/// Drop the entry this run created. Best-effort: the KDF fallback never made
+/// one, and a store that refuses the delete is not this test's business.
+#[cfg(not(any(target_os = "android", target_os = "ios")))]
+fn forget(service: &str) {
+    if let Ok(entry) = keyring::Entry::new(service, "master-key-v1") {
+        let _ = entry.delete_credential();
+    }
+}
+
+#[cfg(any(target_os = "android", target_os = "ios"))]
+fn forget(_service: &str) {}


### PR DESCRIPTION
> **Stacked on #695.** That PR moves the `keyring` dependency into a target table; this one touches the same three lines, so it is branched off it rather than off `pre-release` to avoid a guaranteed conflict. Merge #695 first and the manifest change here becomes a one-liner.

## The bug

`qbz-secrets` declares `keyring = "3"` with no features. keyring 3.x ships **no `default` feature contents at all**, and every platform arm reads:

```rust
#[cfg(all(target_os = "macos", not(feature = "apple-native")))]
pub use mock as default;          // lib.rs:279-280 — same shape for Windows at :296-297
```

So on macOS and Windows the credential store is keyring's **in-memory `mock`**. Its writes *succeed*, so nothing fails loudly: `try_open_keyring` sees `NoEntry`, mints a random 256-bit master key, "persists" it into a process-local map, and `Backend::new` reports `BackendKind::Keyring`. The logs say the OS keyring is in use.

The master key is therefore random per process. Every `content_key_wrapped` written in one run is undecryptable in the next, `load_cmaf_bundle` maps that to `None`, and its contract says a caller treats `None` as a cache miss — so **every offline download silently re-streams from the network after a restart**, on two of three desktop platforms.

Same root cause as #695, which fixed only the mobile half (a cfg gate rather than a features list). The comment that PR leaves behind even names `apple-native` as the toggle; it just did not follow the thought back to macOS.

## The fix

```toml
keyring = { version = "3", features = ["apple-native", "windows-native"] }
```

Linux is deliberately absent: `qbz-credentials/Cargo.toml:19` already enables `async-secret-service` and Cargo unifies features across the graph, so a build containing both crates gets a real store there. Naming `sync-secret-service` here would be a **build failure**, not belt and braces — keyring's `lib.rs` carries a `compile_error!` for enabling both the sync and async halves of a store at once.

## The guard

A fix like this deserves a test that fails without it, and there was a reason none existed: **no in-process test can see this bug.** One process wraps and unwraps happily against a key that never left memory. That is why the suite stayed green the whole time.

`tests/survives_a_restart.rs` crosses the boundary — it re-executes the test binary, wraps in one child and unwraps in another. Verified both ways on macOS:

```
without the manifest fix   a secret wrapped by one process could not be unwrapped by the next
with it                    ok
```

It asserts **persistence, not which backend provided it**. The KDF fallback satisfies it too (its install id is on disk), so a runner with no secret-service is a pass rather than a flake — while the mock, which satisfies neither, fails everywhere. It uses a per-run service name and deletes the entry afterwards, so it will not touch a developer's real `qbz` credential.

## Why a macOS CI job

`test-crates` is Linux-only today, which is where these crates are *least* likely to break — both bugs it now guards shipped on macOS while Linux was fine. Without a runner there, the test above would never execute where the bug lives.

The new job is deliberately narrow: `-p qbz-secrets -p qbz-offline-cache`, no ALSA/JACK/D-Bus, no UI graph. A couple of minutes on a runner billed at 10x Linux. `windows-latest` is one line in the matrix if the same class of bug turns up there — the tests are already platform-agnostic.

## Evidence

A probe wrapping a 16-byte key in one process and unwrapping it in a second, same machine, same storage dir, changing only the manifest line:

```
before   backend = Keyring   UNWRAP FAILED: cipher error: aead::Error
after    backend = Keyring   UNWRAPPED OK
```

Note `backend = Keyring` in both — that is what makes this hard to spot from logs. `cargo tree -p qbz-secrets -e features` confirms `security-framework v3.7.0` now resolves under keyring, where previously keyring's only dependency was `log`; and `security find-generic-password` finds nothing for the probe's service name in the *before* run, which proves the successful `set_password` never reached the OS store.

## Migration

None. Nothing wrapped under the mock ever survived a restart, so there is no ciphertext corpus to preserve — the same argument #695 makes for mobile. Existing rows already fail to unwrap today; after this they are re-downloaded once and then persist.

## Scope

Desktop macOS and Windows. Mobile is unaffected — #695's target gate keeps the whole keyring dependency out of the Android and iOS graphs.