### PR TITLE
fix(qobuz): replace the bundle token cache atomically

### DIFF
--- a/crates/Cargo.lock
+++ b/crates/Cargo.lock
@@ -6306,6 +6306,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/crates/qbz-qobuz/Cargo.toml
+++ b/crates/qbz-qobuz/Cargo.toml
@@ -27,8 +27,9 @@ base64 = { workspace = true }
 # Time
 chrono = { workspace = true }
 
-# Filesystem (bundle-token cache location)
+# Filesystem (bundle-token cache location, atomic replacement of it)
 dirs = "6"
+tempfile = "3"
 
 # Regex
 regex = { workspace = true }

--- a/crates/qbz-qobuz/src/bundle.rs
+++ b/crates/qbz-qobuz/src/bundle.rs
@@ -6,8 +6,10 @@
 use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::time::Duration;
+use tempfile::Builder;
 
 use super::error::{ApiError, Result};
 
@@ -59,6 +61,37 @@ fn cache_path() -> Option<PathBuf> {
     Some(dirs::cache_dir()?.join("qbz").join("bundle_tokens.json"))
 }
 
+/// Replace `path` with whatever `write` produces, or leave it exactly as it was.
+///
+/// The bytes land in a sibling temp file that is flushed and then renamed over
+/// the target, so a reader either sees the previous cache or the new one and
+/// never the gap between them. Writing in place cannot offer that: it truncates
+/// the file before the first byte of the replacement is written.
+///
+/// `write` is a closure rather than a `&[u8]` so a test can fail partway through
+/// and assert what survives.
+fn atomic_write_with(
+    path: &Path,
+    write: impl FnOnce(&mut std::fs::File) -> io::Result<()>,
+) -> io::Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "cache path has no parent"))?;
+    std::fs::create_dir_all(parent)?;
+
+    let mut temp = Builder::new()
+        .prefix(".bundle_tokens.")
+        .tempfile_in(parent)?;
+    write(temp.as_file_mut())?;
+    temp.as_file().sync_all()?;
+    temp.persist(path).map_err(|error| error.error)?;
+    Ok(())
+}
+
+fn atomic_write(path: &Path, bytes: &[u8]) -> io::Result<()> {
+    atomic_write_with(path, |file| file.write_all(bytes))
+}
+
 /// Load cached tokens if a valid cache file exists. Returns `None` on any error
 /// (missing file, malformed JSON, empty fields) so the caller falls back to a
 /// live fetch.
@@ -83,11 +116,8 @@ fn save_cached_bundle(c: &CachedBundle) {
         log::warn!("[Bundle] No cache dir available, skipping token cache write");
         return;
     };
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
     match serde_json::to_vec_pretty(c) {
-        Ok(bytes) => match std::fs::write(&path, bytes) {
+        Ok(bytes) => match atomic_write(&path, &bytes) {
             Ok(_) => log::info!("[Bundle] Cached tokens (version {})", c.bundle_version),
             Err(e) => log::warn!("[Bundle] Failed to write token cache: {}", e),
         },
@@ -409,5 +439,89 @@ mod tests {
         let result = extract_app_id(bundle);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "123456789");
+    }
+
+    /// The invariant the temp-file-and-rename buys: a write that dies partway
+    /// leaves the tokens that were already there.
+    ///
+    /// Swap `atomic_write` back to `std::fs::write` and this fails with an empty
+    /// file, which is the state a kill during the launch-time `fetched_at`
+    /// refresh used to leave behind.
+    #[test]
+    fn interrupted_cache_write_preserves_the_previous_file() {
+        let root = tempfile::tempdir().expect("cache root");
+        let path = root.path().join("qbz").join("bundle_tokens.json");
+        atomic_write(&path, b"previous cache").expect("initial cache write");
+
+        let result = atomic_write_with(&path, |file| {
+            file.write_all(b"partial replacement")?;
+            Err(io::Error::other("simulated interruption"))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            std::fs::read(&path).expect("previous cache remains readable"),
+            b"previous cache"
+        );
+    }
+
+    /// What losing the file costs, and why the invariant above is worth a temp
+    /// file: there is no partial recovery. Any truncated cache is simply gone,
+    /// and the next launch pays a full live bundle extraction.
+    #[test]
+    fn a_truncated_cache_cannot_be_salvaged() {
+        let root = tempfile::tempdir().expect("cache root");
+        let path = root.path().join("bundle_tokens.json");
+        let whole = serde_json::to_vec_pretty(&CachedBundle {
+            bundle_version: "8.1.0-b019".to_string(),
+            app_id: "123456789".to_string(),
+            secrets: vec!["secret".to_string()],
+            private_key: None,
+            fetched_at: 1,
+        })
+        .expect("serialize");
+
+        for kept in [0, whole.len() / 2] {
+            std::fs::write(&path, &whole[..kept]).expect("write truncated cache");
+            let data = std::fs::read(&path).expect("read truncated cache");
+            assert!(
+                serde_json::from_slice::<CachedBundle>(&data).is_err(),
+                "{kept} of {} bytes should not parse",
+                whole.len()
+            );
+        }
+    }
+
+    /// The replacement file is owner-only, where writing in place left it at
+    /// whatever the umask allowed (0644 on a default Linux setup). These are
+    /// app-level values scraped from a public bundle rather than user
+    /// credentials, so this is tidiness on a shared machine, not a fix for a
+    /// vulnerability.
+    #[cfg(unix)]
+    #[test]
+    fn cache_file_is_owner_readable_and_writable_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().expect("cache root");
+        let path = root.path().join("qbz").join("bundle_tokens.json");
+        atomic_write(&path, b"cache").expect("cache write");
+
+        let mode = std::fs::metadata(path)
+            .expect("cache metadata")
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
+    }
+
+    /// The cache dir is created on demand, so a first run on a clean machine
+    /// caches its tokens rather than warning and moving on.
+    #[test]
+    fn a_missing_cache_directory_is_created() {
+        let root = tempfile::tempdir().expect("cache root");
+        let path = root.path().join("qbz").join("nested").join("tokens.json");
+
+        atomic_write(&path, b"cache").expect("cache write into a missing directory");
+
+        assert_eq!(std::fs::read(&path).expect("cache readable"), b"cache");
     }
 }


### PR DESCRIPTION
## The problem

`save_cached_bundle` writes the token cache in place:

```rust
match std::fs::write(&path, bytes) {
```

`std::fs::write` opens with truncate, so the previous cache is destroyed *before* the first byte of the replacement is written. Anything that kills the process in that window leaves `bundle_tokens.json` empty or half-written, and a partial file parses as nothing, so `load_cached_bundle` returns `None` and the tokens are simply gone.

What that costs on the next launch is a full live extraction: a ~7 MB `bundle.js` fetch behind `BUNDLE_FETCH_TIMEOUT` (45s), retried up to `BUNDLE_EXTRACTION_RETRIES + 1` times, before anything can be signed.

The window is not rare. `refresh_bundle_if_changed` rewrites the whole file on **every launch that finds the version unchanged**, purely to touch `fetched_at`:

```rust
if version == cached_version {
    if let Some(mut c) = load_cached_bundle() {
        c.fetched_at = now_unix();
        save_cached_bundle(&c);
    }
```

So a warm cache is torn down and rebuilt each time the app starts, and every one of those rewrites is a chance to lose it.

I measured the three steps rather than assuming them, against unmodified `pre-release`:

```
mode from std::fs::write:   644
bytes on disk mid-write:    0        <- previous cache already gone
parse of truncated cache:   Err      <- nothing recoverable
```

## The change

The bytes land in a sibling temp file that is flushed and then renamed over the target, so a reader sees either the previous cache or the new one and never the gap between them. `create_dir_all` moves into the same helper and its error is now propagated rather than discarded with `let _ =`.

`atomic_write_with` takes a closure rather than a `&[u8]` purely so a test can fail partway through and assert what survives; `atomic_write` is the one-line wrapper the caller uses.

One side effect worth naming: the replacement file is owner-only (0600), where writing in place left it at whatever the umask allowed. These are app-level values scraped from a public JS bundle rather than user credentials, so that is tidiness on a shared machine, **not** a fix for a vulnerability, and I would rather say so than let the diff imply otherwise.

## Tests

Four new tests in `bundle.rs`. Two of them have teeth, which I checked by reimplementing the helper the old way (`File::create` + write in place) and confirming they fail:

| test | with the fix | written in place |
| --- | --- | --- |
| `interrupted_cache_write_preserves_the_previous_file` | pass | **fail**, reads back `partial replacement` |
| `cache_file_is_owner_readable_and_writable_only` | pass | **fail**, mode 420 (0644), want 384 (0600) |

The other two document behaviour rather than guard a regression, and are labelled as such in the source: `a_truncated_cache_cannot_be_salvaged` (why there is no partial recovery, so the invariant above is worth a temp file) and `a_missing_cache_directory_is_created` (first run on a clean machine).

## Verification

`cargo test -p qbz-qobuz --lib` on this branch: **64 passed, 2 failed**.

The same 2 fail on untouched `pre-release` (**60 passed, 2 failed**): `client::tests::offline_gate_fails_fast_with_typed_error` and `offline_gate_exempts_login_methods`, both panicking inside `reqwest`'s client builder at `async_impl/client.rs:767`, which looks like the missing process-level rustls `CryptoProvider`. Pre-existing and unrelated to this change; I have left them alone.

`rustfmt --check` is clean on `bundle.rs`. I deliberately did not run `cargo fmt` across the crate, since it rewrites nine unrelated files.

## Why I hit this

I am reusing these crates in a mobile client, where the OS kills backgrounded apps as a matter of routine, so the launch-time rewrite window gets hit often enough to notice. The bug is not mobile-specific though: any crash, power loss, or `pkill` during startup does the same thing on the desktop.
