### PR TITLE
feat(qobuz): let an embedder choose the bundle cache directory

### DIFF
--- a/crates/qbz-qobuz/src/bundle.rs
+++ b/crates/qbz-qobuz/src/bundle.rs
@@ -6,7 +6,7 @@
 use regex::Regex;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use super::error::{ApiError, Result};
@@ -55,15 +55,24 @@ impl From<CachedBundle> for BundleTokens {
     }
 }
 
-fn cache_path() -> Option<PathBuf> {
-    Some(dirs::cache_dir()?.join("qbz").join("bundle_tokens.json"))
+/// Where the token cache lives.
+///
+/// `cache_dir` is what an embedder supplied; without one this falls back to the
+/// platform cache directory, which is what the desktop has always used.
+fn cache_path(cache_dir: Option<&Path>) -> Option<PathBuf> {
+    let root = cache_dir.map(Path::to_path_buf).or_else(dirs::cache_dir)?;
+    Some(root.join("qbz").join("bundle_tokens.json"))
 }
 
 /// Load cached tokens if a valid cache file exists. Returns `None` on any error
 /// (missing file, malformed JSON, empty fields) so the caller falls back to a
 /// live fetch.
 pub fn load_cached_bundle() -> Option<CachedBundle> {
-    let path = cache_path()?;
+    load_cached_bundle_from(None)
+}
+
+pub(crate) fn load_cached_bundle_from(cache_dir: Option<&Path>) -> Option<CachedBundle> {
+    let path = cache_path(cache_dir)?;
     let data = std::fs::read(&path).ok()?;
     match serde_json::from_slice::<CachedBundle>(&data) {
         Ok(c) if !c.app_id.is_empty() && !c.secrets.is_empty() => Some(c),
@@ -78,8 +87,8 @@ pub fn load_cached_bundle() -> Option<CachedBundle> {
     }
 }
 
-fn save_cached_bundle(c: &CachedBundle) {
-    let Some(path) = cache_path() else {
+fn save_cached_bundle(c: &CachedBundle, cache_dir: Option<&Path>) {
+    let Some(path) = cache_path(cache_dir) else {
         log::warn!("[Bundle] No cache dir available, skipping token cache write");
         return;
     };
@@ -177,18 +186,28 @@ async fn extract_bundle_tokens_once(client: &Client) -> Result<(BundleTokens, St
 /// [`refresh_bundle_if_changed`] on warm starts so the UI never blocks on the
 /// 7 MB download.
 pub async fn extract_and_cache_bundle_tokens(client: &Client) -> Result<BundleTokens> {
+    extract_and_cache_bundle_tokens_in(client, None).await
+}
+
+pub(crate) async fn extract_and_cache_bundle_tokens_in(
+    client: &Client,
+    cache_dir: Option<&Path>,
+) -> Result<BundleTokens> {
     let mut last_err: Option<ApiError> = None;
     let attempts = BUNDLE_EXTRACTION_RETRIES + 1;
     for attempt in 1..=attempts {
         match extract_bundle_tokens_once(client).await {
             Ok((tokens, version)) => {
-                save_cached_bundle(&CachedBundle {
-                    bundle_version: version,
-                    app_id: tokens.app_id.clone(),
-                    secrets: tokens.secrets.clone(),
-                    private_key: tokens.private_key.clone(),
-                    fetched_at: now_unix(),
-                });
+                save_cached_bundle(
+                    &CachedBundle {
+                        bundle_version: version,
+                        app_id: tokens.app_id.clone(),
+                        secrets: tokens.secrets.clone(),
+                        private_key: tokens.private_key.clone(),
+                        fetched_at: now_unix(),
+                    },
+                    cache_dir,
+                );
                 return Ok(tokens);
             }
             Err(e) => {
@@ -222,11 +241,19 @@ pub async fn refresh_bundle_if_changed(
     client: &Client,
     cached_version: &str,
 ) -> Option<BundleTokens> {
+    refresh_bundle_if_changed_in(client, cached_version, None).await
+}
+
+pub(crate) async fn refresh_bundle_if_changed_in(
+    client: &Client,
+    cached_version: &str,
+    cache_dir: Option<&Path>,
+) -> Option<BundleTokens> {
     let (_, version) = fetch_bundle_url(client).await.ok()?;
     if version == cached_version {
-        if let Some(mut c) = load_cached_bundle() {
+        if let Some(mut c) = load_cached_bundle_from(cache_dir) {
             c.fetched_at = now_unix();
-            save_cached_bundle(&c);
+            save_cached_bundle(&c, cache_dir);
         }
         log::debug!("[Bundle] Background check: version {} unchanged", version);
         return None;
@@ -236,7 +263,9 @@ pub async fn refresh_bundle_if_changed(
         cached_version,
         version
     );
-    extract_and_cache_bundle_tokens(client).await.ok()
+    extract_and_cache_bundle_tokens_in(client, cache_dir)
+        .await
+        .ok()
 }
 
 /// Backwards-compatible one-shot extraction (no caching). Retained for callers
@@ -401,6 +430,26 @@ mod tests {
         let result = extract_bundle_url(html);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), "/resources/7.0.1-b001/bundle.js");
+    }
+
+    /// An embedder's root is used verbatim, and the `qbz/` namespace inside it
+    /// is kept, so the cache has the same name and shape wherever it lands.
+    #[test]
+    fn an_explicit_cache_root_keeps_the_qbz_namespace() {
+        let root = Path::new("/app/cache");
+        assert_eq!(
+            cache_path(Some(root)),
+            Some(root.join("qbz").join("bundle_tokens.json"))
+        );
+    }
+
+    /// Without one, nothing about the desktop's path changes.
+    #[test]
+    fn no_explicit_root_falls_back_to_the_platform_cache_dir() {
+        assert_eq!(
+            cache_path(None),
+            dirs::cache_dir().map(|d| d.join("qbz").join("bundle_tokens.json"))
+        );
     }
 
     #[test]

--- a/crates/qbz-qobuz/src/client.rs
+++ b/crates/qbz-qobuz/src/client.rs
@@ -2,6 +2,7 @@
 
 use reqwest::{Client, StatusCode};
 use serde_json::Value;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -54,6 +55,9 @@ pub struct QobuzClient {
     validated_secret: Arc<RwLock<Option<String>>>,
     locale: Arc<RwLock<String>>,
     cmaf_session: Arc<RwLock<Option<CmafSession>>>,
+    /// Where the regenerable bundle-token cache goes, when the embedder rather
+    /// than the platform decides. `None` keeps `dirs::cache_dir()`.
+    bundle_cache_dir: Option<PathBuf>,
     /// Backs off the hot streaming/favorites paths after repeated 403s so a
     /// post-outage account hiccup can't be escalated into a per-IP edge block
     /// by the no-backoff prefetch scheduler (issue #637).
@@ -69,14 +73,27 @@ impl Clone for QobuzClient {
             validated_secret: Arc::clone(&self.validated_secret),
             locale: Arc::clone(&self.locale),
             cmaf_session: Arc::clone(&self.cmaf_session),
+            bundle_cache_dir: self.bundle_cache_dir.clone(),
             forbidden_breaker: Arc::clone(&self.forbidden_breaker),
         }
     }
 }
 
 impl QobuzClient {
-    /// Create a new client
+    /// Create a new client, caching bundle tokens under the platform cache
+    /// directory.
     pub fn new() -> Result<Self> {
+        Self::build(None)
+    }
+
+    /// Create a client whose regenerable bundle-token cache lives beneath
+    /// `cache_dir`, for hosts that are handed their cache location rather than
+    /// deriving it from the environment.
+    pub fn with_cache_dir(cache_dir: PathBuf) -> Result<Self> {
+        Self::build(Some(cache_dir))
+    }
+
+    fn build(bundle_cache_dir: Option<PathBuf>) -> Result<Self> {
         let http = Client::builder()
             .user_agent(USER_AGENT)
             .cookie_store(true)
@@ -93,6 +110,7 @@ impl QobuzClient {
             validated_secret: Arc::new(RwLock::new(None)),
             locale: Arc::new(RwLock::new("en".to_string())),
             cmaf_session: Arc::new(RwLock::new(None)),
+            bundle_cache_dir,
             forbidden_breaker: Arc::new(ForbiddenBreaker::new()),
         })
     }
@@ -147,7 +165,7 @@ impl QobuzClient {
     /// a live extraction (cold) — callers can use this to drive a "connecting"
     /// UI only when it actually matters.
     pub async fn init(&self) -> Result<bool> {
-        if let Some(cached) = bundle::load_cached_bundle() {
+        if let Some(cached) = bundle::load_cached_bundle_from(self.bundle_cache_dir.as_deref()) {
             let version = cached.bundle_version.clone();
             log::info!("[Bundle] Using cached tokens (version {})", version);
             *self.tokens.write().await = Some(cached.into());
@@ -160,9 +178,14 @@ impl QobuzClient {
                 Ok(client) => {
                     let client = client.clone();
                     let tokens_arc = Arc::clone(&self.tokens);
+                    let cache_dir = self.bundle_cache_dir.clone();
                     tokio::spawn(async move {
-                        if let Some(fresh) =
-                            bundle::refresh_bundle_if_changed(&client, &version).await
+                        if let Some(fresh) = bundle::refresh_bundle_if_changed_in(
+                            &client,
+                            &version,
+                            cache_dir.as_deref(),
+                        )
+                        .await
                         {
                             *tokens_arc.write().await = Some(fresh);
                             log::info!("[Bundle] Background refresh applied rotated tokens");
@@ -180,7 +203,11 @@ impl QobuzClient {
         // Cold start: a live bundle fetch is a network request — gated on
         // purpose so an offline cold start fails fast instead of waiting out
         // the network timeouts.
-        let tokens = bundle::extract_and_cache_bundle_tokens(self.http()?).await?;
+        let tokens = bundle::extract_and_cache_bundle_tokens_in(
+            self.http()?,
+            self.bundle_cache_dir.as_deref(),
+        )
+        .await?;
         *self.tokens.write().await = Some(tokens);
         Ok(false)
     }


### PR DESCRIPTION
## The problem

`cache_path` asks the environment where the token cache belongs:

```rust
fn cache_path() -> Option<PathBuf> {
    Some(dirs::cache_dir()?.join("qbz").join("bundle_tokens.json"))
}
```

So the location comes from process-global ambient state, and a host that already knows where its cache goes has no way to say so.

That is fine on the desktop, which is what `dirs` is for. It is not fine everywhere `dirs` resolves. On Android it takes the XDG implementation:

```rust
pub fn cache_dir() -> Option<PathBuf> {
    env::var_os("XDG_CACHE_HOME").and_then(dirs_sys::is_absolute_path)
        .or_else(|| home_dir().map(|h| h.join(".cache")))
}
```

An app process has neither of those. The cache then either has nowhere to go at all, taking the existing branch:

```rust
let Some(path) = cache_path() else {
    log::warn!("[Bundle] No cache dir available, skipping token cache write");
```

…or it names somewhere the process cannot write, so the write fails and is logged. Either way the tokens never persist and **every launch pays a full live extraction** of a ~7 MB `bundle.js`.

Worth being precise about the scope, since it would be easy to overstate: on iOS `dirs` uses the macOS implementation, `$HOME/Library/Caches`, and `$HOME` is the app container, so it already resolves correctly there. This is about Android and about embedders generally, not a claim that `dirs` is broken.

## The change

`QobuzClient::with_cache_dir(PathBuf)` takes the root instead of inferring it.

Nothing existing changes. `QobuzClient::new`, `load_cached_bundle`, `extract_and_cache_bundle_tokens` and `refresh_bundle_if_changed` keep their signatures and their behaviour: passing no directory still resolves through `dirs`, which `no_explicit_root_falls_back_to_the_platform_cache_dir` pins. The `qbz/` namespace is kept inside whatever root is supplied, so the file has the same name and shape wherever it lands.

The internals gain `_in`/`_from` variants that carry the `Option<&Path>`; the public functions became one-line delegations to them.

## Verification

`cargo test -p qbz-qobuz --lib`: **62 passed, 2 failed**.

The same 2 fail on untouched `pre-release` (**60 passed, 2 failed**): `client::tests::offline_gate_fails_fast_with_typed_error` and `offline_gate_exempts_login_methods`, both panicking inside `reqwest`'s client builder at `async_impl/client.rs:767`, which looks like the missing process-level rustls `CryptoProvider`. Pre-existing and unrelated; left alone.

`rustfmt --check` is clean on `bundle.rs` and on every line this touches in `client.rs`. I did not run `cargo fmt` across the crate: it wants to rewrite ~51 unrelated regions of `client.rs` alone, on `pre-release` as much as here.

## Overlap with #707

#707 makes the same `save_cached_bundle` write atomically. The two are independent in substance but touch adjacent lines, so whichever lands second needs a trivial conflict resolution in that one function. Happy to rebase this on top of #707 once it is reviewed, or to fold them together if you would rather have one PR.

## Why I hit this

I am reusing these crates in a mobile client, where the platform hands the app its caches directory rather than the app deriving it.
